### PR TITLE
Yet more memory reductions

### DIFF
--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
     // at this point, target should be equal to expected_logits, let's compare
     // copy logits to CPU so we can compare them
     float* logits_cpu = (float*)mallocCheck(B * T * V * sizeof(float));
-    cudaMemcpy(logits_cpu, model.acts.logits, B * T * V * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(logits_cpu, model.acts.output.logits, B * T * V * sizeof(float), cudaMemcpyDeviceToHost);
     int logits_ok = 1;
     for (int i=0; i<B*T*V; i++) {
         if(i < 3) {

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
     // at this point, target should be equal to expected_logits, let's compare
     // copy logits to CPU so we can compare them
     float* logits_cpu = (float*)mallocCheck(B * T * V * sizeof(float));
-    cudaMemcpy(logits_cpu, model.acts.output.logits, B * T * V * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(logits_cpu, model.acts.output, B * T * V * sizeof(float), cudaMemcpyDeviceToHost);
     int logits_ok = 1;
     for (int i=0; i<B*T*V; i++) {
         if(i < 3) {

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -312,6 +312,7 @@ if __name__ == "__main__":
     import time
     import argparse
     import tiktoken
+    print(f"Running pytorch {torch.version.__version__}")
 
     # default settings will overfit a tiny batch of data
     # and save model weights and debug state to disk on the first iteration
@@ -396,6 +397,7 @@ if __name__ == "__main__":
     x, y = next(data_iter) # we'll overfit this batch below
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
     timings = []
+    torch.cuda.reset_peak_memory_stats()
     for i in range(args.num_iterations):
         t0 = time.time()
         logits, loss = model(x, y)
@@ -417,6 +419,8 @@ if __name__ == "__main__":
         print(f"iteration {i}, loss: {loss.item()}, time: {(t1-t0)*1000:.3f}ms")
     if len(timings) > 0:
         print(f"final 20 iters avg: {np.mean(timings)*1000:.3f}ms")
+
+    print(f"Peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
 
     # before we end, let's also do one round of inference
     # we'll kick off the generation with "<|endoftext|>", which designates the start of a new sequence


### PR DESCRIPTION
Currently fails the test, because right now there is no way to get logits out of the model
Run as training => get  dlogits
Run for inference => get probs

The memory savings are quite substantial, though:
```
allocated 7127 MiB for activations
allocated 1421 MiB for activation gradients
=>
allocated 5946 MiB for activations
allocated 636 MiB for activation gradients
```