### PR TITLE
Fix the potential int overflow related to B*T*V

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -35,7 +35,7 @@ void cublasCheck(cublasStatus_t status, const char *file, int line)
 // ----------------------------------------------------------------------------
 // random utils
 
-float* make_random_float_01(int N) {
+float* make_random_float_01(size_t N) {
     float* arr = (float*)malloc(N * sizeof(float));
     for (int i = 0; i < N; i++) {
         arr[i] = ((float)rand() / RAND_MAX); // range 0..1
@@ -43,7 +43,7 @@ float* make_random_float_01(int N) {
     return arr;
 }
 
-float* make_random_float(int N) {
+float* make_random_float(size_t N) {
     float* arr = (float*)malloc(N * sizeof(float));
     for (int i = 0; i < N; i++) {
         arr[i] = ((float)rand() / RAND_MAX) * 2.0 - 1.0; // range -1..1
@@ -51,7 +51,7 @@ float* make_random_float(int N) {
     return arr;
 }
 
-int* make_random_int(int N, int V) {
+int* make_random_int(size_t N, int V) {
     int* arr = (int*)malloc(N * sizeof(int));
     for (int i = 0; i < N; i++) {
         arr[i] = rand() % V; // range 0..V-1
@@ -59,13 +59,13 @@ int* make_random_int(int N, int V) {
     return arr;
 }
 
-float* make_zeros_float(int N) {
+float* make_zeros_float(size_t N) {
     float* arr = (float*)malloc(N * sizeof(float));
     memset(arr, 0, N * sizeof(float)); // all zero
     return arr;
 }
 
-float* make_ones_float(int N) {
+float* make_ones_float(size_t N) {
     float* arr = (float*)malloc(N * sizeof(float));
     for (int i = 0; i < N; i++) {
         arr[i] = 1.0f;

--- a/dev/cuda/crossentropy_softmax_backward.cu
+++ b/dev/cuda/crossentropy_softmax_backward.cu
@@ -42,8 +42,8 @@ void crossentropy_softmax_backward_cpu(float* dlogits,
 __global__ void crossentropy_softmax_backward_kernel1(float* dlogits,
                            const float* dlosses, const float* probs, const int* targets,
                            int B, int T, int V) {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < B * T * V) {
+    size_t i = (size_t)(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < (size_t)(B) * T * V) {
         int b = i / (T * V);
         int t = (i / V) % T;
         int v = i % V;
@@ -64,8 +64,8 @@ void crossentropy_softmax_backward1(float* dlogits,
                            const float* dlosses, const float* probs, const int* targets,
                            int B, int T, int V,
                            const int block_size) {
-    const int N = B * T * V;
-    const int grid_size = ceil_div(N, block_size);
+    const size_t N = (size_t)(B) * T * V;
+    const int grid_size = ceil_div(N, (size_t) block_size);
     crossentropy_softmax_backward_kernel1<<<grid_size, block_size>>>(dlogits, dlosses, probs, targets, B, T, V);
     cudaCheck(cudaGetLastError());
 }

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -635,7 +635,7 @@ int main(int argc, char **argv) {
     softmax_forward_cpu(out, inp, B * T, V);
     {
         float max_el = -INFINITY;
-        for(int i = 0; i <  B * T * V; ++i) {
+        for(size_t i = 0; i <  (size_t)(B) * T * V; ++i) {
             max_el = max(max_el, out[i]);
         }
         assert(max_el > 1e-4);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -485,8 +485,8 @@ __global__ void softmax_forward_kernel7(float* out, const float* inp, int N, int
 __global__ void crossentropy_softmax_backward_kernel1(float* dlogits,
                            const float* dlosses, const float* probs, const int* targets,
                            int B, int T, int V) {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < B * T * V) {
+    size_t i = (size_t)(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < (size_t)(B) * T * V) {
         int b = i / (T * V);
         int t = (i / V) % T;
         int v = i % V;


### PR DESCRIPTION
With
```
    int B = 8;
    int T = 1024;
    int V = 50257;
```

The ratio of (8 * 1024 * 52507) to INT_MAX is: 0.200298.
Therefore, if we make B = 64, B * T * V overflows.