### PR TITLE
fix: torch warning of python demo

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
         tokens = np.frombuffer(f.read(), dtype=np.int32)
 
     # np -> tensor, long, on device
-    tokens = torch.from_numpy(tokens)
+    tokens = torch.tensor(tokens)
     tokens = tokens.to(torch.long)
     tokens = tokens.to(device)
 


### PR DESCRIPTION
Just fix torch warning of python version.


`train_gpt2.py:333: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:212.)`