### PR TITLE
Easy Cloud Setup Script

### DIFF
--- a/cloud_gpt2_train.py
+++ b/cloud_gpt2_train.py
@@ -2,6 +2,7 @@ import runhouse as rh
 
 
 def train_cloud():
+    # This can be modified to use other instance types or other cloud providers.
     cluster = rh.cluster(name="rh-cuda-gpu", instance_type="A10G:1").up_if_not()
     env = rh.env(name="llm_c_train",
                  setup_cmds=[
@@ -10,7 +11,8 @@ def train_cloud():
                      "sudo apt-get update",
                      "sudo apt install clang -y --fix-missing"
                  ],
-                 working_dir="./")
+                 working_dir="./")  # rsync over the current git root
+    # Note this is cached, so it will not run the installation commands again unless they change.
     env.to(cluster)
     cluster.run(["cd llm.c; make train_gpt2",
                  "OMP_NUM_THREADS=8 llm.c/train_gpt2"])

--- a/cloud_gpt2_train.py
+++ b/cloud_gpt2_train.py
@@ -12,8 +12,8 @@ def train_cloud():
     cluster = rh.cluster(name="rh-cuda-gpu", instance_type="A10G:1").up_if_not()
     env = rh.env(name="llm_c_train",
                  setup_cmds=[
-                     "python llm.c/prepro_tinyshakespeare.py",
-                     "python llm.c/train_gpt2.py",
+                     "python -u llm.c/prepro_tinyshakespeare.py",
+                     "python -u llm.c/train_gpt2.py",
                      "sudo apt-get update",
                      "sudo apt install clang -y --fix-missing"
                  ],

--- a/cloud_gpt2_train.py
+++ b/cloud_gpt2_train.py
@@ -1,3 +1,9 @@
+# This script uses Runhouse and SkyPilot to launch, set up, and run the GPT-2 training
+# script in the cloud. For installation instructions, see:
+# https://www.run.house/docs/tutorials/quick-start-cloud
+# After bringing up this box, you can ssh into it directly with `$ ssh rh-cuda-gpu`, or
+# bring it down with `$ sky down rh-cuda-gpu`.
+
 import runhouse as rh
 
 
@@ -11,7 +17,7 @@ def train_cloud():
                      "sudo apt-get update",
                      "sudo apt install clang -y --fix-missing"
                  ],
-                 working_dir="./")  # rsync over the current git root
+                 working_dir="./")  # rsync over the current git root and install requirements.txt
     # Note this is cached, so it will not run the installation commands again unless they change.
     env.to(cluster)
     cluster.run(["cd llm.c; make train_gpt2",

--- a/cloud_gpt2_train.py
+++ b/cloud_gpt2_train.py
@@ -1,0 +1,21 @@
+import runhouse as rh
+
+
+def train_cloud():
+    cluster = rh.cluster(name="rh-cuda-gpu", instance_type="A10G:1").up_if_not()
+    env = rh.env(name="llm_c_train",
+                 setup_cmds=[
+                     "python llm.c/prepro_tinyshakespeare.py",
+                     "python llm.c/train_gpt2.py",
+                     "sudo apt-get update",
+                     "sudo apt install clang -y --fix-missing"
+                 ],
+                 working_dir="./")
+    env.to(cluster)
+    cluster.run(["cd llm.c; make train_gpt2",
+                 "OMP_NUM_THREADS=8 llm.c/train_gpt2"])
+
+
+if __name__ == "__main__":
+    train_cloud()
+


### PR DESCRIPTION
Hi! Sometimes it's tricky or daunting to set up the hardware and environment for a script like this on a self-hosted cloud GPU. I was trying out llm.c on a fresh A10G on AWS, automating the setup and compilation via the library I work on (Runhouse), and figured I'd contribute it back in case you think it's useful to others. Feel free to close if not, or I can change to a notable fork.

Runhouse is built for rapid remote Python iteration, but the makefile actually takes care of this for C. If you make changes to the C code and rerun this script they'll be synced over and rebuilt quickly via the makefile. I'm also happy to change this script to strictly do the hardware setup in Python and then leave the user to compile and run in C via ssh.