### PR TITLE
-fno-finite-math-only for almost 2x speed up, fix for [#19]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= clang
-CFLAGS = -O3 -Ofast -Wno-unused-result -march=native
+CFLAGS = -Ofast -fno-finite-math-only -Wno-unused-result -march=native
 LDFLAGS =
 LDLIBS = -lm
 INCLUDES =

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can have a look inside the `Makefile` and its comments. It will try to autod
 
 ```
 # try this first
-CFLAGS="-Ofast -fno-fast-math -Wno-unused-result -march=native" make train_gpt2
+CFLAGS="-Ofast -fno-finite-math-only -Wno-unused-result -march=native" make train_gpt2
 # try this second
 CFLAGS="-O3 -Wno-unused-result -march=native" make train_gpt2
 ```


### PR DESCRIPTION
final compilation opts on cpu, -fno-finite-math-only instead of -fno-fast-math, and add -march=native.
benchmarks comparisons: https://github.com/karpathy/llm.c/issues/19#issuecomment-2049099144
and now:
```bash
step 0: train loss 5.356086 (took 9611.016869 ms)
step 1: train loss 4.300644 (took 8780.770364 ms)
step 2: train loss 4.623083 (took 7137.313333 ms)
step 3: train loss 4.599365 (took 6426.557283 ms)
step 4: train loss 4.616659 (took 6864.495874 ms)
step 5: train loss 4.231428 (took 6635.326672 ms)
step 6: train loss 3.753164 (took 6516.244371 ms)
step 7: train loss 3.650456 (took 6362.145571 ms)
step 8: train loss 4.182243 (took 6333.873539 ms)
step 9: train loss 4.199581 (took 6407.929416 ms)
```