### PR TITLE
Full BF16 including layernorms by default (minimising number of BF16 atomics)

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -76,19 +76,19 @@ float* make_ones_float(size_t N) {
 // ----------------------------------------------------------------------------
 // testing and benchmarking utils
 
-template<class T>
-void validate_result(T* device_result, const T* cpu_reference, const char* name, std::size_t num_elements, T tolerance=1e-4) {
-    T* out_gpu = (T*)malloc(num_elements * sizeof(T));
-    cudaCheck(cudaMemcpy(out_gpu, device_result, num_elements * sizeof(T), cudaMemcpyDeviceToHost));
+template<class D, class T>
+void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements, T tolerance=1e-4) {
+    D* out_gpu = (D*)malloc(num_elements * sizeof(T));
+    cudaCheck(cudaMemcpy(out_gpu, device_result, num_elements * sizeof(D), cudaMemcpyDeviceToHost));
     int nfaults = 0;
     for (int i = 0; i < num_elements; i++) {
         // print the first few comparisons
         if (i < 5) {
-            printf("%f %f\n", cpu_reference[i], out_gpu[i]);
+            printf("%f %f\n", cpu_reference[i], (T)out_gpu[i]);
         }
         // ensure correctness for all elements. We can set an "ignore" mask by writing NaN
-        if (fabs(cpu_reference[i] - out_gpu[i]) > tolerance && !isnan(cpu_reference[i])) {
-            printf("Mismatch of %s at %d: CPU_ref: %f vs GPU: %f\n", name, i, cpu_reference[i], out_gpu[i]);
+        if (fabs(cpu_reference[i] - (T)out_gpu[i]) > tolerance && !isnan(cpu_reference[i])) {
+            printf("Mismatch of %s at %d: CPU_ref: %f vs GPU: %f\n", name, i, cpu_reference[i], (T)out_gpu[i]);
             nfaults ++;
             if (nfaults >= 10) {
                 free(out_gpu);

--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -78,7 +78,7 @@ float* make_ones_float(size_t N) {
 
 template<class D, class T>
 void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements, T tolerance=1e-4) {
-    D* out_gpu = (D*)malloc(num_elements * sizeof(T));
+    D* out_gpu = (D*)malloc(num_elements * sizeof(D));
     cudaCheck(cudaMemcpy(out_gpu, device_result, num_elements * sizeof(D), cudaMemcpyDeviceToHost));
     int nfaults = 0;
     for (int i = 0; i < num_elements; i++) {

--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -20,6 +20,24 @@ version 2 moves a lot of reduction to shared memory over global memory
 #include "common.h"
 
 // ----------------------------------------------------------------------------
+// CUDA settings
+int cuda_num_SMs = 0; // for persistent threads where we want 1 threadblock per SM
+
+// turn on bf16 as default, done up here for now
+#define ENABLE_BF16
+
+#if defined(ENABLE_BF16)
+typedef __nv_bfloat16 floatX;
+typedef __nv_bfloat16 floatN;
+#elif defined(ENABLE_FP16)
+typedef half floatX;
+typedef half floatN;
+#else
+typedef float floatX;
+typedef float floatN;
+#endif
+
+// ----------------------------------------------------------------------------
 // CPU code reference
 
 void layernorm_forward_cpu(float* out, float* mean, float* rstd,
@@ -110,6 +128,33 @@ void layernorm_backward_cpu(float* dinp, float* dweight, float* dbias,
 // ----------------------------------------------------------------------------
 // GPU kernels
 
+// GPU helper functions for atomicAdd on smaller than 32-bit types
+#ifdef ENABLE_BF16
+__device__ void atomicAddX(__nv_bfloat16* addr, __nv_bfloat16 val) {
+    uintptr_t ptr_val = reinterpret_cast<uintptr_t>(addr);
+    __nv_bfloat162* ptr_bf16 = reinterpret_cast<__nv_bfloat162*>(ptr_val & ~uintptr_t(0x3));
+
+    // Prepare the value to add, setting the other half to zero
+    __nv_bfloat162 add_val = (ptr_val & 0x3) ? __halves2bfloat162(__ushort_as_bfloat16(0), val)
+                                             : __halves2bfloat162(val, __ushort_as_bfloat16(0));
+    atomicAdd(ptr_bf16, add_val);
+}
+#endif
+#ifdef ENABLE_FP16
+__device__ void atomicAddX(half* addr, half val) {
+    uintptr_t ptr_val = reinterpret_cast<uintptr_t>(addr);
+    half2* ptr_fp16 = reinterpret_cast<half2*>(ptr_val & ~uintptr_t(0x3));
+
+    // Prepare the value to add, setting the other half to zero
+    half2 add_val = (ptr_val & 0x3) ? __halves2half2(__ushort_as_half(0), val)
+                                    : __halves2half2(val, __ushort_as_half(0));
+    atomicAdd(ptr_fp16, add_val);
+}
+#endif
+__device__ void atomicAddX(float* addr, float val) {
+    atomicAdd(addr, val);
+}
+
 // super naive kernel that just parallelizes over B,T and loops over C
 __global__ void layernorm_backward_kernel1(float* dinp, float* dweight, float* dbias,
                         const float* dout, const float* inp, const float* weight, const float* mean, const float* rstd,
@@ -156,9 +201,10 @@ __global__ void layernorm_backward_kernel1(float* dinp, float* dweight, float* d
 }
 
 // uses shared memory instead for the reduces
-__global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* dbias,
-                                           const float* dout, const float* inp, const float* weight, const float* mean, const float* rstd,
-                                           int B, int T, int C) {
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+__global__ void layernorm_backward_kernel2(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C) {
     extern __shared__ float shared[]; // size = 2 * C
 
     namespace cg = cooperative_groups;
@@ -171,11 +217,11 @@ __global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* d
     int b = idx / T;
     int t = idx % T;
 
-    const float* dout_bt = dout + b * T * C + t * C;
-    const float* inp_bt = inp + b * T * C + t * C;
-    float* dinp_bt = dinp + b * T * C + t * C;
-    const float mean_bt = mean[b * T + t];
-    const float rstd_bt = rstd[b * T + t];
+    const Tdout* dout_bt = dout + b * T * C + t * C;
+    const Trest* inp_bt = inp + b * T * C + t * C;
+    Tdinp* dinp_bt = dinp + b * T * C + t * C;
+    const float mean_bt = (float)mean[b * T + t];
+    const float rstd_bt = (float)rstd[b * T + t];
 
     // the first half of shared memory is bias, second is weight
     float* dbias_shared = shared;
@@ -183,7 +229,7 @@ __global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* d
 
     // init shared memory to zero
     #pragma unroll
-	for(int i = threadIdx.x; i < C; i+= blockDim.x){
+    for(int i = threadIdx.x; i < C; i+= blockDim.x){
        dbias_shared[i] = 0.0f;
        dweight_shared[i] = 0.0f;
     }
@@ -193,8 +239,8 @@ __global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* d
     float dnorm_mean = 0.0f;
     float dnorm_norm_mean = 0.0f;
     for (int i = warp.thread_rank(); i < C; i  += warp.size()) {
-        float norm_bti = (inp_bt[i] - mean_bt) * rstd_bt;
-        float dnorm_i = weight[i] * dout_bt[i];
+        float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+        float dnorm_i = (float)weight[i] * (float)dout_bt[i];
         dnorm_mean += dnorm_i;
         dnorm_norm_mean += dnorm_i * norm_bti;
     }
@@ -205,27 +251,408 @@ __global__ void layernorm_backward_kernel2(float* dinp, float* dweight, float* d
 
     // now iterate again and accumulate all the gradients
     for (int i = warp.thread_rank(); i < C; i += warp.size()) {
-        float norm_bti = (inp_bt[i] - mean_bt) * rstd_bt;
-        float dnorm_i = weight[i] * dout_bt[i];
+        float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+        float dnorm_i = (float)weight[i] * (float)dout_bt[i];
         // gradient contribution to bias
-        atomicAdd(&dbias_shared[i], dout_bt[i]);
+        atomicAdd(&dbias_shared[i], (float)dout_bt[i]);
         // gradient contribution to weight
-        atomicAdd(&dweight_shared[i], norm_bti * dout_bt[i]);
+        atomicAdd(&dweight_shared[i], norm_bti * (float)dout_bt[i]);
         // gradient contribution to input
         float dval = 0.0f;
         dval += dnorm_i; // term 1
         dval -= dnorm_mean; // term 2
         dval -= norm_bti * dnorm_norm_mean; // term 3
         dval *= rstd_bt; // final scale
-        dinp_bt[i] += dval;
+        dinp_bt[i] = (Tdinp)((float)dinp_bt[i] + dval);
     }
     __syncthreads();
 
     // write to global memory
-	for(int i = threadIdx.x; i < C; i+= blockDim.x){
-        atomicAdd(&dbias[i], dbias_shared[i]);
-        atomicAdd(&dweight[i], dweight_shared[i]);
-	}
+    for(int i = threadIdx.x; i < C; i+= blockDim.x) {
+        atomicAddX(&dbias[i], (Tparams)dbias_shared[i]);
+        atomicAddX(&dweight[i], (Tparams)dweight_shared[i]);
+    }
+}
+
+// kernel2 is 1 threadblock for all Cs on 32 BTs (assuming threadblock size of 1024 threads = 32 warps)
+// To minimise the amount of atomicAdds, we will aim for 1 threadblock per SM, processing (total BTs / threadblocks) BTs
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+__global__ void layernorm_backward_kernel3(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C) {
+    extern __shared__ float shared[]; // size = 2 * C
+
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    int base_idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+
+    // the first half of shared memory is bias, second is weight
+    float* dbias_shared = shared;
+    float* dweight_shared = shared + C;
+
+    // init shared memory to zero
+    #pragma unroll 4
+    for(int i = threadIdx.x; i < C; i+= blockDim.x){
+       dbias_shared[i] = 0.0f;
+       dweight_shared[i] = 0.0f;
+    }
+    __syncthreads();
+
+    int warps_in_grid = gridDim.x * warp.meta_group_size();
+    for (int idx = base_idx; idx < B * T; idx += warps_in_grid) {
+        int b = idx / T;
+        int t = idx % T;
+
+        const Tdout* dout_bt = dout + b * T * C + t * C;
+        const Trest* inp_bt = inp + b * T * C + t * C;
+        Tdinp* dinp_bt = dinp + b * T * C + t * C;
+        const float mean_bt = (float)mean[b * T + t];
+        const float rstd_bt = (float)rstd[b * T + t];
+
+        // first: two reduce operations
+        float dnorm_mean = 0.0f;
+        float dnorm_norm_mean = 0.0f;
+        for (int i = warp.thread_rank(); i < C; i  += warp.size()) {
+            float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * (float)dout_bt[i];
+            dnorm_mean += dnorm_i;
+            dnorm_norm_mean += dnorm_i * norm_bti;
+        }
+        dnorm_mean = cg::reduce(warp, dnorm_mean, cg::plus<float>{});
+        dnorm_norm_mean = cg::reduce(warp, dnorm_norm_mean, cg::plus<float>{});
+        dnorm_mean = dnorm_mean / C;
+        dnorm_norm_mean = dnorm_norm_mean / C;
+
+        // now iterate again and accumulate all the gradients
+        for (int i = warp.thread_rank(); i < C; i += warp.size()) {
+            float dout_i = (float)__ldcs(&dout_bt[i]);
+            float norm_bti = ((float)__ldcs(&inp_bt[i]) - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * dout_i;
+            // gradient contribution to bias
+            atomicAdd(&dbias_shared[i], dout_i);
+            // gradient contribution to weight
+            atomicAdd(&dweight_shared[i], norm_bti * dout_i);
+            // gradient contribution to input
+            float dval = 0.0f;
+            dval += dnorm_i; // term 1
+            dval -= dnorm_mean; // term 2
+            dval -= norm_bti * dnorm_norm_mean; // term 3
+            dval *= rstd_bt; // final scale
+            dinp_bt[i] = (Tdinp)((float)dinp_bt[i] + dval);
+        }
+    }
+    __syncthreads();
+
+    for(int i = threadIdx.x; i < C; i+= blockDim.x) {
+        atomicAddX(&dbias[i], (Tparams)dbias_shared[i]);
+        atomicAddX(&dweight[i], (Tparams)dweight_shared[i]);
+    }
+}
+
+// atomicCAS version of kernel3
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+__global__ void layernorm_backward_kernel4(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C) {
+    extern __shared__ float shared[]; // size = 2 * C
+
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    int base_idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+
+    // the first half of shared memory is bias, second is weight
+    float* dbias_shared = shared;
+    float* dweight_shared = shared + C;
+
+    // init shared memory to zero
+    #pragma unroll 4
+    for(int i = threadIdx.x; i < C; i+= blockDim.x){
+       dbias_shared[i] = 0.0f;
+       dweight_shared[i] = 0.0f;
+    }
+    __syncthreads();
+
+    int warps_in_grid = gridDim.x * warp.meta_group_size();
+    for (int idx = base_idx; idx < B * T; idx += warps_in_grid) {
+        int b = idx / T;
+        int t = idx % T;
+
+        const Tdout* dout_bt = dout + b * T * C + t * C;
+        const Trest* inp_bt = inp + b * T * C + t * C;
+        Tdinp* dinp_bt = dinp + b * T * C + t * C;
+        const float mean_bt = (float)mean[b * T + t];
+        const float rstd_bt = (float)rstd[b * T + t];
+
+        // first: two reduce operations
+        float dnorm_mean = 0.0f;
+        float dnorm_norm_mean = 0.0f;
+        for (int i = warp.thread_rank(); i < C; i  += warp.size()) {
+            float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * (float)dout_bt[i];
+            dnorm_mean += dnorm_i;
+            dnorm_norm_mean += dnorm_i * norm_bti;
+        }
+        dnorm_mean = cg::reduce(warp, dnorm_mean, cg::plus<float>{});
+        dnorm_norm_mean = cg::reduce(warp, dnorm_norm_mean, cg::plus<float>{});
+        dnorm_mean = dnorm_mean / C;
+        dnorm_norm_mean = dnorm_norm_mean / C;
+
+        // now iterate again and accumulate all the gradients
+        for (int i = warp.thread_rank(); i < C; i += warp.size()) {
+            float dout_i = (float)__ldcs(&dout_bt[i]);
+            float norm_bti = ((float)__ldcs(&inp_bt[i]) - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * dout_i;
+            // gradient contribution to bias
+            atomicAdd(&dbias_shared[i], dout_i);
+            // gradient contribution to weight
+            atomicAdd(&dweight_shared[i], norm_bti * dout_i);
+            // gradient contribution to input
+            float dval = 0.0f;
+            dval += dnorm_i; // term 1
+            dval -= dnorm_mean; // term 2
+            dval -= norm_bti * dnorm_norm_mean; // term 3
+            dval *= rstd_bt; // final scale
+            dinp_bt[i] = (Tdinp)((float)dinp_bt[i] + dval);
+        }
+    }
+    __syncthreads();
+
+    __nv_bfloat162* dbiasVec2 = reinterpret_cast<__nv_bfloat162*>(dbias);
+    __nv_bfloat162* dweightVec2 = reinterpret_cast<__nv_bfloat162*>(dweight);
+
+    // write to global memory
+    for(int i = threadIdx.x; i < C/2; i+= blockDim.x) {
+        __nv_bfloat162 add_dbias = __halves2bfloat162((__nv_bfloat16)dbias_shared[i*2], (__nv_bfloat16)dbias_shared[i*2+1]);
+        __nv_bfloat162 add_dweight = __halves2bfloat162((__nv_bfloat16)dweight_shared[i*2], (__nv_bfloat16)dweight_shared[i*2+1]);
+
+        // Get the current value from L2 cache
+        __nv_bfloat162 current_dbias = __ldcg(&dbiasVec2[i]);
+        __nv_bfloat162 current_dweight = __ldcg(&dweightVec2[i]);
+
+        // Add the two values
+        __nv_bfloat162 new_dbias = add_dbias + current_dbias;
+        __nv_bfloat162 new_dweight = add_dweight + current_dweight;
+
+        // Write the result back to L2 cache using 32-bit integer atomic compare and exchange
+        uint current_dbias32b = *reinterpret_cast<uint*>(&current_dbias);
+        uint current_dweight32b = *reinterpret_cast<uint*>(&current_dweight);
+
+        uint new_dbias32b = *reinterpret_cast<uint*>(&new_dbias);
+        uint new_dweight32b = *reinterpret_cast<uint*>(&new_dweight);
+
+        uint old_dbias32b = atomicCAS((uint*)&dbiasVec2[i], current_dbias32b, new_dbias32b);
+        uint old_dweight32b = atomicCAS((uint*)&dweightVec2[i], current_dweight32b, new_dweight32b);
+
+        // If the value has changed between read and atomic, we need to try again
+        while (old_dbias32b != current_dbias32b) {
+            current_dbias32b = old_dbias32b;
+            new_dbias = *reinterpret_cast<__nv_bfloat162*>(&current_dbias32b) + add_dbias;
+            new_dbias32b = *reinterpret_cast<uint*>(&new_dbias);
+            old_dbias32b = atomicCAS((uint*)&dbiasVec2[i], current_dbias32b, new_dbias32b);
+        }
+
+        while (old_dweight32b != current_dweight32b) {
+            current_dweight32b = old_dweight32b;
+            new_dweight = *reinterpret_cast<__nv_bfloat162*>(&current_dweight32b) + add_dweight;
+            new_dweight32b = *reinterpret_cast<uint*>(&new_dweight);
+            old_dweight32b = atomicCAS((uint*)&dweightVec2[i], current_dweight32b, new_dweight32b);
+        }
+    }
+}
+
+// FP32 scratchpad per threadgroup, zero atomics except atomicAdd on uint for the flag (based on kernel3)
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+__global__ void layernorm_backward_kernel5(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C) {
+    extern __shared__ float shared[]; // size = 2 * C + 1
+
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    int base_idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+
+    // the first half of shared memory is bias, second is weight
+    float* dbias_shared = shared;
+    float* dweight_shared = shared + C;
+
+    // init shared memory to zero
+    #pragma unroll 4
+    for(int i = threadIdx.x; i < C; i+= blockDim.x){
+       dbias_shared[i] = 0.0f;
+       dweight_shared[i] = 0.0f;
+    }
+    uint *tmp_flag = (uint*)(shared + C*2);
+    __syncthreads();
+
+    int warps_in_grid = gridDim.x * warp.meta_group_size();
+    for (int idx = base_idx; idx < B * T; idx += warps_in_grid) {
+        int b = idx / T;
+        int t = idx % T;
+
+        const Tdout* dout_bt = dout + b * T * C + t * C;
+        const Trest* inp_bt = inp + b * T * C + t * C;
+        Tdinp* dinp_bt = dinp + b * T * C + t * C;
+        const float mean_bt = (float)mean[b * T + t];
+        const float rstd_bt = (float)rstd[b * T + t];
+
+        // first: two reduce operations
+        float dnorm_mean = 0.0f;
+        float dnorm_norm_mean = 0.0f;
+        for (int i = warp.thread_rank(); i < C; i  += warp.size()) {
+            float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * (float)dout_bt[i];
+            dnorm_mean += dnorm_i;
+            dnorm_norm_mean += dnorm_i * norm_bti;
+        }
+        dnorm_mean = cg::reduce(warp, dnorm_mean, cg::plus<float>{});
+        dnorm_norm_mean = cg::reduce(warp, dnorm_norm_mean, cg::plus<float>{});
+        dnorm_mean = dnorm_mean / C;
+        dnorm_norm_mean = dnorm_norm_mean / C;
+
+        // now iterate again and accumulate all the gradients
+        for (int i = warp.thread_rank(); i < C; i += warp.size()) {
+            float dout_i = (float)__ldcs(&dout_bt[i]);
+            float norm_bti = ((float)__ldcs(&inp_bt[i]) - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * dout_i;
+            // gradient contribution to bias
+            atomicAdd(&dbias_shared[i], dout_i);
+            // gradient contribution to weight
+            atomicAdd(&dweight_shared[i], norm_bti * dout_i);
+            // gradient contribution to input
+            float dval = 0.0f;
+            dval += dnorm_i; // term 1
+            dval -= dnorm_mean; // term 2
+            dval -= norm_bti * dnorm_norm_mean; // term 3
+            dval *= rstd_bt; // final scale
+            dinp_bt[i] = (Tdinp)((float)dinp_bt[i] + dval);
+        }
+    }
+    __syncthreads();
+
+    float* scratch_dbias = scratch;
+    float* scratch_dweight = scratch + C * gridDim.x;
+    uint* scratchFlag = (uint*)(scratch + (2 * C * gridDim.x));
+
+    for(int i = threadIdx.x; i < C; i+= blockDim.x) {
+        scratch_dbias[i + C*blockIdx.x] = dbias_shared[i];
+        scratch_dweight[i + C*blockIdx.x] = dweight_shared[i];
+    }
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        *tmp_flag = atomicAdd(scratchFlag, 1);
+    }
+    __syncthreads();
+    if (*tmp_flag == gridDim.x-1) {
+        // last block to finish, accumulate the scratchpad
+        for (int i = threadIdx.x; i < C; i += blockDim.x) {
+            float dbias_sum = 0.0f;
+            float dweight_sum = 0.0f;
+            #pragma unroll 8
+            for (int j = 0; j < gridDim.x; j++) {
+                dbias_sum += scratch_dbias[i + j*C];
+                dweight_sum += scratch_dweight[i + j*C];
+            }
+            dbias[i] = (Tparams)((float)dbias[i] + dbias_sum);
+            dweight[i] = (Tparams)((float)dweight[i] + dweight_sum);
+        }
+    }
+}
+
+// single FP32 scratchpad shared by all the threadblocks (based on kernels 3 & 5)
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+__global__ void layernorm_backward_kernel6(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C) {
+    extern __shared__ float shared[]; // size = 2 * C + 1
+
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    int base_idx = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
+
+    // the first half of shared memory is bias, second is weight
+    float* dbias_shared = shared;
+    float* dweight_shared = shared + C;
+
+    // init shared memory to zero
+    #pragma unroll 4
+    for(int i = threadIdx.x; i < C; i+= blockDim.x){
+       dbias_shared[i] = 0.0f;
+       dweight_shared[i] = 0.0f;
+    }
+    uint *tmp_flag = (uint*)(shared + C*2);
+    __syncthreads();
+
+    int warps_in_grid = gridDim.x * warp.meta_group_size();
+    for (int idx = base_idx; idx < B * T; idx += warps_in_grid) {
+        int b = idx / T;
+        int t = idx % T;
+
+        const Tdout* dout_bt = dout + b * T * C + t * C;
+        const Trest* inp_bt = inp + b * T * C + t * C;
+        Tdinp* dinp_bt = dinp + b * T * C + t * C;
+        const float mean_bt = (float)mean[b * T + t];
+        const float rstd_bt = (float)rstd[b * T + t];
+
+        // first: two reduce operations
+        float dnorm_mean = 0.0f;
+        float dnorm_norm_mean = 0.0f;
+        for (int i = warp.thread_rank(); i < C; i  += warp.size()) {
+            float norm_bti = ((float)inp_bt[i] - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * (float)dout_bt[i];
+            dnorm_mean += dnorm_i;
+            dnorm_norm_mean += dnorm_i * norm_bti;
+        }
+        dnorm_mean = cg::reduce(warp, dnorm_mean, cg::plus<float>{});
+        dnorm_norm_mean = cg::reduce(warp, dnorm_norm_mean, cg::plus<float>{});
+        dnorm_mean = dnorm_mean / C;
+        dnorm_norm_mean = dnorm_norm_mean / C;
+
+        // now iterate again and accumulate all the gradients
+        for (int i = warp.thread_rank(); i < C; i += warp.size()) {
+            float dout_i = (float)__ldcs(&dout_bt[i]);
+            float norm_bti = ((float)__ldcs(&inp_bt[i]) - mean_bt) * rstd_bt;
+            float dnorm_i = (float)weight[i] * dout_i;
+            // gradient contribution to bias
+            atomicAdd(&dbias_shared[i], dout_i);
+            // gradient contribution to weight
+            atomicAdd(&dweight_shared[i], norm_bti * dout_i);
+            // gradient contribution to input
+            float dval = 0.0f;
+            dval += dnorm_i; // term 1
+            dval -= dnorm_mean; // term 2
+            dval -= norm_bti * dnorm_norm_mean; // term 3
+            dval *= rstd_bt; // final scale
+            dinp_bt[i] = (Tdinp)((float)dinp_bt[i] + dval);
+        }
+    }
+
+    // Accumulate into a FP32 scratchpad
+    // BF16 atomics are potentially much slower... and this is more precise!
+    __syncthreads();
+    float* scratch_dbias = scratch;
+    float* scratch_dweight = scratch + C;
+    uint* scratchFlag = (uint*)(scratch + (2 * C));
+    for(int i = threadIdx.x; i < C; i+= blockDim.x) {
+        atomicAdd(&scratch_dbias[i], dbias_shared[i]);
+        atomicAdd(&scratch_dweight[i], dweight_shared[i]);
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        *tmp_flag = atomicAdd(scratchFlag, 1);
+    }
+    __syncthreads();
+    if (*tmp_flag == gridDim.x-1) {
+        for(int i = threadIdx.x; i < C; i+= blockDim.x) {
+            // todo - potentially do stochastic rounding here as well
+            dbias[i] = (Tparams)scratch_dbias[i];
+            dweight[i] = (Tparams)scratch_dweight[i];
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -239,32 +666,90 @@ void layernorm_backward1(float* dinp, float* dweight, float* dbias,
     layernorm_backward_kernel1<<<grid_size, block_size>>>(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C);
 }
 
-void layernorm_backward2(float* dinp, float* dweight, float* dbias,
-                        const float* dout, const float* inp, const float* weight, const float* mean, const float* rstd,
-                        int B, int T, int C, const int block_size) {
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+void layernorm_backward2(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C, int block_size) {
     const int N = B * T;
     const int grid_size = ceil_div(32*N, block_size);
     size_t shared_mem_size = 2 * C * sizeof(float);
     layernorm_backward_kernel2<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C);
 }
 
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+void layernorm_backward3(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C, int block_size) {
+    const int grid_size = (1024/block_size) * cuda_num_SMs;
+    size_t shared_mem_size = 2 * C * sizeof(float);
+    layernorm_backward_kernel3<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C);
+}
+
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+void layernorm_backward4(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C, int block_size) {
+        const int grid_size = (1024/block_size) * cuda_num_SMs;
+        size_t shared_mem_size = 2 * C * sizeof(float);
+        layernorm_backward_kernel4<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C);
+}
+
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+void layernorm_backward5(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C, int block_size) {
+        const int grid_size = 1 * cuda_num_SMs; // only support 1 block per SM for simplicity, 1024 threads is best anyway
+        size_t shared_mem_size = (2 * C + 1) * sizeof(float);
+        cudaMemset(scratch, 0, (grid_size * 2 * C + 1) * sizeof(float));
+        layernorm_backward_kernel5<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, scratch, dout, inp, weight, mean, rstd, B, T, C);
+}
+
+template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
+void layernorm_backward6(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
+                        const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
+                        int B, int T, int C, int block_size) {
+        const int grid_size = (1024/block_size) * cuda_num_SMs;
+        size_t shared_mem_size = (2 * C + 1) * sizeof(float);
+
+        // Including this as part of the timing until we can parallelise it
+        // It should fully hide the cost and improve kernel perf by >5% if done in parallel using CUDA streams
+        cudaMemset(scratch, 0, (1 + 2 * C) * sizeof(float));
+
+        layernorm_backward_kernel6<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, scratch, dout, inp, weight, mean, rstd, B, T, C);
+}
+
 // kernel version dispatch
 void layernorm_backward(int kernel_num,
-                        float* dinp, float* dweight, float* dbias,
-                        const float* dout, const float* inp, const float* weight, const float* mean, const float* rstd,
+                        floatX* dinp, floatX* dweight, floatX* dbias, float* scratch,
+                        const floatX* dout, const floatX* inp, const floatX* weight, const floatX* mean, const floatX* rstd,
                         int B, int T, int C,
                         const int block_size) {
     switch (kernel_num) {
+#if !defined(ENABLE_BF16) && !defined(ENABLE_FP16)
         case 1:
             layernorm_backward1(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
             break;
+#endif
         case 2:
             layernorm_backward2(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
+            break;
+        case 3:
+            layernorm_backward3(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
+            break;
+        case 4:
+            layernorm_backward4(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
+            break;
+        case 5:
+            layernorm_backward5(dinp, dweight, dbias, scratch, dout, inp, weight, mean, rstd, B, T, C, block_size);
+            break;
+        case 6:
+            layernorm_backward6(dinp, dweight, dbias, scratch, dout, inp, weight, mean, rstd, B, T, C, block_size);
             break;
     default:
             printf("Invalid kernel number\n");
             exit(1);
     }
+    cudaCheck(cudaGetLastError());
 }
 
 // ----------------------------------------------------------------------------
@@ -278,6 +763,9 @@ int main(int argc, char **argv) {
 
     int deviceIdx = 0;
     cudaCheck(cudaSetDevice(deviceIdx));
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, deviceIdx);
+    cuda_num_SMs = deviceProp.multiProcessorCount;
 
     // first do the forward pass in CPU
     float* out = (float*)malloc(B * T * C * sizeof(float));
@@ -295,6 +783,25 @@ int main(int argc, char **argv) {
     float *dbias = make_zeros_float(C);
     layernorm_backward_cpu(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C);
 
+    // convert all the necessary cpu data to floatX (e.g. bfloat16)
+    floatX* meanX = (floatX*)malloc(B * T * sizeof(floatX));
+    floatX* rstdX = (floatX*)malloc(B * T * sizeof(floatX));
+    floatX* doutX = (floatX*)malloc(B * T * C * sizeof(floatX));
+    floatX* inpX = (floatX*)malloc(B * T * C * sizeof(floatX));
+    floatX* weightX = (floatX*)malloc(C * sizeof(floatX));
+
+    for (int i = 0; i < B * T; i++) {
+        meanX[i] = (floatX)mean[i];
+        rstdX[i] = (floatX)rstd[i];
+    }
+    for (int i = 0; i < B * T * C; i++) {
+        doutX[i] = (floatX)dout[i];
+        inpX[i] = (floatX)inp[i];
+    }
+    for (int i = 0; i < C; i++) {
+        weightX[i] = (floatX)weight[i];
+    }
+
     // the above calculations act as the reference
     // now let's do the same on the GPU
 
@@ -306,45 +813,49 @@ int main(int argc, char **argv) {
     printf("Using kernel %d\n", kernel_num);
 
     // move all the variables we need for backward pass onto the GPU
-    float* d_dinp;
-    float* d_dweight;
-    float* d_dbias;
-    float* d_dout;
-    float* d_inp;
-    float* d_weight;
-    float* d_mean;
-    float* d_rstd;
-    cudaCheck(cudaMalloc(&d_dinp, B * T * C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_dweight, C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_dbias, C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_dout, B * T * C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_inp, B * T * C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_weight, C * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_mean, B * T * sizeof(float)));
-    cudaCheck(cudaMalloc(&d_rstd, B * T * sizeof(float)));
+    floatX* d_dinp;
+    floatX* d_dweight;
+    floatX* d_dbias;
+    floatX* d_dout;
+    floatX* d_inp;
+    floatX* d_weight;
+    floatX* d_mean;
+    floatX* d_rstd;
+    float* d_scratch;
+    cudaCheck(cudaMalloc(&d_dinp, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_dweight, C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_dbias, C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_dout, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_inp, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_weight, C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_mean, B * T * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_rstd, B * T * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_scratch, cuda_num_SMs * (2 * C + 1) * sizeof(float)));
     // copy over the "inputs" to the backward call
-    cudaCheck(cudaMemcpy(d_dout, dout, B * T * C * sizeof(float), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(d_inp, inp, B * T * C * sizeof(float), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(d_weight, weight, C * sizeof(float), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(d_mean, mean, B * T * sizeof(float), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(d_rstd, rstd, B * T * sizeof(float), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_dout, doutX, B * T * C * sizeof(floatX), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_inp, inpX, B * T * C * sizeof(floatX), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_weight, weightX, C * sizeof(floatX), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_mean, meanX, B * T * sizeof(floatX), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(d_rstd, rstdX, B * T * sizeof(floatX), cudaMemcpyHostToDevice));
     // init the "outputs" of the backward call to zeros
-    cudaCheck(cudaMemset(d_dinp, 0, B * T * C * sizeof(float)));
-    cudaCheck(cudaMemset(d_dweight, 0, C * sizeof(float)));
-    cudaCheck(cudaMemset(d_dbias, 0, C * sizeof(float)));
+    cudaCheck(cudaMemset(d_dinp, 0, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMemset(d_dweight, 0, C * sizeof(floatX)));
+    cudaCheck(cudaMemset(d_dbias, 0, C * sizeof(floatX)));
 
     // launch the kernel
     const int block_size = 256;
-    layernorm_backward(kernel_num, d_dinp, d_dweight, d_dbias, d_dout, d_inp, d_weight, d_mean, d_rstd, B, T, C, block_size);
+    layernorm_backward(kernel_num, d_dinp, d_dweight, d_dbias, d_scratch, d_dout, d_inp, d_weight, d_mean, d_rstd, B, T, C, block_size);
 
     // check the correctness of the kernel
+    float error_threshold_dinp = sizeof(floatX) == 4 ? 1e-3f : 1e-1f; // allow larger errors for BF16/FP16
+    float error_threshold_dparams = sizeof(floatX) == 4 ? 1e-3f : 20.0f; // much, much larger...
     printf("Checking correctness...\n");
     printf("dinp:\n");
-    validate_result(d_dinp, dinp, "dinp", B * T * C, 1e-3f);
+    validate_result(d_dinp, dinp, "dinp", B * T * C, error_threshold_dinp);
     printf("dweight:\n");
-    validate_result(d_dweight, dweight, "dweight", C, 1e-3f);
+    validate_result(d_dweight, dweight, "dweight", C, error_threshold_dparams);
     printf("dbias:\n");
-    validate_result(d_dbias, dbias, "dbias", C, 1e-3f);
+    validate_result(d_dbias, dbias, "dbias", C, error_threshold_dparams);
 
     // now time the kernel
     int block_sizes[] = {32, 64, 128, 256, 512, 1024};
@@ -352,7 +863,7 @@ int main(int argc, char **argv) {
         int block_size = block_sizes[j];
         int repeat_times = 100;
         float elapsed_time = benchmark_kernel(repeat_times, layernorm_backward, kernel_num,
-                                              d_dinp, d_dweight, d_dbias, d_dout, d_inp, d_weight, d_mean, d_rstd,
+                                              d_dinp, d_dweight, d_dbias, d_scratch, d_dout, d_inp, d_weight, d_mean, d_rstd,
                                               B, T, C, block_size);
         printf("block_size %4d time %.4f ms\n", block_size, elapsed_time);
     }
@@ -368,6 +879,11 @@ int main(int argc, char **argv) {
     free(dinp);
     free(dweight);
     free(dbias);
+    free(meanX);
+    free(rstdX);
+    free(doutX);
+    free(inpX);
+    free(weightX);
     cudaCheck(cudaFree(d_dinp));
     cudaCheck(cudaFree(d_dweight));
     cudaCheck(cudaFree(d_dbias));
@@ -376,6 +892,6 @@ int main(int argc, char **argv) {
     cudaCheck(cudaFree(d_weight));
     cudaCheck(cudaFree(d_mean));
     cudaCheck(cudaFree(d_rstd));
-
+    cudaCheck(cudaFree(d_scratch));
     return 0;
 }

--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -736,9 +736,11 @@ void layernorm_backward(int kernel_num,
         case 3:
             layernorm_backward3(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
             break;
+#if defined(ENABLE_BF16)
         case 4:
             layernorm_backward4(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, block_size);
             break;
+#endif
         case 5:
             layernorm_backward5(dinp, dweight, dbias, scratch, dout, inp, weight, mean, rstd, B, T, C, block_size);
             break;

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -31,6 +31,9 @@ int main(int argc, char *argv[]) {
     cudaCheck(cudaSetDevice(deviceIdx));
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, deviceIdx);
+    cuda_num_SMs = deviceProp.multiProcessorCount;
+    cuda_arch_major = deviceProp.major;
+    cuda_arch_minor = deviceProp.minor;
     printf("[System]\n");
     printf("Device %d: %s\n", deviceIdx, deviceProp.name);
 
@@ -38,7 +41,7 @@ int main(int argc, char *argv[]) {
     cublasCheck(cublasCreate(&cublas_handle));
     cublasCheck(cublasLtCreate(&cublaslt_handle));
     // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
-    int enable_tf32 = deviceProp.major >= 8 ? 1 : 0;
+    int enable_tf32 = cuda_arch_major >= 8 ? 1 : 0;
     enable_tf32 = 0; // NOTE: disable TF32 for testing!!!
     printf("enable_tf32: %d\n", enable_tf32);
     cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1510,9 +1510,9 @@ void gpt2_build_from_checkpoint(GPT2 *model, const char* checkpoint_path) {
     freadCheck(model_header, sizeof(int), 256, model_file);
     if (model_header[0] != 20240326) { printf("Bad magic model file\n"); exit(EXIT_FAILURE); }
     int version = model_header[1];
-    if (!(version == 3 || version == 4)) {
+    if (!(version == 3 || version == 5)) {
         // 3 = fp32, padded vocab
-        // 4 = bf16, padded vocab
+        // 5 = bf16, padded vocab, layernorms also in bf16
         fprintf(stderr, "Bad version in model file\n");
         fprintf(stderr, "---> HINT: try to re-run `python train_gpt2.py`\n");
         exit(EXIT_FAILURE);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -57,13 +57,13 @@ mpirun -np 4 ./train_gpt2cu -b 8 -v 200 -s 200 -i data/TinyStories
 // use bf16 (bfloat 16)
 #if defined(ENABLE_BF16)
 typedef __nv_bfloat16 floatX;
-typedef float floatN;
+typedef __nv_bfloat16 floatN;
 #define CUBLAS_LOWP CUDA_R_16BF
 #define CUBLAS_LOWP_COMPUTE CUBLAS_COMPUTE_32F
 
 #ifdef MULTI_GPU
 const ncclDataType_t ncclFloatX = ncclBfloat16;
-const ncclDataType_t ncclFloatN = ncclFloat;
+const ncclDataType_t ncclFloatN = ncclBfloat16;
 #endif
 
 // use fp16 (note: this may require gradient scaler, currently not implemented!)

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -270,9 +270,9 @@ def write_tensors_bf16(model_tensors, L, file):
     write_bf16(model_tensors["transformer.wte.weight"], file) # (V, C)
     write_bf16(model_tensors["transformer.wpe.weight"], file) # (T, C)
     for i in range(L): # (L, C)
-        write_fp32(model_tensors[f"transformer.h.{i}.ln_1.weight"], file)
+        write_bf16(model_tensors[f"transformer.h.{i}.ln_1.weight"], file)
     for i in range(L): # (L, C)
-        write_fp32(model_tensors[f"transformer.h.{i}.ln_1.bias"], file)
+        write_bf16(model_tensors[f"transformer.h.{i}.ln_1.bias"], file)
     for i in range(L): # (L, 3C, C)
         write_bf16(model_tensors[f"transformer.h.{i}.attn.c_attn.weight"], file)
     for i in range(L): # (L, 3C)
@@ -282,9 +282,9 @@ def write_tensors_bf16(model_tensors, L, file):
     for i in range(L): # (L, C)
         write_bf16(model_tensors[f"transformer.h.{i}.attn.c_proj.bias"], file)
     for i in range(L): # (L, C)
-        write_fp32(model_tensors[f"transformer.h.{i}.ln_2.weight"], file)
+        write_bf16(model_tensors[f"transformer.h.{i}.ln_2.weight"], file)
     for i in range(L): # (L, C)
-        write_fp32(model_tensors[f"transformer.h.{i}.ln_2.bias"], file)
+        write_bf16(model_tensors[f"transformer.h.{i}.ln_2.bias"], file)
     for i in range(L): # (L, 4C, C)
         write_bf16(model_tensors[f"transformer.h.{i}.mlp.c_fc.weight"], file)
     for i in range(L): # (L, 4C)
@@ -293,8 +293,8 @@ def write_tensors_bf16(model_tensors, L, file):
         write_bf16(model_tensors[f"transformer.h.{i}.mlp.c_proj.weight"], file)
     for i in range(L): # (L, C)
         write_bf16(model_tensors[f"transformer.h.{i}.mlp.c_proj.bias"], file)
-    write_fp32(model_tensors["transformer.ln_f.weight"], file) # (C, )
-    write_fp32(model_tensors["transformer.ln_f.bias"], file) # (C, )
+    write_bf16(model_tensors["transformer.ln_f.weight"], file) # (C, )
+    write_bf16(model_tensors["transformer.ln_f.bias"], file) # (C, )
 
 @torch.no_grad()
 def pad_vocab(tensor, multiple=128, value=0):
@@ -323,7 +323,7 @@ def write_model(model, filename, dtype):
     assert dtype in {"float32", "bfloat16"} # float16 todo maybe later
     version = {
         "float32": 3,
-        "bfloat16": 4,
+        "bfloat16": 5,
     }[dtype]
     header = torch.zeros(256, dtype=torch.int32)
     header[0] = 20240326 # magic


### PR DESCRIPTION
I added 4 different new versions of layernorm_backward_kernel, performance is best for:

- Kernel 4 (using atomicCAS, no scratch, but rounding many times so probably worse numerical accuracy
- Kernel 6 ==> new default (FP32 scratchpad, do one final rounding to BF16 at the end, could be made stochastic in the future).

We probably just want to integrate Kernel 6 but might want to add all of them to /dev/cuda/ in the future. I haven't fixed the BF16 atomics in encoder_backward yet but the performance penalty of that is much much smaller, it might be worth doing it manually using atomicCAS so we can implement stochastic rounding there as well though.

Performance on my RTX 4090 is a tiny bit faster (potentially noise) than with the previous mixed FP32/BF16.