### PR TITLE
Support for FP16/BF16 in train_gpt2.cu (1.86x Perf)

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -496,7 +496,7 @@ __global__ void softmax_forward_kernel5(Type* out, float inv_temperature, const 
 
     if(4*pos_by_4 + warp.thread_rank() <= own_pos) {
         float old_maxval = maxval;
-        maxval = fmaxf(maxval, x[4*pos_by_4 + warp.thread_rank()]);
+        maxval = fmaxf(maxval, (float)x[4*pos_by_4 + warp.thread_rank()]);
         sumval *= expf(inv_temperature * (old_maxval - maxval));
         sumval += expf(inv_temperature * ((float)x[4*pos_by_4 + warp.thread_rank()] - maxval));
     }
@@ -820,7 +820,7 @@ __global__ void softmax_autoregressive_backward_kernel(floatX* dpreatt, const fl
             // don't touch the cache. Some parts will still be here from the previous loop, and
             // we want to exploit those.
             float acc = (float)__ldcs(att_bth + t3) * ((float)__ldcs(datt_bth + t3) - local_sum);
-            __stcs(dpreatt_bth + t3, scale * acc);
+            __stcs(dpreatt_bth + t3, (floatX)(scale * acc));
         }
     }
 }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1354,12 +1354,12 @@ void fill_in_parameter_sizes(size_t* param_sizes, size_t* param_sizeof, GPT2Conf
     for (int i = 0; i < NUM_PARAMETER_TENSORS; i++) {
         param_sizeof[i] = sizeof(floatX);
     }
-    param_sizes[2] = sizeof(floatN); // ln1w
-    param_sizes[3] = sizeof(floatN); // ln1b
-    param_sizes[8] = sizeof(floatN); // ln2w
-    param_sizes[9] = sizeof(floatN); // ln2b
-    param_sizes[14] = sizeof(floatN); // lnfw
-    param_sizes[15] = sizeof(floatN); // lnfb
+    param_sizeof[2] = sizeof(floatN); // ln1w
+    param_sizeof[3] = sizeof(floatN); // ln1b
+    param_sizeof[8] = sizeof(floatN); // ln2w
+    param_sizeof[9] = sizeof(floatN); // ln2b
+    param_sizeof[14] = sizeof(floatN); // lnfw
+    param_sizeof[15] = sizeof(floatN); // lnfb
 }
 
 // allocate memory for the parameters and point the individual tensors to the right places


### PR DESCRIPTION
Now finished and reasonably happy with it!
1.86x performance on my RTX 4090:
- FP32: ~80ms
- BF16: ~43ms (with layernorm params in FP32, but all activations in BF16)

This allows the same train_gpt2.cu to work as full FP32, full BF16, full FP16, or full (BF/FP)16 + FP32 layernorm simply by changing the define at the top of the file. Also included stochastic rounding for the Adam kernel (but nothing else at this point, possibly worth adding to gradients in general when we move to FP8?)

To simplify the logic compared to the first version of the PR, all activation tensors are now always "floatX", we cannot mix-and-match. However, because atomicAdd on 16-bit values in some of the backwards kernels are HORRIBLY slow (10x slower or worse), and because this kind of flexibility seems useful in general for layernorm accuracy, layernorm is kept at FP32 by defining "floatN" as "float".

I reduced the amount of code duplication by using very lightweight templates for the kernel types. It's still a *BIG* change though, unfortunately I don't think there's any way around that!