### PR TITLE
simple fix for bug [#106]

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -594,7 +594,7 @@ void encoder_forward(float* out,
 void layernorm_forward(float* out, float* mean, float* rstd,
                        float* inp, float* weight, float* bias,
                        int B, int T, int C) {
-    const int block_size = 1024;
+    const int block_size = 512;
     const int N = B * T;
     const int grid_size = CEIL_DIV(N * 32, block_size);
     layernorm_forward_kernel3<<<grid_size, block_size>>>(out, mean, rstd, inp, weight, bias, N, C);


### PR DESCRIPTION
@karpathy I have two solutions to fix the out-of-resource issue that some folks are observing (see https://github.com/karpathy/llm.c/issues/106). We are hitting this issue due to excessive register usage and the compiler is unable to determine it well. The two solutions to this are: 

a) keep the block_size = 1024 and add __launch_bounds__(1024, 2) as a prefix as shown below. This would force register spills to the memory subsystem. 

 ```
__global__ void layernorm_forward_kernel3(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
                                   const float* __restrict__ inp, const float* __restrict__ weight,
                                   const float* __restrict__ bias, int N, int C) {
```

to below 

```
__global__ __launch_bounds__(1024,2)
void layernorm_forward_kernel3(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
                                   const float* __restrict__ inp, const float* __restrict__ weight,
                                   const float* __restrict__ bias, int N, int C) {
``` 

This works great for GPUs with 2048 as their maximum resident number of threads. However, we some users (SM version: 8.6) have a maximum resident number of threads as 1536 and this solution will fail for them.  A potential alternative to keeping the block_size=1024 is reduced occupancy (up to 50% and at the cost of run time) using the below change 
```
__global__ __launch_bounds__(1024,1)
void layernorm_forward_kernel3(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
                                   const float* __restrict__ inp, const float* __restrict__ weight,
                                   const float* __restrict__ bias, int N, int C) {
``` 

I am not in favor of this either. 

b) Fundamental to the issue is we are launching too many resources and observing a launch failure. In this case, reducing the block size enables the compiler to optimize better. This is why I reduced the block size from 1024 to 512 (can be 256 too). Before I made this change, I checked for correctness and running `dev/cuda/layernorm_forward.cu`. block_size 256 or 512 makes about a 10% drop difference in performance (on an average run).  However, end-to-end layer time, I did not observe much difference! 

If you still want to keep block_size = 1024 then we need to add the `__CUDA_ARCH__` qualifier to make it conditioned for respective SM versions. Alternatively, we can think of ways to reduce register usage (not that easy given it uses cg.). (The last one is I need to check if there is a compiler flag that automatically allows register spill if it detects it. ) 

Let me know what you think! 