### PR TITLE
Include the online softmax CPU code and a fully parallelized GPU kernal

### DIFF
--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -24,11 +24,9 @@ version 6 is softmax_online that parallelizes over all of B,T,C
 ./softmax_forward 6
 */
 
-#include <cuda_runtime.h>
-#include "device_launch_parameters.h"
-#include <math.h> 
 #include <stdio.h>
 #include <stdlib.h>
+#include <cuda_runtime.h>
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
 

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -16,6 +16,9 @@ version 3 uses intra-warp reductions for maxval and sumval, must use block_size=
 version 4 uses both intra-warp reductions and shared memory for inter-warp reductions
 so it can tolerate any block_size % 32 == 0. this is hopefully the most efficient version
 ./softmax_forward 4
+
+version 5 is naive port from CPU code (softmax_online) to kernel: parallelizes over B,T, loops over C
+./softmax_forward 5
 */
 
 #include <stdio.h>
@@ -60,6 +63,32 @@ void softmax_forward_cpu(float* out, float* inp, int N, int C) {
         }
         for (int j = 0; j < C; j++) {
             out_row[j] /= sum;
+        }
+    }
+}
+
+
+// Implement the online version of softmax on CPU from the paper:
+// Online normalizer calculation for softmax
+void softmax_forward_online_cpu(float* out, float* inp, int N, int C) {
+    // inp is (N, C)
+    // out is (N, C), each row of inp will get softmaxed
+    for (int i = 0; i < N; i++) {
+        float* inp_row = inp + i * C;
+        float* out_row = out + i * C;
+
+        float maxval = -INFINITY;
+        float sum = 0.0f;
+        for (int j = 0; j < C; j++) {
+            float maxval_prev = maxval;
+            if (inp_row[j] > maxval) {
+                maxval = inp_row[j];
+            }
+            sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+        }
+
+        for (int j = 0; j < C; j++) {
+            out_row[j] = expf(inp_row[j] - maxval) / sum;
         }
     }
 }
@@ -289,6 +318,30 @@ __global__ void softmax_forward_kernel4(float* out, float* inp, int N, int C) {
     }
 }
 
+__global__ void softmax_forward_online_kernel1(float* out, float* inp, int N, int C) {
+    // inp is (N, C)
+    // out is (N, C), each row of inp will get softmaxed
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) {
+        float* inp_row = inp + i * C;
+        float* out_row = out + i * C;
+
+        float maxval = -INFINITY;
+        float sum = 0.0f;
+        for (int j = 0; j < C; j++) {
+            float maxval_prev = maxval;
+            if (inp_row[j] > maxval) {
+                maxval = inp_row[j];
+            }
+            sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+        }
+
+        for (int j = 0; j < C; j++) {
+            out_row[j] = expf(inp_row[j] - maxval) / sum;
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 // kernel launcher
 
@@ -317,6 +370,12 @@ void softmax_forward4(float* out, float* inp, int N, int C, int block_size) {
     softmax_forward_kernel4<<<grid_size, block_size, shared_mem_size>>>(out, inp, N, C);
 }
 
+void softmax_forward_online1(float* out, float* inp, int N, int C, int block_size) {
+    const int grid_size = CEIL_DIV(N, block_size);
+    softmax_forward_online_kernel1 << <grid_size, block_size >> > (out, inp, N, C);
+    cudaCheck(cudaGetLastError());
+}
+
 // kernel version dispatch
 void softmax_forward(int kernel_num, float* out, float* inp, int N, int C, const int block_size) {
     switch (kernel_num) {
@@ -331,6 +390,9 @@ void softmax_forward(int kernel_num, float* out, float* inp, int N, int C, const
             break;
         case 4:
             softmax_forward4(out, inp, N, C, block_size);
+            break;
+        case 5:
+            softmax_forward_online1(out, inp, N, C, block_size);
             break;
         default:
             printf("Invalid kernel number\n");

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -79,15 +79,16 @@ void softmax_forward_online_cpu(float* out, float* inp, int N, int C) {
 
         float maxval = -INFINITY;
         float sum = 0.0f;
-        for (int j = 0; j < C; j++) {
-            float maxval_prev = maxval;
-            if (inp_row[j] > maxval) {
-                maxval = inp_row[j];
-                sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
-            } else {
+		for (int j = 0; j < C; j++) {
+			float maxval_prev = maxval;
+			if (inp_row[j] > maxval) {
+				maxval = inp_row[j];
+				sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+			}
+			else {
 				sum += expf(inp_row[j] - maxval);
 			}
-        }
+		}
 
         for (int j = 0; j < C; j++) {
             out_row[j] = expf(inp_row[j] - maxval) / sum;
@@ -332,14 +333,14 @@ __global__ void softmax_forward_online_kernel1(float* out, float* inp, int N, in
         float sum = 0.0f;
         for (int j = 0; j < C; j++) {
             float maxval_prev = maxval;
-            if (inp_row[j] > maxval) {
-                maxval = inp_row[j];
-                sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
-            }
-            else {
-                sum += expf(inp_row[j] - maxval);
-            }
-        }
+			if (inp_row[j] > maxval) {
+				maxval = inp_row[j];
+				sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+			}
+			else {
+				sum += expf(inp_row[j] - maxval);
+			}
+		}
 
         for (int j = 0; j < C; j++) {
             out_row[j] = expf(inp_row[j] - maxval) / sum;

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -83,8 +83,10 @@ void softmax_forward_online_cpu(float* out, float* inp, int N, int C) {
             float maxval_prev = maxval;
             if (inp_row[j] > maxval) {
                 maxval = inp_row[j];
-            }
-            sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+                sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+            } else {
+				sum += expf(inp_row[j] - maxval);
+			}
         }
 
         for (int j = 0; j < C; j++) {
@@ -332,8 +334,11 @@ __global__ void softmax_forward_online_kernel1(float* out, float* inp, int N, in
             float maxval_prev = maxval;
             if (inp_row[j] > maxval) {
                 maxval = inp_row[j];
+                sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
             }
-            sum = sum * expf(maxval_prev - maxval) + expf(inp_row[j] - maxval);
+            else {
+                sum += expf(inp_row[j] - maxval);
+            }
         }
 
         for (int j = 0; j < C; j++) {


### PR DESCRIPTION
1. Include the online softmax CPU code (from the paper [Online normalizer calculation for softmax](https://arxiv.org/pdf/1805.02867.pdf)).
2. Its native port to GPU kernel `kernel 5` (for education comparison).
3. Include the fully parallel kernel `kernel 6`, where the [reduction op](https://github.com/karpathy/llm.c/pull/79/files#diff-a00ef278da39f24a9d5cb4306c15626b921d437013fb5aa60ac2d8df6b5a5508R362) uses

![image](https://github.com/karpathy/llm.c/assets/7495155/e0b54131-3f7c-4a05-9917-7bdc0d9523a9)

and cooperative group (from @ngc92 ) .


RTX3070: 

`B=8, T=1024`
Kernal 4:
![image](https://github.com/karpathy/llm.c/assets/7495155/10563152-029f-4fd3-87ac-811a9d984f3b)

Kernel 6:
![image](https://github.com/karpathy/llm.c/assets/7495155/ed841ab8-5f2d-4ba8-af4b-067bc0f93500)

`B=64, T=1024`
Kernal 4:
![image](https://github.com/karpathy/llm.c/assets/7495155/9f9935a8-bb76-4fa9-83da-145980b23ebb)


Kernal 6:
![image](https://github.com/karpathy/llm.c/assets/7495155/6e704028-4565-49d1-88bd-07af2e41b922)

