### PR TITLE
Support for vanilla build without CUDA tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 data/
 gpt2_124M.bin
 gpt2_124M_debug_state.bin
+
+test_gpt2
+test_gpt2cu
+train_gpt2
+train_gpt2cu

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= clang
-CFLAGS = -Ofast -Wno-unused-result
+CFLAGS = -Ofast -Wno-unused-result -Wno-ignored-pragmas -Wno-unknown-attributes
 LDFLAGS =
 LDLIBS = -lm
 INCLUDES =


### PR DESCRIPTION
I tried to build on my mac and ran into a build error

```
$ make
NICE Compiling with OpenMP support
cc -Ofast -fno-finite-math-only -Wno-unused-result -march=native -Xclang -fopenmp -DOMP  -I/opt/homebrew/opt/libomp/include  -L/opt/homebrew/opt/libomp/lib train_gpt2.c -lm -lomp -o train_gpt2
clang: error: the clang compiler does not support '-march=native'
make: *** [train_gpt2] Error 1
```

It seems like the flag -march=native was not supported on my clang compiler.

I introduced the CFLAGS_COND as a list of CFlags that are included only if the CC supports it.

I also only build the nvcc targets if nvcc is installed. 