### PR TITLE
Added shared memory for the atomic additions for the layernorm_back

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -556,7 +556,7 @@ __global__ void matmul_backward_bias_kernel2(float* dbias, const float* dout, in
     }
 }
 
-__global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* dbias,
+__global__ void layernorm_backward_kernel(float* dinp, float* dweight, float* dbias,
                                            const float* dout, const float* inp, const float* weight, const float* mean, const float* rstd,
                                            int B, int T, int C) {
     cg::thread_block block = cg::this_thread_block();


### PR DESCRIPTION
This cr was made to address the issue found in the profiler that the atomic operations in the final loop of this kernel were causing a bunch of warp stalls. By doing the atomic operation on shared memory instead of global memory and then copying the shared memory afterwards it signifigantly reduces the time by almost a factor of 4 for the largest block sizes:

Before:
```
block_size   32 time 0.3854 ms
block_size   64 time 0.4663 ms
block_size  128 time 0.4643 ms
block_size  256 time 0.4715 ms
block_size  512 time 0.4740 ms
block_size 1024 time 0.4769 ms
```


After:
```
block_size   32 time 0.3658 ms
block_size   64 time 0.2301 ms
block_size  128 time 0.1782 ms
block_size  256 time 0.1526 ms
block_size  512 time 0.1426 ms
block_size 1024 time 0.1431 ms
```
