### PR TITLE
Add CMake project for cross platform support and easier quick start setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
 data/
+build/
 gpt2_124M.bin
 gpt2_124M_debug_state.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(llm.c
+    LANGUAGES C
+    VERSION 0.1.0
+)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED True)
+
+set(GPT2_TRAIN_SOURCES platform_utils.h)
+set(GPT2_TRAIN_DEFINES)
+set(GPT2_TEST_SOURCES platform_utils.h)
+set(GPT2_LIB_DEPENDENCIES)
+set(GPT2_CUSTOM_DEPENDENCIES)
+set(GPT2_COMPILE_FLAGS)
+
+# optional cuda support
+if(ENABLE_CUDA)
+    find_package(CUDAToolkit)
+    if(NOT CUDAToolkit_FOUND AND WIN32)
+        message(SEND_ERROR "CUDA is not installed. Go to https://developer.nvidia.com/cuda-toolkit")
+    endif()
+
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 11)
+    set(CMAKE_CUDA_STANDARD_REQUIRED True)
+
+    list(APPEND GPT2_TRAIN_SOURCES train_gpt2.cu)
+    list(APPEND GPT2_TEST_SOURCES test_gpt2.cu)
+
+    list(APPEND GPT2_LIB_DEPENDENCIES CUDA::cublas)
+
+    # https://forums.developer.nvidia.com/t/suppress-warning-conversion-from-a-string-literal-to-char-is-deprecated/258050/3
+    list(APPEND GPT2_COMPILE_FLAGS "-diag-suppress" "2464")
+else()
+    list(APPEND GPT2_TRAIN_SOURCES train_gpt2.c)
+    list(APPEND GPT2_TEST_SOURCES test_gpt2.c)
+
+    find_package(OpenMP)
+    if(OpenMP_C_FOUND)
+        list(APPEND GPT2_LIB_DEPENDENCIES OpenMP::OpenMP_C)
+        list(APPEND GPT2_TRAIN_DEFINES OMP)
+    endif()
+endif()
+
+if(NOT WIN32)
+list(APPEND GPT2_LIB_DEPENDENCIES m)
+endif()
+
+# python requirements
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+set(PYTHON_REQUIREMENTS_INSTALLED_MARKER "${CMAKE_BINARY_DIR}/python_requirements_installed.marker")
+add_custom_command(
+    COMMAND ${Python3_EXECUTABLE} -m pip install -r "${CMAKE_SOURCE_DIR}/requirements.txt" --quiet
+    COMMAND ${CMAKE_COMMAND} -E touch ${PYTHON_REQUIREMENTS_INSTALLED_MARKER}
+    OUTPUT ${PYTHON_REQUIREMENTS_INSTALLED_MARKER}
+    COMMENT "Installing requirements..."
+)
+add_custom_target(python_requirements ALL
+    DEPENDS ${PYTHON_REQUIREMENTS_INSTALLED_MARKER}
+)
+
+# tinyshakespeare
+set(PREPRO_TINYSHAKESPEARE_MARKER "${CMAKE_BINARY_DIR}/prepro_tinyshakespeare.marker")
+add_custom_command(
+    COMMAND ${Python3_EXECUTABLE} prepro_tinyshakespeare.py
+    COMMAND ${CMAKE_COMMAND} -E touch ${PREPRO_TINYSHAKESPEARE_MARKER}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT ${PREPRO_TINYSHAKESPEARE_MARKER}
+    DEPENDS python_requirements
+    COMMENT "Tokenizing TinyShakespeare..."
+)
+add_custom_target(prepro_tinyshakespeare ALL
+    DEPENDS ${PREPRO_TINYSHAKESPEARE_MARKER}
+)
+list(APPEND GPT2_CUSTOM_DEPENDENCIES prepro_tinyshakespeare)
+
+# TODO: add optional custom target and configuration prefix for tinystories pre-processing
+
+# PyTorch gpt2
+set(PYTORCH_GPT2_TRAIN_MARKER "${CMAKE_BINARY_DIR}/pytorch_gpt2.marker")
+add_custom_command(
+    OUTPUT ${PYTORCH_GPT2_TRAIN_MARKER}
+    COMMAND ${Python3_EXECUTABLE} "${CMAKE_SOURCE_DIR}/train_gpt2.py"
+    COMMAND ${CMAKE_COMMAND} -E touch ${PYTORCH_GPT2_TRAIN_MARKER}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Training PyTorch GPT-2 reference implementation..."
+)
+add_custom_target(pytorch_gpt2_train ALL
+    DEPENDS ${PYTORCH_GPT2_TRAIN_MARKER} prepro_tinyshakespeare
+)
+list(APPEND GPT2_CUSTOM_DEPENDENCIES pytorch_gpt2_train)
+
+# train_gpt2
+add_executable(train_gpt2
+    ${GPT2_TRAIN_SOURCES}
+)
+target_link_libraries(train_gpt2
+    PRIVATE
+        ${GPT2_LIB_DEPENDENCIES}
+)
+target_compile_definitions(train_gpt2
+    PRIVATE
+        ${GPT2_TRAIN_DEFINES}
+)
+add_dependencies(train_gpt2
+    ${GPT2_CUSTOM_DEPENDENCIES}
+)
+target_compile_options(train_gpt2
+    PRIVATE
+        ${GPT2_COMPILE_FLAGS}
+)
+
+# test_gpt2
+add_executable(test_gpt2
+    ${GPT2_TEST_SOURCES}
+)
+target_link_libraries(test_gpt2
+    PRIVATE
+        ${GPT2_LIB_DEPENDENCIES}
+)
+add_dependencies(test_gpt2
+    ${GPT2_CUSTOM_DEPENDENCIES}
+)
+target_compile_options(test_gpt2
+    PRIVATE
+        ${GPT2_COMPILE_FLAGS}
+)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,77 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired":
+    {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "gpt2",
+            "description": "Implementation of GPT-2",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build"
+        },
+        {
+            "name": "gpt2-cuda",
+            "inherits": "gpt2",
+            "hidden": true,
+            "cacheVariables": {
+                "ENABLE_CUDA": "ON"
+            }
+        },
+        {
+            "name": "gpt2-tinyshakespeare",
+            "hidden": false,
+            "inherits": "gpt2"
+        },
+        {
+            "name": "gpt2-tinyshakespeare-cuda",
+            "hidden": false,
+            "inherits": "gpt2-cuda"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "gpt2",
+            "hidden": true,
+            "targets": [
+                "train_gpt2"
+            ]
+        },
+        {
+            "name": "gpt2-test",
+            "hidden": true,
+            "inherits": "gpt2",
+            "targets": [
+                "train_gpt2",
+                "test_gpt2"
+            ]
+        },
+        {
+            "name": "gpt2-tinyshakespeare",
+            "hidden": false,
+            "inherits": "gpt2",
+            "configurePreset": "gpt2-tinyshakespeare"
+        },
+        {
+            "name": "gpt2-tinyshakespeare-cuda",
+            "hidden": false,
+            "inherits": "gpt2",
+            "configurePreset": "gpt2-tinyshakespeare-cuda"
+        },
+        {
+            "name": "gpt2-tinyshakespeare-test",
+            "hidden": false,
+            "inherits": "gpt2-test",
+            "configurePreset": "gpt2-tinyshakespeare"
+        },
+        {
+            "name": "gpt2-tinyshakespeare-cuda-test",
+            "hidden": false,
+            "inherits": "gpt2-test",
+            "configurePreset": "gpt2-tinyshakespeare-cuda"
+        }
+    ]
+}

--- a/platform_utils.h
+++ b/platform_utils.h
@@ -1,0 +1,46 @@
+#ifndef PLATFORM_UTILS_H
+#define PLATFORM_UTILS_H
+
+// ----------------------------------------------------------------------------
+// platform-specific utilities
+
+#if defined(__unix__)
+#include <unistd.h>
+#include <time.h>
+
+double get_time_ms() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (ts.tv_sec * 1000.0) + (ts.tv_nsec / 1e6);
+}
+
+int file_exists(const char* filename) {
+    return access(filename, F_OK) != -1;
+}
+
+#elif defined(_WIN32)
+#include <windows.h>
+
+double get_time_ms() {
+    LARGE_INTEGER freq;
+    LARGE_INTEGER time;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&time);
+    return (double)time.QuadPart / (double)freq.QuadPart * 1000.0;
+}
+
+int file_exists(const char* filename) {
+    DWORD dwAttrib = GetFileAttributes(filename);
+    if (dwAttrib != INVALID_FILE_ATTRIBUTES && 
+        !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+#else
+#error "Unsupported platform"
+#endif
+
+#endif // PLATFORM_UTILS_H

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 torch
 tiktoken
 transformers
+requests

--- a/test_gpt2.c
+++ b/test_gpt2.c
@@ -1,4 +1,5 @@
 #define TESTING
+#include "platform_utils.h"
 #include "train_gpt2.c"
 
 // poor man's tensor checker
@@ -71,16 +72,13 @@ int main(int argc, char *argv[]) {
     // let's do 10 training iterations, following the pytorch code
     float losses[10];
     for (int step = 0; step < 10; step++) {
-
-        struct timespec start, end;
-        clock_gettime(CLOCK_MONOTONIC, &start);
-
+        const double start_time_ms = get_time_ms();
         gpt2_forward(&model, x, y, B, T);
         gpt2_zero_grad(&model);
         gpt2_backward(&model);
 
-        clock_gettime(CLOCK_MONOTONIC, &end);
-        double time_elapsed_s = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+        const double end_time_ms = get_time_ms();
+        double time_elapsed_s = (end_time_ms - start_time_ms) / 1000.0;
 
         if (step == 0) {
             // error checking at step 0 for reference activations/gradients

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -1,4 +1,5 @@
 #define TESTING
+#include "platform_utils.h"
 #include "train_gpt2.cu"
 
 // poor man's tensor checker
@@ -30,10 +31,10 @@ int main(int argc, char *argv[]) {
     GPT2 model;
     gpt2_build_from_checkpoint(&model, "gpt2_124M.bin");
 
-    int C = model.config.channels;
+    //int C = model.config.channels;
     int V = model.config.vocab_size;
-    int maxT = model.config.max_seq_len;
-    int L = model.config.num_layers;
+    //int maxT = model.config.max_seq_len;
+    //int L = model.config.num_layers;
 
     // load additional information that we will use for debugging and error checking
     FILE *state_file = fopen("gpt2_124M_debug_state.bin", "rb");
@@ -69,13 +70,12 @@ int main(int argc, char *argv[]) {
     int allok = 1;
 
     // let's do 10 training iterations, following the pytorch code
-    float losses[10];
+    //float losses[10];
     for (int step = 0; step < 10; step++) {
-        struct timespec start, end;
-        clock_gettime(CLOCK_MONOTONIC, &start);
+        const double start_time_ms = get_time_ms();
         gpt2_forward(&model, x, y, B, T);
-        clock_gettime(CLOCK_MONOTONIC, &end);
-        double time_elapsed_s = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+        const double end_time_ms = get_time_ms();
+        double time_elapsed_s = (end_time_ms - start_time_ms) / 1000.0;
 
         if (step == 0) {
             // error checking at step 0 for reference activations

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -14,7 +14,6 @@ There will be other versions of this code that specialize it and make it fast.
 #define _USE_MATH_DEFINES
 #endif
 #include <math.h>
-#include <time.h>
 #include <string.h>
 #if defined(OMP) && !(_OPENMP < 202011)
 #include <omp.h>

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -10,13 +10,21 @@ There will be other versions of this code that specialize it and make it fast.
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <time.h>
 #include <string.h>
-#include <unistd.h>
-#ifdef OMP
+#if defined(OMP) && !(_OPENMP < 202011)
 #include <omp.h>
+#define OMP_ENABLED
+#else
+#pragma message \
+    "The installed OpenMP version is less than 5.2, you may need update to the latest standard to enable to OpenMP directives"
 #endif
+
+#include "platform_utils.h"
 
 // ----------------------------------------------------------------------------
 // all the individual layers' forward and backward passes
@@ -157,7 +165,9 @@ void matmul_forward(float* out,
     // OC is short for "output channels"
     // inp is (B,T,C), weight is (OC, C), bias is (OC)
     // out will be (B,T,OC)
+#ifdef OMP_ENABLED
     #pragma omp parallel for collapse(2)
+#endif
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             float* out_bt = out + b * T * OC + t * OC;
@@ -182,7 +192,9 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
     // but that doesn't afford an efficient parallelization strategy
 
     // backward into inp first, parallelize over B,T
+#ifdef OMP_ENABLED
     #pragma omp parallel for collapse(2)
+#endif
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             float* dout_bt = dout + b * T * OC + t * OC;
@@ -197,7 +209,9 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
         }
     }
     // backward into weight/bias, parallelize over output channels OC
+#ifdef OMP_ENABLED
     #pragma omp parallel for
+#endif
     for (int o = 0; o < OC; o++) {
         for (int b = 0; b < B; b++) {
             for (int t = 0; t < T; t++) {
@@ -228,7 +242,9 @@ void attention_forward(float* out, float* preatt, float* att,
     int hs = C / NH; // head size
     float scale = 1.0 / sqrtf(hs);
 
+#ifdef OMP_ENABLED
     #pragma omp parallel for collapse(3)
+#endif
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             for (int h = 0; h < NH; h++) {
@@ -389,7 +405,9 @@ void residual_backward(float* dinp1, float* dinp2, float* dout, int N) {
 void softmax_forward(float* probs, float* logits, int B, int T, int V) {
     // output: probs are (B,T,V) of the probabilities (sums to 1.0 in each b,t position)
     // input: logits is (B,T,V) of the unnormalized log probabilities
+#ifdef OMP_ENABLED
     #pragma omp parallel for collapse(2)
+#endif
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             // probs <- softmax(logits)
@@ -1048,6 +1066,10 @@ int sample_mult(float* probabilities, int n, float coin) {
 
 // ----------------------------------------------------------------------------
 // main training loop
+
+// during inference step we'll generate sequences of this many tokens
+#define GEN_MAX_LENGTH 64
+
 int main() {
 
     // build the GPT-2 model from a checkpoint
@@ -1059,8 +1081,8 @@ int main() {
     char* tiny_stories_val = "data/TinyStories_val.bin";
     char* tiny_shakespeare_train = "data/tiny_shakespeare_train.bin";
     char* tiny_shakespeare_val = "data/tiny_shakespeare_val.bin";
-    char* train_tokens = access(tiny_shakespeare_train, F_OK) != -1 ? tiny_shakespeare_train : tiny_stories_train;
-    char* val_tokens = access(tiny_shakespeare_val, F_OK) != -1 ? tiny_shakespeare_val : tiny_stories_val;
+    char* train_tokens = file_exists(tiny_shakespeare_train) ? tiny_shakespeare_train : tiny_stories_train;
+    char* val_tokens = file_exists(tiny_shakespeare_val) ? tiny_shakespeare_val : tiny_stories_val;
     int B = 4; // batch size 4 (i.e. 4 independent token sequences will be trained on)
     int T = 64; // sequence length 64 (i.e. each sequence is 64 tokens long). must be <= maxT, which is 1024 for GPT-2
     DataLoader train_loader;
@@ -1073,11 +1095,9 @@ int main() {
 
     // some memory for generating samples from the model
     unsigned long long rng_state = 1337;
-    const int gen_max_length = 64; // during inference step we'll generate sequences of this many tokens
-    int gen_tokens[gen_max_length];
+    int gen_tokens[GEN_MAX_LENGTH];
 
     // train
-    struct timespec start, end;
     for (int step = 0; step <= 20; step++) {
 
         // once in a while estimate the validation loss
@@ -1096,7 +1116,7 @@ int main() {
         // once in a while do model inference to print generated text
         if (step > 0 && step % 20 == 0) {
             gen_tokens[0] = GPT2_EOT; // the GPT-2 EOT token kicks off the generation
-            for (int t = 1; t < gen_max_length; t++) {
+            for (int t = 1; t < GEN_MAX_LENGTH; t++) {
                 // note that inference is wasteful here because
                 // for each t, we re-compute all activations between 0 and t
                 // leaving this alone because you want separate code for inference anyway
@@ -1108,22 +1128,22 @@ int main() {
                 gen_tokens[t] = next_token;
             }
             printf("generated: ");
-            for (int t = 0; t < gen_max_length; t++) {
+            for (int t = 0; t < GEN_MAX_LENGTH; t++) {
                 printf("%d ", gen_tokens[t]);
             }
             printf("\n");
         }
 
         // do a training step
-        clock_gettime(CLOCK_MONOTONIC, &start);
+        const double start_time_ms = get_time_ms();
         dataloader_next_batch(&train_loader);
         gpt2_forward(&model, train_loader.inputs, train_loader.targets, B, T);
         gpt2_zero_grad(&model);
         gpt2_backward(&model);
         gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, step+1);
-        clock_gettime(CLOCK_MONOTONIC, &end);
-        double time_elapsed_s = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
-        printf("step %d: train loss %f (took %f ms)\n", step, model.mean_loss, time_elapsed_s * 1000);
+        const double end_time_ms = get_time_ms();
+        const double time_elapsed_ms = end_time_ms - start_time_ms;
+        printf("step %d: train loss %f (took %f ms)\n", step, model.mean_loss, time_elapsed_ms);
     }
 
     // free


### PR DESCRIPTION
I'm a windows guy so I wanted to get this working on there. I also automated the data setup for tinyshakespeare, and I can do it for tinystories as well if wanted.

## Build Instructions

To configure, run the following. If you want the software/optional OpenMP implementation, don't add the `-cuda` flag:
`cmake --preset gpt2-tinyshakepeare[-cuda] [-G <generator>]`

To build, run the following. If you want to train only, don't add the `-test` portion:
`cmake --build --config <Release|Debug> --preset gpt2-tinyshakespeare[-cuda][-test]`

## Windows
Example using `gpt2-tinyshakepeare-cuda-test` on Windows

### Configure
![windows_cuda_configure](https://github.com/karpathy/llm.c/assets/11325341/6eab5d6b-e3ec-48c9-8fe8-8aa1417a878a)

### Build
![windows_cuda_build](https://github.com/karpathy/llm.c/assets/11325341/30e4b084-2adf-4833-8137-1b8b5572f6f7)

### Train
![windows_cuda_train](https://github.com/karpathy/llm.c/assets/11325341/75c7fbd6-825d-4253-864f-4bbd328d1321)

### Test
![windows_cuda_test](https://github.com/karpathy/llm.c/assets/11325341/1aea3eb7-4481-4b38-bbf9-ce66e1f75a81)

## Ubuntu 22.04 (WSL2)
`gpt2-tinyshakepeare-cuda-test` also builds for me on Ubuntu 22.04 (WSL2), but here is an example of just training via `gpt2-tinyshakespeare` using OpenMP impl instead

### Configure
![ubuntu_openmp_configure](https://github.com/karpathy/llm.c/assets/11325341/fc3b6856-4c22-4de0-8e71-610b66f871c4)

### Build
![ubuntu_openmp_build](https://github.com/karpathy/llm.c/assets/11325341/062b0a7d-6c8b-49d8-bfbf-350c7c51376c)

### Train
![image](https://github.com/karpathy/llm.c/assets/11325341/185cfe1a-84aa-4220-b65e-e5306ab9abab)

