### PR TITLE
Fix the backward dbias precision issue in matmul_backward

### DIFF
--- a/dev/cuda/matmul_backward.cu
+++ b/dev/cuda/matmul_backward.cu
@@ -47,18 +47,20 @@ void matmul_backward_cpu(float* dinp, float* dweight, float* dbias,
     // backward into weight/bias, parallelize over output channels OC
     #pragma omp parallel for
     for (int o = 0; o < OC; o++) {
+        double sum = 0.0f;
         for (int b = 0; b < B; b++) {
             for (int t = 0; t < T; t++) {
                 float* dout_bt = dout + b * T * OC + t * OC;
                 float* inp_bt = inp + b * T * C + t * C;
                 float* dwrow = dweight + o*C;
                 float d = dout_bt[o];
-                if (dbias != NULL) { dbias[o] += d; }
+                if (dbias != NULL) { sum += d; }
                 for (int i = 0; i < C; i++) {
                     dwrow[i] += inp_bt[i] * d;
                 }
             }
         }
+        if (dbias != NULL){dbias[o] = sum;}
     }
 }
 


### PR DESCRIPTION
The original code does pass in Linux.
However, in windows,
```
Device 0: NVIDIA GeForce RTX 3070 Laptop GPU
enable_tf32: 0
Using kernel 1
Checking correctness...
dinp:
12.846249 12.846246
25.214823 25.214817
-13.958217 -13.958220
-15.573501 -15.573508
31.178213 31.178207
dweight:
-40.251938 -40.252014
15.850185 15.850141
-64.966507 -64.966446
-66.537521 -66.537636
-26.666681 -26.666658
dbias:
1.125021 1.125035
26.328951 26.328930
11.523802 11.523788
17.523970 17.523972
16.781780 16.781767
Mismatch of dbias at 158: -305.011322 vs -305.009247
```

Modify the CPU code to reach logic parity (using double `sum` as the accumulator for float) with the GPU code and results match after the fix.


