### PR TITLE
New softmax for non-self-attention case optimised for large Cs + add more __ldcs

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -382,6 +382,123 @@ __global__ void crossentropy_forward_kernel1(float* losses,
     }
 }
 
+__global__ void softmax_forward_kernel6_largeC(float* out, float* inp, int N, int C) {
+    // out is (N, C) just like inp. Each row of inp will get softmaxed.
+    // same as kernel4, but optimised for very large Cs with advanced unrolling
+
+    // The trick is to read into a register array (all indices known at compile time)
+    // and always read UNROLL_FACTOR values to maximise memory level parallelism
+    // even if we would be out of bounds, we set the index to min(C-1, idx)
+    // so we just do some unnecessary reads (obviously bad for small C)
+    // the writes are in a separate loop with a conditional check for out of bounds
+    // making it separate is necessary to convince the compiler to do the right thing
+    const int UNROLL_FACTOR = 8;
+    const int warpsPerBlock = blockDim.x / 32;
+
+    extern __shared__ float shared[];
+    int idx = blockIdx.x;
+    int tid = threadIdx.x;
+    int warpId = threadIdx.x / 32; // warp index within a block
+    int laneId = threadIdx.x % 32; // thread index within a warp
+
+    // shared[] must be allocated to have 2 * warpsPerBlock elements
+    // first half for max values, the second half for sum values
+    float* maxvals = shared;
+    float* sumvals = &shared[warpsPerBlock];
+    
+    if (tid >= C) {
+        maxvals[warpId] = -INFINITY;
+        sumvals[warpId] = 0.0f;
+        return;
+    }
+
+    float* x = inp + idx * C; // input
+    float* y = out + idx * C; // output
+
+    // first, thread coarsening by directly accessing global memory in series
+    float maxval = -INFINITY;
+    for (int i = tid; i < C; i += blockDim.x * UNROLL_FACTOR) {
+        #pragma unroll
+        for (int u = 0; u < UNROLL_FACTOR; u++) {
+            maxval = fmaxf(maxval, x[min(C - 1, i + u*blockDim.x)]);
+        }
+    }
+
+    // now within-warp reductions for maxval
+    maxval = warpReduceMax(maxval);
+    // the 0th thread of each warp writes the maxval of that warp to shared memory
+    if (laneId == 0) maxvals[warpId] = maxval;
+    __syncthreads();
+    // now the 0th thread reduces the maxvals in shared memory, i.e. across warps
+    if (tid == 0) {
+        float val = maxvals[tid];
+        #pragma unroll
+        for (int i = 1; i < warpsPerBlock; i++) {
+            val = fmaxf(val, maxvals[i]);
+        }
+        // store the final max in the first position
+        maxvals[0] = val;
+    }
+    __syncthreads();
+    // broadcast the max to all threads
+    float offset = maxvals[0];
+
+    // compute expf and write the result to global memory
+    // + thread coarsening for sum
+    float sumval = 0.0f;
+    for (int i = tid; i < C; i += blockDim.x * UNROLL_FACTOR) {
+        float reg_array[UNROLL_FACTOR];
+        #pragma unroll
+        for (int u = 0; u < UNROLL_FACTOR; u++) {
+            reg_array[u] = __ldcs(&x[min(C - 1, i + u*blockDim.x)]);
+        }
+        #pragma unroll
+        for (int u = 0; u < UNROLL_FACTOR; u++) {
+            if (i + u*blockDim.x < C) {
+                float output = expf(reg_array[u] - offset);
+                y[min(C - 1, i + u*blockDim.x)] = output; // compiler likes redundant min()?!
+                sumval += output; // combined into the same loop unlike kernel3
+            }
+        }
+    }
+
+    // okay now we calculated exp(x - max(x))
+    // step 2: sum all the values and divide by the sum
+
+    // within-warp reduction for sumval
+    sumval = warpReduceSum(sumval);
+    // write sumval to shared memory
+    if (laneId == 0) sumvals[warpId] = sumval;
+    __syncthreads();
+    // inter-thread reduction of sum
+    if (tid == 0) {
+        float val = sumvals[tid];
+        #pragma unroll
+        for (int i = 1; i < warpsPerBlock; ++i) {
+            val += sumvals[i];
+        }
+        sumvals[0] = val;
+    }
+    __syncthreads();
+    // broadcast the sum to all threads
+    float sum = sumvals[0];
+
+    // divide the whole row by the sum
+    for (int i = tid; i < C; i += blockDim.x * UNROLL_FACTOR) {
+        float reg_array[UNROLL_FACTOR];
+        #pragma unroll
+        for (int u = 0; u < UNROLL_FACTOR; u++) {
+            reg_array[u] = y[min(C - 1, i + u*blockDim.x)];
+        }
+        #pragma unroll
+        for (int u = 0; u < UNROLL_FACTOR; u++) {
+            if (i + u*blockDim.x < C) {
+                y[i + u*blockDim.x] = reg_array[u] / sum;
+            }
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 // kernel launchers
 
@@ -575,10 +692,16 @@ void gelu_forward(float* out, const float* inp, int N) {
 }
 
 void softmax_forward(float* out, float* inp, int N, int C) {
-    const int block_size = 256;
     int grid_size = N;
-    size_t shared_mem_size = 2 * block_size / 32 * sizeof(float);
-    softmax_forward_kernel4<<<grid_size, block_size, shared_mem_size>>>(out, inp, N, C);
+    if (C >= 4096) { // TODO find optimal heuristic
+        const int block_size = 512;
+        size_t shared_mem_size = 2 * block_size / 32 * sizeof(float);
+        softmax_forward_kernel6_largeC<<<grid_size, block_size, shared_mem_size>>>(out, inp, N, C);
+    } else {
+        const int block_size = 256;
+        size_t shared_mem_size = 2 * block_size / 32 * sizeof(float);
+        softmax_forward_kernel4<<<grid_size, block_size, shared_mem_size>>>(out, inp, N, C);
+    }
 }
 
 void crossentropy_forward(float* losses,

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -173,9 +173,9 @@ __global__ void permute_kernel(float* q, float* k, float* v,
             +          (nh_ * d)
             +                d_;
 
-        q[idx] = inp[inp_idx];
-        k[idx] = inp[inp_idx + NH * d];
-        v[idx] = inp[inp_idx + 2 * (NH * d)];
+        q[idx] = __ldcs(&inp[inp_idx]);
+        k[idx] = __ldcs(&inp[inp_idx + NH * d]);
+        v[idx] = __ldcs(&inp[inp_idx + 2 * (NH * d)]);
     }
 }
 
@@ -193,7 +193,7 @@ __global__ void unpermute_kernel(float* inp, float *out, int B, int N, int NH, i
         int d_ = rest % d;
 
         int other_idx = (b * NH * N * d) + (n * NH * d) + (nh_ * d) + d_;
-        out[other_idx] = inp[idx];
+        out[other_idx] = __ldcs(&inp[idx]);
     }
 }
 
@@ -355,7 +355,7 @@ __global__ void softmax_forward_kernel5(float* out, float inv_temperature, const
 __global__ void residual_forward_kernel(float* out, float* inp1, float* inp2, int N) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < N) {
-        out[idx] = inp1[idx] + inp2[idx];
+        out[idx] = __ldcs(&inp1[idx]) + __ldcs(&inp2[idx]);
     }
 }
 


### PR DESCRIPTION
This adds the softmax I wrote for #89 optimised for large Cs with very aggressive loop unrolling. Ideally the best ideas of this kernel should be merged with the best ideas of kernel5 (online softmax), but the current kernel5 is likely to be slower because I think it won't have enough parallel warps to keep the entire GPU busy etc...

Also added a few more __ldcs qualifiers for loads with data that won't be read again (or not for a long time), this makes them low priority in the L1/L2 caches and more likely to be replaced by useful data instead.

A100:
Before: 25.1ms
After Softmax: 23.5
After __ldcs: 23.4 (reliably faster, the ~0.1 isn't just noise)