### PR TITLE
towards an even better backward attention kernel

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -5,7 +5,7 @@
 
 
 template<class T>
-T ceil_div(T dividend, T divisor) {
+__host__ __device__ T ceil_div(T dividend, T divisor) {
     return (dividend + divisor-1) / divisor;
 }
 


### PR DESCRIPTION
Back to the drawing board, because I think the other kernels hit a local minimum, or at least the way the loops where organized made it very difficult to think about how to optimize this further.

I think there is quite a bit of room to optimize this version further, but for educational purposes, I think it is better to have a simpler version first, where the main idea is evident, and then go crazy with the optimizations in a second version.

This design limits T to multiples of the block_size. Incidentally, on my system at least, block size 64 turns out to be fastest, which actually is compatible with both our training at test scripts.