### PR TITLE
Fixes -Ofast optimizations breaking model by skipping them for gelu_backward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= clang
-CFLAGS = -Ofast -fno-finite-math-only -Wno-unused-result -march=native
+CFLAGS = -Ofast -Wno-unused-result -march=native
 LDFLAGS =
 LDLIBS = -lm
 INCLUDES =

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -363,6 +363,8 @@ void gelu_forward(float* out, float* inp, int N) {
     }
 }
 
+#pragma float_control(precise, on, push) // On msvc /fp:fast is a lot faster, but the expf inside coshf breaks the model
+__attribute__((optimize("no-finite-math-only"))) // same for gcc -Ofast 
 void gelu_backward(float* dinp, float* inp, float* dout, int N) {
     for (int i = 0; i < N; i++) {
         float x = inp[i];
@@ -375,6 +377,7 @@ void gelu_backward(float* dinp, float* inp, float* dout, int N) {
         dinp[i] += local_grad * dout[i];
     }
 }
+#pragma float_control(pop) 
 
 void residual_forward(float* out, float* inp1, float* inp2, int N) {
     for (int i = 0; i < N; i++) {


### PR DESCRIPTION
Please see https://github.com/karpathy/llm.c/pull/168 for details and work being done on optimizing the activation function on CPU.

This PR results in a 10-23% speedup on CPU and has been tested on `msvc` and `gcc` on x86 and fixes #19 