### PR TITLE
float4 with better vectorization for encoder_forward.cu

### DIFF
--- a/dev/cuda/encoder_forward.cu
+++ b/dev/cuda/encoder_forward.cu
@@ -89,14 +89,6 @@ __device__ inline float4 operator+(const float4& a, const float4& b) {
     return make_float4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
 }
 
-__device__ inline float& vec_at(float4& vec, int index) {
-    return reinterpret_cast<float*>(&vec)[index];
-}
-
-__device__ inline float vec_at(const float4& vec, int index) {
-    return reinterpret_cast<const float*>(&vec)[index];
-}
-
 __global__ void encoder_forward_kernel3(float4* out,
                                const int* inp, const float4* wte, const float4* wpe,
                                int B, int T, int C) {
@@ -111,19 +103,10 @@ __global__ void encoder_forward_kernel3(float4* out,
         int c4 = idx % C4;
 
         int ix = inp[b * T + t];
-
-        // float4* out_btc4 = out + b * T * C4 + t * C4 + c4;
-        // const float4* wte_ix4 = wte + ix * C4 + c4;
-        // const float4* wpe_tc4 = wpe + t * C4 + c4;
-        // for (int i = 0; i < 4; i++) {
-        //     vec_at(*out_btc4, i) = vec_at(*wte_ix4, i) + vec_at(*wpe_tc4, i);
-        // }
-        //*out_btc4 = *wte_ix4 + *wpe_tc4;
+        
         out[b * T * C4 + t * C4 + c4] = wte[ix * C4 + c4] + wpe[t * C4 + c4];
     }
 }
-
-
 
 // ----------------------------------------------------------------------------
 // kernel launcher
@@ -154,7 +137,7 @@ void encoder_forward3(float* out,
                      const int block_size) {
     assert(C % 4 == 0);
     const int N = B * T * C;
-    const int grid_size = ceil_div(N, block_size);
+    const int grid_size = ceil_div(N / 4, block_size);
     encoder_forward_kernel3<<<grid_size, block_size>>>((float4*) out, inp, (float4*) wte, (float4*) wpe, B, T, C);
     cudaCheck(cudaGetLastError());
 }

--- a/dev/cuda/encoder_forward.cu
+++ b/dev/cuda/encoder_forward.cu
@@ -83,8 +83,6 @@ __global__ void encoder_forward_kernel2(float* out,
 }
 
 // use float4 for memory coalescing
-// optimized implementation: parallelize over all of B,T,C
-
 __device__ inline float4 operator+(const float4& a, const float4& b) {
     return make_float4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
 }
@@ -103,7 +101,7 @@ __global__ void encoder_forward_kernel3(float4* out,
         int c4 = idx % C4;
 
         int ix = inp[b * T + t];
-        
+
         out[b * T * C4 + t * C4 + c4] = wte[ix * C4 + c4] + wpe[t * C4 + c4];
     }
 }


### PR DESCRIPTION
On RTX 3070
Kernel 2
```
block_size   32 | time 0.2933 ms | bandwidth 343.26 GB/s
block_size   64 | time 0.2099 ms | bandwidth 479.50 GB/s
block_size  128 | time 0.1924 ms | bandwidth 523.24 GB/s
block_size  256 | time 0.1979 ms | bandwidth 508.77 GB/s
block_size  512 | time 0.1947 ms | bandwidth 516.96 GB/s
block_size 1024 | time 0.2276 ms | bandwidth 442.33 GB/s
```

Kernel 3 runtime is more stable across different blocksize and is faster in terms of the best execution time.
```
block_size   32 | time 0.1902 ms | bandwidth 529.21 GB/s
block_size   64 | time 0.1908 ms | bandwidth 527.52 GB/s
block_size  128 | time 0.1919 ms | bandwidth 524.55 GB/s
block_size  256 | time 0.1916 ms | bandwidth 525.45 GB/s
block_size  512 | time 0.1923 ms | bandwidth 523.43 GB/s
block_size 1024 | time 0.1896 ms | bandwidth 530.82 GB/s
```
