### PR TITLE
Include none null assert for malloc

### DIFF
--- a/test_gpt2.c
+++ b/test_gpt2.c
@@ -1,5 +1,6 @@
 #define TESTING
 #include "train_gpt2.c"
+#include <assert.h>
 
 // poor man's tensor checker
 int check_tensor(float *a, float *b, int n, char* label) {
@@ -56,6 +57,7 @@ int main(int argc, char *argv[]) {
     int* y = (int*) malloc(B * T * sizeof(int));
     float* expected_logits = (float*) malloc(B * T * V * sizeof(float));
     float* expected_loss = (float*) malloc(1 * sizeof(float));
+    assert(x != NULL && y != NULL && expected_logits != NULL && expected_loss != NULL);
 
     // read reference information from Python
     fread(x, sizeof(int), B*T, state_file);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -11,7 +11,6 @@ GPT-2 Transformer Neural Net trained in raw CUDA
 #include <float.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 #include <cublasLt.h>


### PR DESCRIPTION
1. fix [issue](https://github.com/karpathy/llm.c/issues/94). Include an assert for malloc as a minimum check (do not intend to write a robust malloc with free and error check, etc. as it is not the focus of this repo)
2. Remove a duplicate `#include <assert.h>` in `train_gpt2.cu`.
