### PR TITLE
free speedup by utilizing caches better

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -344,7 +344,7 @@ __global__ void softmax_forward_kernel5(float* out, float inv_temperature, const
     namespace cg = cooperative_groups;
     cg::thread_block block = cg::this_thread_block();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
-    int idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+    int idx = (gridDim.x - blockIdx.x -1) * warp.meta_group_size() + warp.meta_group_rank();
     if(idx >= N * T) {
         return;
     }


### PR DESCRIPTION
Instead of always reading from top-left, read from bottom right to better utilize caches.

Before:
```
step 20: train loss 4.296932 (took 28.770662 ms)
step 21: train loss 4.238368 (took 28.684013 ms)
step 22: train loss 4.235001 (took 28.662183 ms)
step 23: train loss 4.037789 (took 28.673183 ms)
step 24: train loss 4.309966 (took 28.679693 ms)
step 25: train loss 4.451100 (took 28.686702 ms)
step 26: train loss 4.406357 (took 28.670413 ms)
step 27: train loss 4.334877 (took 29.079828 ms)
step 28: train loss 4.368477 (took 28.677603 ms)
step 29: train loss 4.287300 (took 28.685273 ms)
val loss 4.517179
step 30: train loss 4.155085 (took 28.939040 ms)
step 31: train loss 4.116601 (took 28.671473 ms)
step 32: train loss 4.182609 (took 28.681243 ms)
step 33: train loss 4.389328 (took 28.680083 ms)
step 34: train loss 4.254278 (took 28.668353 ms)
step 35: train loss 4.252576 (took 28.684273 ms)
step 36: train loss 4.323340 (took 28.705613 ms)
step 37: train loss 4.266943 (took 28.685933 ms)
step 38: train loss 4.267965 (took 28.670763 ms)
step 39: train loss 4.062835 (took 28.664953 ms)
```
After:
```
step 20: train loss 4.296932 (took 27.949317 ms)
step 21: train loss 4.238368 (took 27.939526 ms)
step 22: train loss 4.235001 (took 27.928437 ms)
step 23: train loss 4.037789 (took 27.939787 ms)
step 24: train loss 4.309966 (took 27.933507 ms)
step 25: train loss 4.451100 (took 27.924917 ms)
step 26: train loss 4.406357 (took 27.935437 ms)
step 27: train loss 4.334877 (took 27.931937 ms)
step 28: train loss 4.368477 (took 27.925177 ms)
step 29: train loss 4.287300 (took 27.919606 ms)
val loss 4.517179
step 30: train loss 4.155085 (took 27.950256 ms)
step 31: train loss 4.116601 (took 27.927917 ms)
step 32: train loss 4.182609 (took 27.930627 ms)
step 33: train loss 4.389328 (took 27.917677 ms)
step 34: train loss 4.254278 (took 27.915977 ms)
step 35: train loss 4.252576 (took 27.898277 ms)
step 36: train loss 4.323340 (took 27.935167 ms)
step 37: train loss 4.266943 (took 27.916987 ms)
step 38: train loss 4.267965 (took 27.943397 ms)
step 39: train loss 4.062835 (took 27.937627 ms)
```
