### PR TITLE
Improve numerical stability in loss calculation

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -324,7 +324,7 @@ __global__ void crossentropy_forward_kernel1(float* losses,
         int t = i % T;
         float* probs_bt = probs + b * T * V + t * V;
         int ix = targets[b * T + t];
-        losses[b * T + t] = -logf(probs_bt[ix]);
+        losses[b * T + t] = -logf(probs_bt[ix] + 1e-10f);
     }
 }
 


### PR DESCRIPTION
Hello,
 I was trying to avoid loading a model from Checkpoint and instead train from scratch. When I wrote my own function for that and created an empty model object, I kept running into inf losses when training. Turns out for some indexes, probs_bt[ix] is zero in crossentropy_forward_kernel1, this leads to logarithm of zero. So I added a small epsilon value to work around this issue.

Before:
num_parameters: 124647168
train dataset num_batches: 74
val dataset num_batches: 8
batch size: 4
sequence length: 1024
val_num_batches: 10
num_activations: 2458849280
val loss inf
step 0: train loss inf (took 102.442462 ms)
step 1: train loss inf (took 102.126428 ms)
step 2: train loss inf (took 102.571614 ms)
step 3: train loss inf (took 102.590924 ms)
step 4: train loss inf (took 103.129251 ms)
step 5: train loss inf (took 102.524043 ms)
step 6: train loss inf (took 103.807989 ms)
step 7: train loss inf (took 103.277523 ms)
step 8: train loss inf (took 102.837857 ms)
step 9: train loss inf (took 102.830237 ms)
val loss inf

After:
num_parameters: 124647168
train dataset num_batches: 74
val dataset num_batches: 8
batch size: 4
sequence length: 1024
val_num_batches: 10
num_activations: 2458849280
val loss 22.986301
step 0: train loss 22.999998 (took 103.220494 ms)
step 1: train loss 22.985905 (took 102.331446 ms)
step 2: train loss 23.004875 (took 101.609941 ms)
step 3: train loss 22.999332 (took 101.769972 ms)
step 4: train loss 22.979408 (took 102.095875 ms)
step 5: train loss 22.994795 (took 102.086555 ms)
step 6: train loss 22.980402 (took 102.689939 ms)
step 7: train loss 22.980289 (took 103.169013 ms)
step 8: train loss 22.961029 (took 104.302983 ms)
step 9: train loss 22.993958 (took 102.534179 ms)
val loss 22.986301