### PR TITLE
fix error in small typos in matmul_forward.cu

### DIFF
--- a/dev/cuda/matmul_forward.cu
+++ b/dev/cuda/matmul_forward.cu
@@ -239,12 +239,12 @@ int main(int argc, char **argv) {
             printf("%f %f\n", out[i], out_gpu[i]);
         }
         // ensure correctness for all elements
-        if (i >= 5 && fabs(out[i] - out_gpu[i]) > 1e-4) {
+        if (fabs(out[i] - out_gpu[i]) > 1e-4) {
             printf("Mismatch at %d: %f vs %f\n", i, out[i], out_gpu[i]);
             exit(1);
         }
     }
-    printf("Results match at block_size=256!\n");
+    printf("Results match at block_size=1024!\n");
 
     // time the kernel at different block sizes
     int sqrt_block_sizes[] = {4, 8, 16, 32};


### PR DESCRIPTION
The sqrt_block_size is 32 in `    matmul_forward(kernel_num, d_out, d_inp, d_weight, d_bias, B, T, C, OC, 32);`
thus the printf should have 1024.