### PR TITLE
Fixed a TODO to calculate the max value neatly and use inv sum trick

### DIFF
--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -381,19 +381,20 @@ void softmax_forward(float* probs, float* logits, int B, int T, int V) {
             float* logits_bt = logits + b * T * V + t * V;
             float* probs_bt = probs + b * T * V + t * V;
 
-            float maxval = -10000.0f; // TODO something better
-            for (int i = 0; i < V; i++) {
-                if (logits_bt[i] > maxval) {
-                    maxval = logits_bt[i];
-                }
+            float maxval = logits_bt[0];
+            for (int i = 1; i < V; i++) {
+                maxval = fmaxf(maxval, logits_bt[i]);
             }
             float sum = 0.0f;
             for (int i = 0; i < V; i++) {
                 probs_bt[i] = expf(logits_bt[i] - maxval);
                 sum += probs_bt[i];
             }
+            // Calculate the inv sum instead of dividing
+            // This is potentially faster on some CPU
+            float inv_sum = 1.0f / sum; 
             for (int i = 0; i < V; i++) {
-                probs_bt[i] /= sum;
+                probs_bt[i] *= inv_sum;
             }
         }
     }


### PR DESCRIPTION
There was a TODO in the softmax_forward function to calculate the maxval neatly (`float maxval = -10000.0f; // TODO something better`). You can take the first value as the max and then iterate over the rest of the values in the loop to calculate the max using the `fmaxf` function.

In the normalization loop, we can multiply rather than divide as this can be faster on some hardware.