### PR TITLE
Using the compiler at hand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC = clang
-CFLAGS = -O3 -Ofast
+CC ?= clang
+CFLAGS = -O3 -Ofast -Wno-unused-result
 LDFLAGS =
 LDLIBS = -lm
 INCLUDES =
@@ -10,21 +10,27 @@ INCLUDES =
 # e.g. on MacOS: brew install libomp
 # e.g. on Ubuntu: sudo apt-get install libomp-dev
 # later, run the program by prepending the number of threads, e.g.: OMP_NUM_THREADS=8 ./gpt2
-ifeq ($(shell echo | $(CC) -fopenmp -x c -E - > /dev/null 2>&1; echo $$?), 0)
-  ifeq ($(shell uname), Darwin)
-    # macOS with Homebrew
+ifeq ($(shell uname), Darwin)
+  # Check if the libomp directory exists
+  ifeq ($(shell [ -d /opt/homebrew/opt/libomp/lib ] && echo "exists"), exists)
+    # macOS with Homebrew and directory exists
     CFLAGS += -Xclang -fopenmp -DOMP
     LDFLAGS += -L/opt/homebrew/opt/libomp/lib
     LDLIBS += -lomp
     INCLUDES += -I/opt/homebrew/opt/libomp/include
+    $(info NICE Compiling with OpenMP support)
   else
+    $(warning OOPS Compiling without OpenMP support)
+  endif
+else
+  ifeq ($(shell echo | $(CC) -fopenmp -x c -E - > /dev/null 2>&1; echo $$?), 0)
     # Ubuntu or other Linux distributions
     CFLAGS += -fopenmp -DOMP
     LDLIBS += -lgomp
+    $(info NICE Compiling with OpenMP support)
+  else
+    $(warning OOPS Compiling without OpenMP support)
   endif
-  $(info NICE Compiling with OpenMP support)
-else
-  $(warning OOPS Compiling without OpenMP support)
 endif
 
 # PHONY means these targets will always be executed


### PR DESCRIPTION
I was on a Linux with gcc but no clang installed and when I compiled with gcc I got a bunch of these:

` warning: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Wunused-result]`

So I thought this might be helpful to silence these warnings, but also to give a little flexibility as to what compiler to use.

After installing clang in Ubuntu, and building with clang, there was no such warnings.

