### PR TITLE
train_gtp2.c accesses parameters as arrays

### DIFF
--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -49,7 +49,7 @@ void encoder_forward(float* out,
             // seek to the output position in out[b,t,:]
             float* out_bt = &outBTC[b][t][0];
             // get the index of the token at inp[b, t]
-            const int ix= inpBT[b][t];
+            int ix= inpBT[b][t];
             // seek to the position in wte corresponding to the token
             const float* wte_ix = wteVC[ix];
             // seek to the position in wpe corresponding to the position
@@ -76,7 +76,7 @@ void encoder_backward(float* dwte, float* dwpe,
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             float* dout_bt = &doutBTC[b][t][0];
-            const int ix = inpBT[b][t];
+            int ix = inpBT[b][t];
             float* dwte_ix = dwteVC[ix];
             float* dwpe_t = &dwpeTC[t][0];
             for (int i = 0; i < C; i++) {
@@ -186,14 +186,14 @@ void layernorm_backward(float* dinp, float* dweight, float* dbias,
 }
 
 void matmul_forward(float* out,
-                    float* inp, const float* weight, const float* bias,
+                    const float* inp, const float* weight, const float* bias,
                     int B, int T, int C, int OC) {
     // most of the running time is spent here and in matmul_backward
     // OC is short for "output channels"
     // inp is (B,T,C), weight is (OC, C), bias is (OC)
     // out will be (B,T,OC)
 
-    DECL_ARRAYPTR3(float, inpBTC,B,T,C, inp);
+    DECL_ARRAYPTR3(const float, inpBTC,B,T,C, inp);
     DECL_ARRAYPTR2(const float, weightOCC,OC,C, weight);
     DECL_ARRAYPTR3(float, outBTOC,B,T,OC, out);
 
@@ -201,7 +201,7 @@ void matmul_forward(float* out,
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
             float* out_bt = &outBTOC[b][t][0];
-            float* inp_bt = &inpBTC[b][t][0];
+            const float* inp_bt = &inpBTC[b][t][0];
             for (int o = 0; o < OC; o++) {
                 float val = (bias != NULL) ? bias[o] : 0.0f;
                 const float* wrow = &weightOCC[o][0];

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -349,6 +349,8 @@ void attention_backward(float* dinp, float* dpreatt, float* datt,
     int hs = C / NH; // head size
     float scale = 1.0 / sqrtf(hs);
 
+    DECL_ARRAYPTR3(float, inpBTC3,B,T,C3, inp);
+    DECL_ARRAYPTR3(float, dinpBTC3,B,T,C3, dinp);
     DECL_ARRAYPTR4(const float, attBNHTT,B,NH,T,T, att);
     DECL_ARRAYPTR4(float, dattBNHTT,B,NH,T,T, datt);
     DECL_ARRAYPTR4(float, dpreattBNHTT,B,NH,T,T, dpreatt);
@@ -359,8 +361,8 @@ void attention_backward(float* dinp, float* dpreatt, float* datt,
                 const float* att_bth = &attBNHTT[b][h][t][0];
                 float* datt_bth = &dattBNHTT[b][h][t][0];
                 float* dpreatt_bth = &dpreattBNHTT[b][h][t][0];
-                float* dquery_t = dinp + b * T * C3 + t * C3 + h * hs;
-                float* query_t = inp + b * T * C3 + t * C3 + h * hs;
+                float* dquery_t = &dinpBTC3[b][t][h*hs];
+                float* query_t = &inpBTC3[b][t][h*hs];
 
                 // backward pass 4, through the value accumulation
                 float* dout_bth = dout + b * T * C + t * C + h * hs;


### PR DESCRIPTION
Would you be interested in this patch, where I changed many of the functions that receive multidimensional arrays as parameters.  I believe, since the C code seems mainly as an introduction to understand the process, this would make things much easier to read.

So, instead of doing the multiplications like in the original source, I'm declaring pointers to multidimensional arrays from the parameter, so that the source can use C array syntax like: 

```
old:      float* out_bt = out + b * T * C + t * C;

new:      float* out_bt = &outBTC[b][t][0];
```

or 

```
old:          int ix = inp[b * T + t];

new:          const int ix = inpBT[b][t];
```

There are a few still missing, but if you are interested, I would complete this.


Markus