### PR TITLE
Reduce the duplicate computation  in crossentropy and include the V padding for crossentropy kernel

### DIFF
--- a/dev/cuda/crossentropy_forward.cu
+++ b/dev/cuda/crossentropy_forward.cu
@@ -49,6 +49,21 @@ __global__ void crossentropy_forward_kernel1(float* losses,
     }
 }
 
+__global__ void crossentropy_forward_kernel2(float* losses,
+    const float* probs_pad, const int* targets,
+    int B, int T, int V, int V_pad) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < B * T) {
+        int b = i / T;
+        int t = i % T;
+        const int bt = b * T + t;
+        const float* probs_bt = probs_pad + bt * V_pad;
+        int ix = targets[bt];
+        if (ix < V) { // Make sure we don't read past the end of the original V-sized block
+            losses[bt] = -logf(probs_bt[ix]);
+        }
+    }
+}
 // ----------------------------------------------------------------------------
 // kernel launcher
 
@@ -62,15 +77,29 @@ void crossentropy_forward1(float* losses,
     cudaCheck(cudaGetLastError());
 }
 
+void crossentropy_forward2(float* losses,
+    const float* probs, const int* targets,
+    int B, int T, int V, int V_pad,
+    const int block_size) {
+    const int N = B * T;
+    const int grid_size = ceil_div(N, block_size);
+    crossentropy_forward_kernel2 << <grid_size, block_size >> > (losses, probs, targets, B, T, V, V_pad);
+    cudaCheck(cudaGetLastError());
+}
+
 // kernel version dispatch
 void crossentropy_forward(int kernel_num,
                           float* losses,
-                          const float* probs, const int* targets,
-                          int B, int T, int V,
+                          const float* probs, const float* probs_pad,
+                          const int* targets,
+                          int B, int T, int V, int V_pad,
                           const int block_size) {
     switch (kernel_num) {
         case 1:
             crossentropy_forward1(losses, probs, targets, B, T, V, block_size);
+            break;
+        case 2:
+            crossentropy_forward2(losses, probs_pad, targets, B, T, V, V_pad, block_size);
             break;
         default:
             printf("Invalid kernel number\n");
@@ -86,7 +115,9 @@ int main(int argc, char **argv) {
     int B = 8;
     int T = 1024;
     int V = 50257;
-
+    const int multiplicative_factor = 64; 
+    int V_pad = (V + multiplicative_factor - 1) / multiplicative_factor * multiplicative_factor; // round up to nearest multiple of 64
+    
     int deviceIdx = 0;
     cudaCheck(cudaSetDevice(deviceIdx));
 
@@ -95,15 +126,29 @@ int main(int argc, char **argv) {
     float* probs = make_random_float_01(B * T * V);
     int* targets = make_random_int(B * T, V);
 
+    // Pad the probs tensor
+    float* probs_pad = (float*)malloc(B * T * V_pad * sizeof(float));
+    for (int b = 0; b < B; b++) {
+        for (int t = 0; t < T; t++) {
+            // Copy V elements from probs to probs_pad
+            memcpy(probs_pad + (b * T + t) * V_pad, probs + (b * T + t) * V, V * sizeof(float));
+            // Set the extra elements to a neutral value (e.g., 0)
+            memset(probs_pad + (b * T + t) * V_pad + V, 0, (V_pad - V) * sizeof(float));
+        }
+    }
+
     // move to GPU
     float* d_out;
     float* d_probs;
     int* d_targets;
+    float* d_probs_pad;
     cudaCheck(cudaMalloc(&d_out, B * T * sizeof(float)));
     cudaCheck(cudaMalloc(&d_probs, B * T * V * sizeof(float)));
     cudaCheck(cudaMalloc(&d_targets, B * T * sizeof(int)));
+    cudaCheck(cudaMalloc(&d_probs_pad, B * T * V_pad * sizeof(float)));
     cudaCheck(cudaMemcpy(d_probs, probs, B * T * V * sizeof(float), cudaMemcpyHostToDevice));
     cudaCheck(cudaMemcpy(d_targets, targets, B * T * sizeof(int), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_probs_pad, probs_pad, B * T * V_pad * sizeof(float), cudaMemcpyHostToDevice));
 
     // read kernel_num from command line
     int kernel_num = 1;
@@ -120,7 +165,7 @@ int main(int argc, char **argv) {
     for (int j = 0; j < sizeof(block_sizes) / sizeof(int); j++) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
-        crossentropy_forward(kernel_num, d_out, d_probs, d_targets, B, T, V, block_size);
+        crossentropy_forward(kernel_num, d_out, d_probs, d_probs_pad, d_targets, B, T, V, V_pad, block_size);
         validate_result(d_out, out, "out", B * T, 1e-5f);
     }
 
@@ -131,8 +176,8 @@ int main(int argc, char **argv) {
 
         int repeat_times = 1000;
         float elapsed_time = benchmark_kernel(repeat_times, crossentropy_forward,
-                                              kernel_num, d_out, d_probs, d_targets,
-                                              B, T, V, block_size);
+                                              kernel_num, d_out, d_probs, d_probs_pad, d_targets,
+                                              B, T, V, V_pad, block_size);
 
         printf("block_size %4d | time %.4f ms | per token %.2f ns\n", block_size, elapsed_time, elapsed_time * 1'000'000 / (B*T));
     }

--- a/dev/cuda/crossentropy_forward.cu
+++ b/dev/cuda/crossentropy_forward.cu
@@ -59,9 +59,7 @@ __global__ void crossentropy_forward_kernel2(float* losses,
         const int bt = b * T + t;
         const float* probs_bt = probs_pad + bt * V_pad;
         int ix = targets[bt];
-        if (ix < V) { // Make sure we don't read past the end of the original V-sized block
-            losses[bt] = -logf(probs_bt[ix]);
-        }
+        losses[bt] = -logf(probs_bt[ix]);
     }
 }
 // ----------------------------------------------------------------------------

--- a/dev/cuda/crossentropy_forward.cu
+++ b/dev/cuda/crossentropy_forward.cu
@@ -42,9 +42,10 @@ __global__ void crossentropy_forward_kernel1(float* losses,
     if (i < B * T) {
         int b = i / T;
         int t = i % T;
-        const float* probs_bt = probs + b * T * V + t * V;
-        int ix = targets[b * T + t];
-        losses[b * T + t] = -logf(probs_bt[ix]);
+        const int bt = b * T + t;
+        const float* probs_bt = probs + bt * V;
+        int ix = targets[bt];
+        losses[bt] = -logf(probs_bt[ix]);
     }
 }
 


### PR DESCRIPTION
- introduce `const int bt = b * T + t` to reduce the duplicated computation. [Running 5+ trials on 3070, no obvious improvement in the performance.]
- Include the V padding for crossentropy kernel (kernel 2)


With V_pad =  50304 and V = 50257, on 3070

Kernel 1
block_size   32 | time 0.0073 ms | per token 0.90 ns
block_size   64 | time 0.0069 ms | per token 0.84 ns
block_size  128 | time 0.0080 ms | per token 0.97 ns
block_size  256 | time 0.0069 ms | per token 0.84 ns
block_size  512 | time 0.0067 ms | per token 0.82 ns
block_size 1024 | time 0.0079 ms | per token 0.96 ns

Kernel 2
block_size   32 | time 0.0062 ms | per token 0.75 ns
block_size   64 | time 0.0075 ms | per token 0.92 ns
block_size  128 | time 0.0070 ms | per token 0.86 ns
block_size  256 | time 0.0075 ms | per token 0.92 ns
block_size  512 | time 0.0069 ms | per token 0.84 ns
block_size 1024 | time 0.0069 ms | per token 0.84 ns


Overall, the performance of kernels 1 & 2 is noisy and on par with fluctuations in runtime across different runs.

