### PR TITLE
profiling script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ train_gpt2cu: train_gpt2.cu
 test_gpt2cu: test_gpt2.cu
 	nvcc -O3 --use_fast_math $< -lcublas -lcublasLt -o $@
 
+profile_gpt2cu: profile_gpt2.cu
+	nvcc -O3 --use_fast_math -lineinfo $< -lcublas -lcublasLt -o $@
+
 clean:
 	rm -f train_gpt2 test_gpt2 train_gpt2cu test_gpt2cu
 

--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -1,0 +1,57 @@
+#define TESTING
+#include "train_gpt2.cu"
+
+int main() {
+
+    // set up the device
+    int deviceIdx = 0;
+    cudaCheck(cudaSetDevice(deviceIdx));
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, deviceIdx);
+    printf("[System]\n");
+    printf("Device %d: %s\n", deviceIdx, deviceProp.name);
+
+    // setup cuBLAS and cuBLASLt
+    cublasCheck(cublasCreate(&cublas_handle));
+    cublasCheck(cublasLtCreate(&cublaslt_handle));
+    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
+    int enable_tf32 = deviceProp.major >= 8 ? 1 : 0;
+    printf("enable_tf32: %d\n", enable_tf32);
+    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
+    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
+    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
+    // setup the (global) cuBLASLt workspace
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
+
+    // build the GPT-2 model from a checkpoint
+    GPT2 model;
+    gpt2_build_from_checkpoint(&model, "gpt2_124M.bin");
+
+    int B = 4;
+    int T = 1024;
+    printf("batch size: %d\n", B);
+    printf("sequence length: %d\n", T);
+
+    int* x = (int*)mallocCheck(B * T * sizeof(int));
+    int* y = (int*)mallocCheck(B * T * sizeof(int));
+    for(int  i = 0; i < B  * T; ++i) {
+        x[i] = i % model.config.vocab_size;
+        y[i] = i % model.config.vocab_size;
+    }
+
+    model.config.num_layers = 1;
+
+    // do a training step
+    gpt2_forward(&model, x, y, B, T);
+    gpt2_zero_grad(&model);
+    gpt2_backward(&model);
+    gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, 1);
+    cudaCheck(cudaDeviceSynchronize()); // finish all CUDA work to get correct precise timings
+    // free
+    gpt2_free(&model);
+    cudaCheck(cudaFree(cublaslt_workspace));
+    cublasCheck(cublasDestroy(cublas_handle));
+    cublasCheck(cublasLtDestroy(cublaslt_handle));
+
+    return 0;
+}


### PR DESCRIPTION
makes sure we see each kernel show up in the profile, while being as fast as possible (i.e, running only for one layer, for one step)

also gets compiled with lineinfo by default