### PR TITLE
use cublaslt and optionally tf32, which fuses bias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ test_gpt2: test_gpt2.c
 
 # possibly may want to disable warnings? e.g. append -Xcompiler -Wno-unused-result
 train_gpt2cu: train_gpt2.cu
-	nvcc -O3 --use_fast_math $< -lcublas -o $@
+	nvcc -O3 --use_fast_math $< -lcublas -lcublasLt -o $@
 
 test_gpt2cu: test_gpt2.cu
-	nvcc -O3 --use_fast_math $< -lcublas -o $@
+	nvcc -O3 --use_fast_math $< -lcublas -lcublasLt -o $@
 
 clean:
 	rm -f train_gpt2 test_gpt2 train_gpt2cu test_gpt2cu

--- a/dev/cuda/matmul_forward.cu
+++ b/dev/cuda/matmul_forward.cu
@@ -49,8 +49,8 @@ void cublasCheck(cublasStatus_t status, const char *file, int line)
 }
 #define cublasCheck(status) { cublasCheck((status), __FILE__, __LINE__); }
 
-// cuBLAS workspace
-static size_t cublaslt_workspace_size = 4 * 1024 * 1024;
+// cuBLAS workspace. Hardcoding to 32MiB but only Hopper needs 32, for others 4 is OK
+static size_t cublaslt_workspace_size = 32 * 1024 * 1024;
 static void* cublaslt_workspace = NULL;
 
 // ----------------------------------------------------------------------------

--- a/dev/cuda/matmul_forward.cu
+++ b/dev/cuda/matmul_forward.cu
@@ -3,19 +3,26 @@ Kernels for matmul forward pass.
 It's advised to use OpenMP here because the CPU implementation is fairly slow otherwise
 
 Compile example:
-nvcc -O3 --use_fast_math -Xcompiler -fopenmp matmul_forward.cu -o matmul_forward -lcublas
+nvcc -O3 --use_fast_math -Xcompiler -fopenmp matmul_forward.cu -o matmul_forward -lcublas -lcublasLt
 
 version 1 is naive port from CPU code to kernel: parallelizes over B,T, loops over C
 OMP_NUM_THREADS=32 ./matmul_forward 1
 
 version 2 calls cuBLAS, very fast
 OMP_NUM_THREADS=32 ./matmul_forward 2
+
+version 3 calls cuBLASLt, should be even faster
+OMP_NUM_THREADS=32 ./matmul_forward 3
+
+version 4 calls cuBLASLt with TF32, should be even even faster
+OMP_NUM_THREADS=32 ./matmul_forward 4
 */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
+#include <cublasLt.h>
 #include <omp.h>
 
 // ----------------------------------------------------------------------------
@@ -23,15 +30,28 @@ OMP_NUM_THREADS=32 ./matmul_forward 2
 
 #define CEIL_DIV(M, N) (((M) + (N)-1) / (N))
 
-// error checking
+// CUDA error checking
 void cudaCheck(cudaError_t error, const char *file, int line) {
   if (error != cudaSuccess) {
-    printf("[CUDA ERROR] at file %s:%d:\n%s\n", file, line,
-           cudaGetErrorString(error));
+    printf("[CUDA ERROR] at file %s:%d:\n%s\n", file, line, cudaGetErrorString(error));
     exit(EXIT_FAILURE);
   }
 };
 #define cudaCheck(err) (cudaCheck(err, __FILE__, __LINE__))
+
+// cuBLAS error checking
+void cublasCheck(cublasStatus_t status, const char *file, int line)
+{
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        printf("[cuBLAS ERROR]: %d %s %d\n", status, file, line);
+        exit(EXIT_FAILURE);
+    }
+}
+#define cublasCheck(status) { cublasCheck((status), __FILE__, __LINE__); }
+
+// cuBLAS workspace
+static size_t cublaslt_workspace_size = 4 * 1024 * 1024;
+static void* cublaslt_workspace = NULL;
 
 // ----------------------------------------------------------------------------
 // CPU code reference
@@ -158,6 +178,104 @@ void matmul_forward2(float* out,
     cublasDestroy(handle);
 }
 
+// uses cublasLt to fuse the bias and gelu
+// https://docs.nvidia.com/cuda/cublas/#cublasltmatmul
+// https://github.com/NVIDIA/CUDALibrarySamples/blob/master/cuBLASLt/LtSgemm/sample_cublasLt_LtSgemm.cu
+void matmul_forward3(float* out,
+                     float* inp, float* weight, float* bias,
+                     int B, int T, int C, int OC,
+                     int enable_tf32) {
+    int has_bias = (bias != NULL);
+    int has_gelu = 0;
+
+    // check bias alignment
+    if(((uintptr_t)bias % 16) != 0) {
+        printf("Bias pointer is not aligned (cuBLASLt requirement)!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // setup cuBLAS and cuBLASLt handles
+    cublasHandle_t cublas_handle;
+    cublasLtHandle_t cublaslt_handle;
+    cublasCheck(cublasCreate(&cublas_handle));
+    cublasCheck(cublasLtCreate(&cublaslt_handle));
+
+    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
+    cublasComputeType_t cublas_compute_type;
+    cublasMath_t cublas_math_mode;
+    if (enable_tf32) {
+        cublas_compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
+        cublas_math_mode = CUBLAS_TF32_TENSOR_OP_MATH;
+    } else {
+        cublas_compute_type = CUBLAS_COMPUTE_32F;
+        cublas_math_mode = CUBLAS_DEFAULT_MATH;
+    }
+    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
+
+    int returnedResults = 0;
+    cublasLtMatmulDesc_t operationDesc;
+    cublasLtMatmulPreference_t preference;
+    cublasLtMatrixLayout_t weightLayout;
+    cublasLtMatrixLayout_t inputLayout;
+    cublasLtMatrixLayout_t outputLayout;
+    cublasLtMatrixLayout_t biasLayout;
+    cublasLtMatmulHeuristicResult_t heuristic;
+
+    // create the operation descriptor
+    cublasOperation_t opNoTranspose = CUBLAS_OP_N;
+    cublasOperation_t opTranspose = CUBLAS_OP_T;
+    cublasLtEpilogue_t epilogueBias = CUBLASLT_EPILOGUE_DEFAULT;
+    if (has_bias && has_gelu) {
+        epilogueBias = CUBLASLT_EPILOGUE_GELU_BIAS;
+    } else if (has_bias) {
+        epilogueBias = CUBLASLT_EPILOGUE_BIAS;
+    } else if (has_gelu) {
+        epilogueBias = CUBLASLT_EPILOGUE_GELU;
+    }
+    cublasCheck(cublasLtMatmulDescCreate(&operationDesc, cublas_compute_type, CUDA_R_32F));
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA, &opTranspose, sizeof(opTranspose)));
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB, &opNoTranspose, sizeof(opNoTranspose)));
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE, &epilogueBias, sizeof(epilogueBias)));
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+
+    // define matrix layouts
+    cublasCheck(cublasLtMatrixLayoutCreate(&weightLayout, CUDA_R_32F, C, OC, C));
+    cublasCheck(cublasLtMatrixLayoutCreate(&inputLayout, CUDA_R_32F, C, B*T, C));
+    cublasCheck(cublasLtMatrixLayoutCreate(&outputLayout, CUDA_R_32F, OC, B*T, OC));
+    cublasCheck(cublasLtMatrixLayoutCreate(&biasLayout, CUDA_R_32F, OC, 1, OC));
+
+    // create a preference handle with specified max workspace
+    cublasCheck(cublasLtMatmulPreferenceCreate(&preference));
+    cublasCheck(cublasLtMatmulPreferenceSetAttribute(preference,
+        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &cublaslt_workspace_size, sizeof(cublaslt_workspace_size)));
+
+    // find a suitable algorithm
+    cublasCheck(cublasLtMatmulAlgoGetHeuristic(cublaslt_handle, operationDesc,
+        weightLayout, inputLayout, outputLayout, outputLayout,
+        preference, 1, &heuristic, &returnedResults));
+    if (returnedResults == 0) {
+        printf("No cuBLASLt algorithm: B: %d, T: %d, C: %d, OC: %d, bias: %d, gelu: %d\n",
+            B, T, C, OC, has_bias, has_gelu);
+        exit(EXIT_FAILURE);
+    }
+
+    // call the matmul
+    const float alpha = 1.0f, beta = 0.0f;
+    cublasCheck(cublasLtMatmul(cublaslt_handle, operationDesc,
+        &alpha, weight, weightLayout, inp, inputLayout, &beta,
+        out, outputLayout, out, outputLayout, &heuristic.algo,
+        cublaslt_workspace, cublaslt_workspace_size, 0));
+
+    // cleanups
+    cublasCheck(cublasLtMatmulPreferenceDestroy(preference));
+    cublasCheck(cublasLtMatmulDescDestroy(operationDesc));
+    cublasCheck(cublasLtMatrixLayoutDestroy(weightLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(inputLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(outputLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(biasLayout));
+}
+
 // kernel version dispatch
 void matmul_forward(int kernel_num,
                     float* out,
@@ -170,6 +288,12 @@ void matmul_forward(int kernel_num,
             break;
         case 2:
             matmul_forward2(out, inp, weight, bias, B, T, C, OC, sqrt_block_size);
+            break;
+        case 3:
+            matmul_forward3(out, inp, weight, bias, B, T, C, OC, 0); // no tf32
+            break;
+        case 4:
+            matmul_forward3(out, inp, weight, bias, B, T, C, OC, 1); // with tf32
             break;
         default:
             printf("Invalid kernel number\n");
@@ -198,8 +322,12 @@ int main(int argc, char **argv) {
     int C = 768;
     int OC = 768 * 4; // expansion of 4, e.g. in the MLP
 
+    // set up the device
     int deviceIdx = 0;
     cudaCheck(cudaSetDevice(deviceIdx));
+
+    // setup (global) cuBLASLt workspace
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
 
     // create host memory of random numbers
     float* out = (float*)malloc(B * T * OC * sizeof(float));
@@ -239,7 +367,7 @@ int main(int argc, char **argv) {
             printf("%f %f\n", out[i], out_gpu[i]);
         }
         // ensure correctness for all elements
-        if (fabs(out[i] - out_gpu[i]) > 1e-4) {
+        if (fabs(out[i] - out_gpu[i]) > 1e-1) {
             printf("Mismatch at %d: %f vs %f\n", i, out[i], out_gpu[i]);
             exit(1);
         }
@@ -252,7 +380,7 @@ int main(int argc, char **argv) {
     for (int j = 0; j < sizeof(sqrt_block_sizes) / sizeof(int); j++) {
         int sqrt_block_size = sqrt_block_sizes[j];
 
-        int repeat_times = 10;
+        int repeat_times = 100;
         cudaEvent_t start, stop;
         cudaCheck(cudaEventCreate(&start));
         cudaCheck(cudaEventCreate(&stop));

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -26,6 +26,15 @@ int check_tensor(float *a, float *b, int n, char* label) {
 
 int main(int argc, char *argv[]) {
 
+    // set up the device
+    int deviceIdx = 0;
+    cudaCheck(cudaSetDevice(deviceIdx));
+
+    // setup (global) cuBLASLt workspace
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
+    printf("[System]\n");
+    printf("enable_tf32: %d\n", enable_tf32);
+
     // build the GPT-2 model from a checkpoint
     GPT2 model;
     gpt2_build_from_checkpoint(&model, "gpt2_124M.bin");

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -29,11 +29,23 @@ int main(int argc, char *argv[]) {
     // set up the device
     int deviceIdx = 0;
     cudaCheck(cudaSetDevice(deviceIdx));
-
-    // setup (global) cuBLASLt workspace
-    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, deviceIdx);
     printf("[System]\n");
+    printf("Device %d: %s\n", deviceIdx, deviceProp.name);
+
+    // setup cuBLAS and cuBLASLt
+    cublasCheck(cublasCreate(&cublas_handle));
+    cublasCheck(cublasLtCreate(&cublaslt_handle));
+    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
+    int enable_tf32 = deviceProp.major >= 8 ? 1 : 0;
+    enable_tf32 = 0; // NOTE: disable TF32 for testing!!!
     printf("enable_tf32: %d\n", enable_tf32);
+    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
+    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
+    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
+    // setup the (global) cuBLASLt workspace
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
 
     // build the GPT-2 model from a checkpoint
     GPT2 model;
@@ -129,5 +141,9 @@ int main(int argc, char *argv[]) {
     free(expected_loss);
     free(expected_grads_memory);
     gpt2_free(&model);
+    cudaCheck(cudaFree(cublaslt_workspace));
+    cublasCheck(cublasDestroy(cublas_handle));
+    cublasCheck(cublasLtDestroy(cublaslt_handle));
+
     return 0;
 }


### PR DESCRIPTION

cc @ademeure , this is cuBLASLt version of matmul only, for now, with a bunch of smaller changes. E.g. I tried to take out global variables and settings, which by default I prefer to do as much as possible. I think the workspace is the only thing that has to stay global (?). (Without streams/graphs involved). I also changed the workspace to 4MiB instead of 64MiB per [official docs recommendations](https://docs.nvidia.com/cuda/cublas/#cublassetworkspace).

When compiling we now add `-lcublasLt`:

```bash
nvcc -O3 --use_fast_math -Xcompiler -fopenmp matmul_forward.cu -o matmul_forward -lcublas -lcublasLt
```

And then these are the timings I am seeing on my A100 40GB PCIe:

```
(pytorch2) ubuntu:~/llm.c/dev/cuda$ ./matmul_forward 2
Using kernel 2
4.452381 4.452382
1.007628 1.007629
0.703605 0.703604
-2.559672 -2.559671
-1.964475 -1.964474
Results match at block_size=1024!
sqrt_block_size    4 | time 459.379211 ms | tflops 8.414553
sqrt_block_size    8 | time 283.652100 ms | tflops 13.627505
sqrt_block_size   16 | time 272.855042 ms | tflops 14.166756
sqrt_block_size   32 | time 279.780365 ms | tflops 13.816090
(pytorch2) ubuntu:~/llm.c/dev/cuda$ ./matmul_forward 3
Using kernel 3
4.452381 4.452382
1.007628 1.007629
0.703605 0.703604
-2.559672 -2.559671
-1.964475 -1.964474
Results match at block_size=1024!
sqrt_block_size    4 | time 298.320618 ms | tflops 12.957438
sqrt_block_size    8 | time 229.404678 ms | tflops 16.850008
sqrt_block_size   16 | time 231.020538 ms | tflops 16.732151
sqrt_block_size   32 | time 231.165955 ms | tflops 16.721626
(pytorch2) ubuntu:~/llm.c/dev/cuda$ ./matmul_forward 4
Using kernel 4
4.452381 4.449594
1.007628 1.007989
0.703605 0.705707
-2.559672 -2.559314
-1.964475 -1.965181
Results match at block_size=1024!
sqrt_block_size    4 | time 65.471039 ms | tflops 59.040924
sqrt_block_size    8 | time 65.196030 ms | tflops 59.289970
sqrt_block_size   16 | time 65.218559 ms | tflops 59.269489
sqrt_block_size   32 | time 58.589184 ms | tflops 65.975838
```

Wow, the TF32 version flies! This is a ~4X improvement! 

Note: I had to increase the correctness check threshold from 1e-4 to 1e-1 because TF32 is more approximate than I realized.

Question 1: The new kernel is block size independent so why does `sqrt_block_size=4` seem to be slower than the rest, for kernel 3? This looks wrong I'm not sure I get it.

Question 2: I'm hardcoding `has_gelu = 0` to not fuse GeLU. My concern is that I'm not sure we can do this without compromising the backward pass later. We may need the pre-GeLU activations? Not sure if GeLU can be backward in place.