### PR TITLE
Pytorch Profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ python train_gpt2.py --inference_only 1 --write_tensors 0 --sequence_length 1024
 
 The time drops down to 26.2ms/iteration. So at the current 26.2ms/iteration we, amusingly and right now, have an identical running time. This somewhat makes sense because most of the FLOPs are in the matmul, and we both call about the same kernels. The remainder of the difference is likely our self-attention implementation, and possibly the round trips for GeLU, and permute/unpermute.
 
+## profiling pytorch implementaiton
+
+```bash
+!python train_gpt2.py --inference_only 1 --write_tensors 0 --sequence_length 1024 --batch_size 4 --compile 1 --tensorcores 1 --profiler 1
+```
+
+The profiler prints the most expensive operations sorted by their cuda execution time.
+
 ## discussions
 
 Ways of organizing development:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,24 @@ The time drops down to 26.2ms/iteration. So at the current 26.2ms/iteration we, 
 !python train_gpt2.py --inference_only 1 --write_tensors 0 --sequence_length 1024 --batch_size 4 --compile 1 --tensorcores 1 --profiler 1
 ```
 
-The profiler prints the most expensive operations sorted by their cuda execution time.
+The profiler prints the most expensive operations sorted by their cuda execution time. eg::
+
+```
+-------------------------------------------------------  ------------  
+                                                   Name    Self CUDA %  
+-------------------------------------------------------  ------------  
+                                          ProfilerStep*         0.00%  
+                                  Torch-Compiled Region         0.00%  
+                                       CompiledFunction         0.00%  
+                                               aten::mm        29.32%  
+void cutlass::Kernel<cutlass_80_tensorop_s1688gemm_1...        19.28%  
+                                              aten::bmm        19.15%  
+                                   triton__0d1d2d3de4de        16.21%  
+            triton_per_fused__softmax_masked_fill_mul_6        15.23%  
+void cutlass::Kernel<cutlass_80_tensorop_s1688gemm_2...        11.32%  
+                       triton_red_fused__log_softmax_15        10.80%  
+-------------------------------------------------------  ------------  
+```
 
 ## discussions
 

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -11,6 +11,7 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 
 import os
 import math
+import struct
 from dataclasses import dataclass
 
 import numpy as np
@@ -291,8 +292,21 @@ def write_state(model, x, y, logits, loss, filename):
         write_tensors(grads, model.config.n_layer, file)
     print(f"wrote {filename}")
 
-import torch
-from torch.profiler import profile, ProfilerActivity
+def write_tokenizer(enc, filename):
+    n = enc.max_token_value + 1
+    header = torch.zeros(256, dtype=torch.int32)
+    header[0] = 20240328 # magic
+    header[1] = 1 # tokenizer version = 1
+    header[2] = n # number of tokens
+    with open(filename, "wb") as file:
+        file.write(header.numpy().tobytes())
+        for i in range(n):
+            b = enc.decode_bytes([i])
+            length = len(b)
+            assert length < 256, f"Token length exceeds 255: {length}"
+            file.write(struct.pack("<B", length))  # Write the length as a 1-byte unsigned integer
+            file.write(b)  # Write the actual bytes
+    print(f"wrote {filename}")
 
 def configure_profiler():
     """Configures the PyTorch profiler with predefined settings."""
@@ -354,6 +368,8 @@ if __name__ == "__main__":
     encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
     decode = lambda l: enc.decode(l)
 
+    write_tokenizer(enc, "gpt2_tokenizer.bin")
+
     if args.tensorcores:
         torch.set_float32_matmul_precision('high')
 
@@ -401,7 +417,6 @@ if __name__ == "__main__":
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
 
     def training_loop(profiler_=None):
-        """Main training loop to perform model updates."""
         timings = []
         for i in range(args.num_iterations):
             t0 = time.time()

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -445,9 +445,9 @@ if __name__ == "__main__":
         if args.num_iterations < 4:
             raise ValueError("--num_iterations should be 4 or higher for profiling")
         with configure_profiler() as profiler:
-            training_loop(model, x, y, optimizer, args, profiler)
+            training_loop(profiler)
     else:
-        training_loop(model, x, y, optimizer, args, None)
+        training_loop()
 
     # before we end, let's also do one round of inference
     # we'll kick off the generation with "<|endoftext|>", which designates the start of a new sequence

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -11,13 +11,13 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 
 import os
 import math
-import struct
 from dataclasses import dataclass
 
 import numpy as np
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+from torch.profiler import profile, record_function, ProfilerActivity
 
 class NewGELU(nn.Module):
     """Careful there are a few versions of GeLU, this one is the exact one used by OpenAI"""
@@ -291,21 +291,28 @@ def write_state(model, x, y, logits, loss, filename):
         write_tensors(grads, model.config.n_layer, file)
     print(f"wrote {filename}")
 
-def write_tokenizer(enc, filename):
-    n = enc.max_token_value + 1
-    header = torch.zeros(256, dtype=torch.int32)
-    header[0] = 20240328 # magic
-    header[1] = 1 # tokenizer version = 1
-    header[2] = n # number of tokens
-    with open(filename, "wb") as file:
-        file.write(header.numpy().tobytes())
-        for i in range(n):
-            b = enc.decode_bytes([i])
-            length = len(b)
-            assert length < 256, f"Token length exceeds 255: {length}"
-            file.write(struct.pack("<B", length))  # Write the length as a 1-byte unsigned integer
-            file.write(b)  # Write the actual bytes
-    print(f"wrote {filename}")
+import torch
+from torch.profiler import profile, ProfilerActivity
+
+def configure_profiler():
+    """Configures the PyTorch profiler with predefined settings."""
+    return profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        record_shapes=True,
+        with_stack=True,
+        schedule=torch.profiler.schedule(
+            skip_first=1, wait=1, warmup=1, active=1, repeat=1
+        ),
+        on_trace_ready=trace_handler
+    )
+
+def trace_handler(profiler_):
+    """Handles profiler traces by exporting summary and detailed stack traces."""
+    print(profiler_.key_averages(group_by_stack_n=5).table(sort_by="cuda_time_total", row_limit=10))
+    profiler_.export_chrome_trace(f"chrometrace-{profiler_.step_num}.json")
+    # TODO the stack trace is empty for some unknown reason
+    # profiler_.export_stacks(f"flamegraph_stacks_{profiler_.step_num}.txt", "self_cuda_time_total")
+
 
 if __name__ == "__main__":
     import time
@@ -324,6 +331,7 @@ if __name__ == "__main__":
     parser.add_argument("--num_iterations", type=int, default=10, help="number of iterations to run")
     parser.add_argument("--batch_size", type=int, default=4, help="batch size")
     parser.add_argument("--sequence_length", type=int, default=64, help="sequence length")
+    parser.add_argument("--profiler", type=int, default=0, help="enable torch.profiler")
     args = parser.parse_args()
     B, T = args.batch_size, args.sequence_length
     assert 1 <= T <= 1024
@@ -345,8 +353,6 @@ if __name__ == "__main__":
     enc = tiktoken.get_encoding("gpt2")
     encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
     decode = lambda l: enc.decode(l)
-
-    write_tokenizer(enc, "gpt2_tokenizer.bin")
 
     if args.tensorcores:
         torch.set_float32_matmul_precision('high')
@@ -393,28 +399,40 @@ if __name__ == "__main__":
     data_iter = iter(get_batch())
     x, y = next(data_iter) # we'll overfit this batch below
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
-    timings = []
-    for i in range(args.num_iterations):
-        t0 = time.time()
-        logits, loss = model(x, y)
-        if not args.inference_only:
-            optimizer.zero_grad()
-            loss.backward()
-            # on the first iteration only, save the state dict to file for later reference
-            if i == 0 and args.write_tensors:
-                write_model(model, "gpt2_124M.bin")
-                write_state(model, x, y, logits, loss, "gpt2_124M_debug_state.bin")
-            optimizer.step()
-        if device == "mps":
-            torch.mps.synchronize()
-        elif device == "cuda":
-            torch.cuda.synchronize()
-        t1 = time.time()
-        if i > args.num_iterations - 20:
-            timings.append(t1-t0)
-        print(f"iteration {i}, loss: {loss.item()}, time: {(t1-t0)*1000:.3f}ms")
-    if len(timings) > 0:
-        print(f"final 20 iters avg: {np.mean(timings)*1000:.3f}ms")
+
+    def training_loop(profiler_=None):
+        """Main training loop to perform model updates."""
+        timings = []
+        for i in range(args.num_iterations):
+            t0 = time.time()
+            logits, loss = model(x, y)
+            if not args.inference_only:
+                optimizer.zero_grad()
+                loss.backward()
+                if i == 0 and args.write_tensors:
+                    write_model(model, "gpt2_124M.bin")
+                    write_state(model, x, y, logits, loss, "gpt2_124M_debug_state.bin")
+                optimizer.step()
+            if device == "mps":
+                torch.mps.synchronize()
+            elif device == "cuda":
+                torch.cuda.synchronize()
+            t1 = time.time()
+            if i >= args.num_iterations - 20:
+                timings.append(t1-t0)
+            print(f"iteration {i}, loss: {loss.item()}, time: {(t1-t0)*1000:.3f}ms")
+            if profiler_:
+                profiler_.step()
+        if timings:
+            print(f"Final 20 iterations avg time: {np.mean(timings)*1000:.3f}ms")
+    
+    if args.profiler:
+        if args.num_iterations < 4:
+            raise ValueError("--num_iterations should be 4 or higher for profiling")
+        with configure_profiler() as profiler:
+            training_loop(model, x, y, optimizer, args, profiler)
+    else:
+        training_loop(model, x, y, optimizer, args, None)
 
     # before we end, let's also do one round of inference
     # we'll kick off the generation with "<|endoftext|>", which designates the start of a new sequence


### PR DESCRIPTION
[Colab link](https://colab.research.google.com/drive/1PmrQCw5fZ_W3NoZnItExnkiNYZ5jZDcn?usp=sharing) Using the pytorch profiler we can see how much we're doing better/worse than pytorch implementation in terms of kernel implementations.
The following is for A100-SXM4-40GB in Colab linked above with command.
```python
python train_gpt2.py --inference_only 1 --write_tensors 0 --sequence_length 1024 --batch_size 4 --compile 1 --tensorcores 1 --profiler 1
```

```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                          ProfilerStep*         3.00%     759.000us        99.98%      25.303ms      25.303ms       0.000us         0.00%      23.059ms      23.059ms             1  
                                  Torch-Compiled Region         1.71%     434.000us        64.76%      16.389ms      16.389ms       0.000us         0.00%      23.056ms      23.056ms             1  
                                       CompiledFunction        29.64%       7.502ms        62.87%      15.910ms      15.910ms       0.000us         0.00%      23.056ms      23.056ms             1  
                                               aten::mm         3.32%     840.000us         4.79%       1.213ms      32.784us       6.761ms        29.32%       6.761ms     182.730us            37  
void cutlass::Kernel<cutlass_80_tensorop_s1688gemm_1...         0.00%       0.000us         0.00%       0.000us       0.000us       4.446ms        19.28%       4.446ms     123.500us            36  
                                              aten::bmm         2.38%     602.000us         3.35%     848.000us      35.333us       4.416ms        19.15%       4.416ms     184.000us            24  
                                   triton__0d1d2d3de4de         0.00%       0.000us         0.00%       0.000us       0.000us       3.739ms        16.21%       3.739ms     155.792us            24  
            triton_per_fused__softmax_masked_fill_mul_6         0.98%     247.000us         1.30%     329.000us      27.417us       3.512ms        15.23%       3.512ms     292.667us            12  
void cutlass::Kernel<cutlass_80_tensorop_s1688gemm_2...         0.00%       0.000us         0.00%       0.000us       0.000us       2.610ms        11.32%       2.610ms       2.610ms             1  
                       triton_red_fused__log_softmax_15         0.09%      24.000us         0.13%      32.000us      32.000us       2.491ms        10.80%       2.491ms       2.491ms             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 25.307ms
Self CUDA time total: 23.059ms
```