### PR TITLE
cooperative groups and fused scale kernel

### DIFF
--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -789,7 +789,7 @@ void attention_forward4(float* out, float* vaccum, float* qkvr, float* preatt, f
     // multiply all elements of preatt elementwise by scale
     float scale = 1.0 / sqrtf(HS);
     int softmax_block_size = 256;
-    int grid_size = B * NH * T * 32 / softmax_block_size;
+    int grid_size = CEIL_DIV(B * NH * T * 32, softmax_block_size);
     softmax_forward_kernel5<<<grid_size, softmax_block_size>>>(att, scale, preatt, B * NH, T);
 
     // new approach: first cuBLAS another batched matmul

--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -25,6 +25,8 @@ this turns out to be ~20X faster than (1) nice
 #include <stdlib.h>
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
 
 // ----------------------------------------------------------------------------
 // CUDA utils
@@ -301,6 +303,48 @@ __global__ void softmax_forward_kernel4(float* out, float* inp, int N, int C) {
         out[idx * C + i] = x[i] / sum;
     }
 }
+
+
+__global__ void softmax_forward_kernel5(float* out, float inv_temperature, const float* inp, int N, int T) {
+    // shape: (N, T, T)
+
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    int idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+    if(idx >= N * T) {
+        return;
+    }
+    int own_pos = idx % T;
+
+    // one row of inp, i.e. inp[idx, :] of shape (T,)
+    const float* x = inp + idx * T;
+
+    // reduce to max
+    float maxval = -INFINITY;
+    for (int i = warp.thread_rank(); i <= own_pos; i += warp.size()) {
+        maxval = fmaxf(maxval, x[i]);
+    }
+    float offset = cg::reduce(warp, maxval, cg::greater<float>{});
+
+
+    // compute exp and sum
+    float sumval = 0.0f;
+    for (int i = warp.thread_rank(); i <= own_pos; i += warp.size()) {
+        // subtract max for numerical stability
+        float ev = expf(inv_temperature * (__ldcs(x + i) - offset));
+        out[idx * T + i] = ev;
+        sumval += ev;
+    }
+    float sum = cg::reduce(warp, sumval, cg::plus<float>{});
+    float norm = 1.f / sum;
+
+    // divide the whole row by the sum
+    for (int i = warp.thread_rank(); i <= own_pos; i += warp.size()) {
+        out[idx * T + i] *= norm;
+    }
+}
+
 
 __global__ void attention_value_kernel1(float* out, float* att, float* inp,
                                        int B, int T, int C, int NH) {
@@ -679,6 +723,75 @@ void attention_forward3(float* out, float* vaccum, float* qkvr, float* preatt, f
     cublasDestroy(handle);
 }
 
+
+void attention_forward4(float* out, float* vaccum, float* qkvr, float* preatt, float* att,
+                        float* inp,
+                        int B, int T, int C, int NH,
+                        const int block_size) {
+    // inp is (B, T, 3C) QKV
+    // preatt, att are (B, NH, T, T)
+    // output is (B, T, C)
+    int HS = C / NH; // head size
+
+    // permute and separate inp from (B, T, 3, NH, HS) to 3X (B, NH, T, HS)
+    float *q, *k, *v;
+    q = qkvr + 0 * B * T * C;
+    k = qkvr + 1 * B * T * C;
+    v = qkvr + 2 * B * T * C;
+    int total_threads = B * NH * T * HS;
+    int num_blocks = CEIL_DIV(total_threads, block_size);
+    permute_kernel<<<num_blocks, block_size>>>(q, k, v, inp, B, T, NH, HS);
+
+    // batched matrix multiply with cuBLAS
+    cublasHandle_t handle;
+    cublasStatus_t stat = cublasCreate(&handle);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    stat = cublasSgemmStridedBatched(handle,
+                                     CUBLAS_OP_T, CUBLAS_OP_N,
+                                     T, T, HS,
+                                     &alpha,
+                                     k, HS, T * HS,
+                                     q, HS, T * HS,
+                                     &beta,
+                                     preatt, T, T * T,
+                                     B * NH);
+    if (stat != CUBLAS_STATUS_SUCCESS) {
+        printf("cublasSgemm failed\n");
+        exit(1);
+    }
+
+    // multiply all elements of preatt elementwise by scale
+    float scale = 1.0 / sqrtf(HS);
+    int softmax_block_size = 256;
+    int grid_size = B * NH * T * 32 / softmax_block_size;
+    softmax_forward_kernel5<<<grid_size, softmax_block_size>>>(att, scale, preatt, B * NH, T);
+
+    // new approach: first cuBLAS another batched matmul
+    // y = att @ v # (B, nh, T, T) @ (B, nh, T, hs) -> (B, nh, T, hs)
+    stat = cublasSgemmStridedBatched(handle,
+                                     CUBLAS_OP_N, CUBLAS_OP_N,
+                                     HS, T, T,
+                                     &alpha,
+                                     v, HS, T * HS,
+                                     att, T, T * T,
+                                     &beta,
+                                     vaccum, HS, T * HS,
+                                     B * NH);
+    if (stat != CUBLAS_STATUS_SUCCESS) {
+        printf("cublasSgemm failed\n");
+        exit(1);
+    }
+
+    // now unpermute
+    // y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
+    num_blocks = CEIL_DIV(B * T * C, block_size);
+    unpermute_kernel<<<num_blocks, block_size>>>(vaccum, out, B, T, NH, HS);
+
+    // cleanups
+    cublasDestroy(handle);
+}
+
 // kernel version dispatch
 void attention_forward(int kernel_num,
                        float* out, float* vaccum, float* qkvr, float* preatt, float* att,
@@ -694,6 +807,9 @@ void attention_forward(int kernel_num,
             break;
         case 3:
             attention_forward3(out, vaccum, qkvr, preatt, att, inp, B, T, C, NH, block_size);
+            break;
+        case 4:
+            attention_forward4(out, vaccum, qkvr, preatt, att, inp, B, T, C, NH, block_size);
             break;
         default:
             printf("Invalid kernel number\n");


### PR DESCRIPTION
Uses a single warp (instead of a block) per token, therefore relying entirely on wrap-level shuffle functionality provided by `cg::reduce`.
Instead of achieving causal attention through masking, since we're looping manually, we may just as well fix the loop bounds to be correct. Finally, do the scaling as part of the computation here, saving us one more round-trip to vram.

I believe this is orthogonal to #79, but I wanted to get the  simple version working first.