### PR TITLE
Added llm.metal to notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ Lastly, I will be a lot more sensitive to complexity in the root folder of the p
 - Rust
   -  [llm.rs](https://github.com/ToJen/llm.rs) by @[ToJen](https://github.com/ToJen): a Rust port of this project
 
+- Metal
+  - [llm.metal](https://github.com/regrettable-username/llm.metal) by @[regrettable-username](https://github.com/regrettable-username): LLM training in simple, raw C/Metal Shading Language
 ## discussions
 
 Ways of organizing development:


### PR DESCRIPTION
This is a fork of llm.c, designed to take full advantage of Apple Silicon via the Metal framework. Just got the forward pass working and will start on the backward pass. I wrote a minimal C wrapper API over the Objective-C Metal API that was needed to set up and run compute shaders. The rest of the code is pure-C and Metal Shading Language. I'm trying to mirror the original repo as closely as possible both in code and project philosophy.