### PR TITLE
Enable multithreading in nvcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS_COND = -march=native
 NVCC := $(shell which nvcc 2>/dev/null)
 
 # NVCC flags
-NVCC_FLAGS = -O3 --use_fast_math
+NVCC_FLAGS = -O3 -t=0 --use_fast_math
 NVCC_LDFLAGS = -lcublas -lcublasLt
 NCLL_INCLUDES =
 NVCC_LDLIBS =


### PR DESCRIPTION
Tested locally and reduced compilation time by 200ms, unfortunately for me upgrading to 12.4 made my compilations times slow by 2x but at least this can make it a bit faster