### PR TITLE
Test updates

### DIFF
--- a/dev/cuda/crossentropy_forward.cu
+++ b/dev/cuda/crossentropy_forward.cu
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
                                               kernel_num, d_out, d_probs, d_targets,
                                               B, T, V, block_size);
 
-        printf("block_size %4d | time %f ms\n", block_size, elapsed_time);
+        printf("block_size %4d | time %.4f ms | per token %.2f ns\n", block_size, elapsed_time, elapsed_time * 1'000'000 / (B*T));
     }
 
     // free memory

--- a/dev/cuda/crossentropy_softmax_backward.cu
+++ b/dev/cuda/crossentropy_softmax_backward.cu
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
                                               kernel_num, d_dlogits, d_dlosses, d_probs, d_targets,
                                               B, T, V, block_size);
 
-        printf("block_size %4d | time %f ms\n", block_size, elapsed_time / repeat_times);
+        printf("block_size %4d | time %f ms\n", block_size, elapsed_time);
     }
 
     // free memory

--- a/dev/cuda/crossentropy_softmax_backward.cu
+++ b/dev/cuda/crossentropy_softmax_backward.cu
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
                                               kernel_num, d_dlogits, d_dlosses, d_probs, d_targets,
                                               B, T, V, block_size);
 
-        printf("block_size %4d | time %f ms\n", block_size, elapsed_time);
+        printf("block_size %4d | time %.4f ms | per token %.2f µs\n", block_size, elapsed_time, elapsed_time * 1'000 / (B*T));
     }
 
     // free memory

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         long memory_ops = B * T * C * 2 * 4;
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
 
-        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
 
     // free memory

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         long memory_ops = B * T * C * 2 * 4;
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
 
-        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time / repeat_times, memory_bandwidth);
+        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
 
     // free memory

--- a/dev/cuda/layernorm_forward.cu
+++ b/dev/cuda/layernorm_forward.cu
@@ -364,7 +364,7 @@ int main(int argc, char **argv) {
         long memory_ops = (2 * B * T * C) * 4; // *4 for float
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
 
-        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
 
     // free memory

--- a/dev/cuda/matmul_forward.cu
+++ b/dev/cuda/matmul_forward.cu
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
         // napkin math: estimate the flops achieved
         // e.g. A100 40GB PCIe is advertised at 19.5 TFLOPS fp32
         float tflops = (float)B * T * C * OC * 2 / elapsed_time * 1e3f / 1e12f;
-        printf("sqrt_block_size %4d | time %f ms | tflops %f\n", sqrt_block_size, elapsed_time, tflops);
+        printf("sqrt_block_size %4d | time %.4f ms | tflops %.2f\n", sqrt_block_size, elapsed_time, tflops);
     }
 
     // free memory

--- a/dev/cuda/positional_forward.cu
+++ b/dev/cuda/positional_forward.cu
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
         long memory_ops = B * T * C * 4 * 4;
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
 
-        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
 
     // free memory

--- a/dev/cuda/residual_forward.cu
+++ b/dev/cuda/residual_forward.cu
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
         long memory_ops = B * T * C * 3 * 4;
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
 
-        printf("block_size %4d | time %f ms | bandwidth %f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
 
     // free memory

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -143,8 +143,8 @@ __global__ void softmax_forward_kernel2(float* out, const float* inp, int N, int
             shared[tid] = fmaxf(shared[tid], shared[tid + stride]);
         }
     }
-    float offset = shared[0];
     __syncthreads();
+    float offset = shared[0];
     // compute expf and write the result to global memory
     for (int i = tid; i < C; i += block_size) {
         out[idx * C + i] = expf(x[i] - offset);
@@ -327,7 +327,7 @@ __global__ void softmax_forward_online_kernel1(float* out, const float* inp, int
         float* out_row = out + i * C;
 
         float maxval = -INFINITY;
-        float sum = 0.0f;
+        double sum = 0.0f;
         for (int j = 0; j < C; j++) {
             float maxval_prev = maxval;
 			if (inp_row[j] > maxval) {

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -29,6 +29,7 @@ version 7 is softmax optimized for very large C.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <cuda_runtime.h>
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
@@ -50,13 +51,17 @@ void softmax_forward_cpu(float* out, const float* inp, int N, int C) {
                 maxval = inp_row[j];
             }
         }
-        float sum = 0.0f;
+        // Note: since we want to ensure that the CUDA-kernels are accurate,
+        // we do this accumulation in higher precision, so we can be assured
+        // that our ground-truth is of high quality.
+        double sum = 0.0;
         for (int j = 0; j < C; j++) {
             out_row[j] = expf(inp_row[j] - maxval);
             sum += out_row[j];
         }
+        float norm = 1.f / (float)sum;
         for (int j = 0; j < C; j++) {
-            out_row[j] /= sum;
+            out_row[j] *= norm;
         }
     }
 }
@@ -592,20 +597,31 @@ int main(int argc, char **argv) {
 
     int B = 8;
     int T = 1024;
+    int V = 50257;
 
     int deviceIdx = 0;
     cudaCheck(cudaSetDevice(deviceIdx));
 
     // create host memory of random numbers
-    float* out = (float*)malloc(B * T * T * sizeof(float));
-    float* inp = make_random_float(B * T * T);
+    float* out = (float*)malloc(B * T * V * sizeof(float));
+    float* inp = make_random_float(B * T * V);
+
+    // make the input less uniformly random: Otherwise, all probabilities will be basically zero,
+    // and the tests are not actually meaningful.
+    const int* outliers = make_random_int(B * T * 3, V);
+    for(int k = 0; k < 3; ++k) {
+        for(int j = 0; j < B * T; ++j) {
+            inp[j * V +  outliers[j*3 + k]] *= 20;
+        }
+    }
+
 
     // move to GPU
     float* d_out;
     float* d_inp;
-    cudaCheck(cudaMalloc(&d_out, B * T * T * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_inp, B * T * T * sizeof(float)));
-    cudaCheck(cudaMemcpy(d_inp, inp, B * T * T * sizeof(float), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMalloc(&d_out, B * T * V * sizeof(float)));
+    cudaCheck(cudaMalloc(&d_inp, B * T * V * sizeof(float)));
+    cudaCheck(cudaMemcpy(d_inp, inp, B * T * V * sizeof(float), cudaMemcpyHostToDevice));
 
     // read kernel_num from command line
     int kernel_num = 1;
@@ -616,14 +632,22 @@ int main(int argc, char **argv) {
 
     int block_sizes[] = {32, 64, 128, 256, 512, 1024};
 
-    softmax_forward_cpu(out, inp, B * T, T);
+    softmax_forward_cpu(out, inp, B * T, V);
+    {
+        float max_el = -INFINITY;
+        for(int i = 0; i <  B * T * V; ++i) {
+            max_el = max(max_el, out[i]);
+        }
+        assert(max_el > 1e-4);
+        printf("Largest output is: %f\n", max_el);
+    }
 
     // first check the correctness of the kernel
     for (int j = 0; j < sizeof(block_sizes) / sizeof(int); j++) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
-        softmax_forward(kernel_num, d_out, d_inp, B * T, T, block_size);
-        validate_result(d_out, out, "out", B * T * T, 1e-4f);
+        softmax_forward(kernel_num, d_out, d_inp, B * T, V, block_size);
+        validate_result(d_out, out, "out", B * T * V, 1e-4f);
     }
 
     printf("All results match. Starting benchmarks.\n\n");
@@ -634,7 +658,7 @@ int main(int argc, char **argv) {
 
         int repeat_times = 1000;
         float elapsed_time = benchmark_kernel(repeat_times, softmax_forward,
-                                              kernel_num, d_out, d_inp, B * T, T, block_size
+                                              kernel_num, d_out, d_inp, B * T, V, block_size
                                               );
 
         printf("block_size %4d | time %.4f ms | per token %.2f µs\n", block_size, elapsed_time, elapsed_time * 1'000 / (B*T));

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -110,13 +110,13 @@ __global__ void softmax_forward_kernel1(float* out, const float* inp, int N, int
                 maxval = inp_row[j];
             }
         }
-        float sum = 0.0f;
+        double sum = 0.0;
         for (int j = 0; j < C; j++) {
             out_row[j] = expf(inp_row[j] - maxval);
             sum += out_row[j];
         }
         for (int j = 0; j < C; j++) {
-            out_row[j] /= sum;
+            out_row[j] /= (float)sum;
         }
     }
 }
@@ -656,7 +656,7 @@ int main(int argc, char **argv) {
     for (int j = 0; j < sizeof(block_sizes) / sizeof(int); j++) {
         int block_size = block_sizes[j];
 
-        int repeat_times = 1000;
+        int repeat_times = 100;
         float elapsed_time = benchmark_kernel(repeat_times, softmax_forward,
                                               kernel_num, d_out, d_inp, B * T, V, block_size
                                               );

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -637,7 +637,7 @@ int main(int argc, char **argv) {
                                               kernel_num, d_out, d_inp, B * T, T, block_size
                                               );
 
-        printf("block_size %4d | time %f ms\n", block_size, elapsed_time);
+        printf("block_size %4d | time %.4f ms | per token %.2f µs\n", block_size, elapsed_time, elapsed_time * 1'000 / (B*T));
     }
 
     // free memory


### PR DESCRIPTION
Several changes to the tests:
* Fixes printed timings, some were divided by the repeats twice
* Ensure that every kernel prints a more relative statistic (bandwidth, flops, time per token), and adjust number of digits so we don't spam meaningless decimals
* changed the softmax tests to use  `vocab_dim`  as the number of channels


The last one has several important implications:
  First, timings between the kernels might be changed now.
  More importantly, the old tests become meaningless, because with uniform logits, we get tiny probabilities for  each  output, and a kernel that just outputs zeros might actually pass the tests.
 This can  be fixed  by adding a few "outliers" to the input. With this, even the current kernels fail the tests.
 However, this is not because the current kernels are bad---In fact, by calculating partial sums in each thread, they are numerically more robust than the CPU implementation.  I've therefore changed the reference code to use  ` double`  for its sum accumulator, so that we can be assured that the ground-truth we're testing against is actually accurate.