### PR TITLE
Minor device settable edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: python prepro_tinyshakespeare.py
 
       - name: Train model
-        run: python train_gpt2.py
+        run: python train_gpt2.py --device cpu
 
       - name: Compile training and testing program
         run: make test_gpt2 train_gpt2

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -328,6 +328,8 @@ if __name__ == "__main__":
     parser.add_argument("--num_iterations", type=int, default=10, help="number of iterations to run")
     parser.add_argument("--batch_size", type=int, default=4, help="batch size")
     parser.add_argument("--sequence_length", type=int, default=64, help="sequence length")
+    parser.add_argument("--device", type=str, default=None, help="device to use (e.g., 'cpu', 'cuda:0')")
+
     args = parser.parse_args()
     B, T = args.batch_size, args.sequence_length
     assert 1 <= T <= 1024
@@ -339,6 +341,9 @@ if __name__ == "__main__":
         device = "cuda"
     elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         device = "mps"
+    # Override with device argument if set
+    if args.device:
+        device = args.device
     print(f"using device: {device}")
 
     # create a context manager following the desired dtype and device


### PR DESCRIPTION
In the CI, we run train_gpt2.py on Mac.
But lately some odd error appears. It looks like this:

```
2024-04-24T17:47:45.8970760Z RuntimeError: MPS backend out of memory (MPS allocated: 0 bytes, other allocations: 0 bytes, max allowed: 7.93 GB). Tried to allocate 147.24 MB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).
2024-04-24T17:47:46.2765760Z ##[error]Process completed with exit code 1.
```

Before then we had this situation:

```
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/torch/backends/mps/init.py:22: UserWarning: Skipping device Apple Paravirtual device that does not support Metal 2.0 (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/mps/MPSDevice.mm:101.)
return torch._C._mps_is_available()
Running pytorch 2.2.2
using device: cpu
```

It means that we could not really use Metal in the virtual CI workflow, our device became selected to cpu.
Now, it seems pytorch in some cases lets us use Metal, and we end up in that situation where when the API calls are done by Pytorch; we get errors.

So in order to specify that we actually want to run on the CPU (even whn MPS is what appears to be falsely "marked" as available) I made this little change.

I know you have a history with argparse, so I only did this via environment variables. 