### PR TITLE
Adding WikiText-103 dataset preprocessing and tokenization

### DIFF
--- a/prepro_wikitext-103.py
+++ b/prepro_wikitext-103.py
@@ -1,0 +1,123 @@
+"""
+Downloads and tokenizes the WikiText-103 dataset.
+- The download is from "https://wikitext.smerity.com/wikitext-103-raw-v1.zip"
+ following https://github.com/tysam-code/hlb-gpt/tree/main
+- The tokenization is GPT-2 tokenizer with tiktoken
+
+The output is written to a newly created data/ folder.
+The script prints:
+
+Saved 241185 tokens to data/wikitext-103_val.bin
+Saved 114933466 tokens to data/wikitext-103_train.bin
+
+And runs in 3-4 minutes (~1.5 minutes to download data 
++ ~2 minutes to preprocess) depending on your internet
+connection and computer. The .bin files are raw byte
+streams of int32 numbers indicating the token ids.
+"""
+
+import os
+import re
+import requests
+from tqdm import tqdm
+
+import tiktoken
+import numpy as np
+
+DATA_CACHE_DIR = "data"
+enc = tiktoken.get_encoding("gpt2")
+encode = lambda s: enc.encode(s, allowed_special={'<|endoftext|>'})
+
+def download_file(url: str, fname: str, chunk_size=1024):
+    """Helper function to download a file from a given url"""
+    resp = requests.get(url, stream=True)
+    total = int(resp.headers.get("content-length", 0))
+    with open(fname, "wb") as file, tqdm(
+        desc=fname,
+        total=total,
+        unit="iB",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
+        for data in resp.iter_content(chunk_size=chunk_size):
+            size = file.write(data)
+            bar.update(size)
+
+def download():
+    """Downloads the WikiText-103 dataset to DATA_CACHE_DIR"""
+    os.makedirs(DATA_CACHE_DIR, exist_ok=True)
+
+    # download the WikiText-103 dataset, unless it's already downloaded
+    data_url = "https://wikitext.smerity.com/wikitext-103-raw-v1.zip"
+    data_filename = os.path.join(DATA_CACHE_DIR, "WikiText-103.zip")
+    if not os.path.exists(data_filename):
+        print(f"Downloading {data_url} to {data_filename}...")
+        download_file(data_url, data_filename)
+    else:
+        print(f"{data_filename} already exists, skipping download...")
+
+    # unzip the file
+    data_dir = os.path.join(DATA_CACHE_DIR, "wikitext-103")
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir, exist_ok=True)
+        print(f"Unzipping {data_filename}...")
+        os.system(f"unzip {data_filename} -d {data_dir}")
+    else:
+        print(f"{data_dir} already exists, skipping unzipping...")
+
+def tokenize():
+    # special token
+    eot = enc._special_tokens['<|endoftext|>']
+
+    # fetch training text
+    train_data_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103/wikitext-103-raw/wiki.train.raw")
+    train_text = open(train_data_filename, 'r').read()
+
+    # cleanup the training text
+    train_text = train_text.strip() # remove leading and trailing whitespace
+    train_text = train_text.replace(" \n \n ", '\n<|endoftext|>') # injecting special token in between sections
+    train_text = "<|endoftext|>" + train_text # adding special token at start
+    train_split = train_text.split("<|endoftext|>") # splitting the text by special token to remove the extraneous headers/titles
+
+    # remove the awkward headers/titles that came from the original parquet format
+    for i in reversed(range(len(train_split))):
+        # if the chunk is of the form of the headers/titles we will pop this chunk out
+        if bool(re.match(r"^\s*= +(.{1,}) +=\s*$", train_split[i])):
+            train_split.pop(i)
+    
+    # now join the remaining chunks via eot
+    train_text = "<|endoftext|>".join(train_split[i] for i in range(len(train_split)))
+    train_tokens = encode(train_text)
+    train_tokens_np = np.array(train_tokens, dtype = np.int32)
+
+    # now repeat same cleanup process but for validation text
+    val_data_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103/wikitext-103-raw/wiki.valid.raw")
+    val_text = open(val_data_filename, 'r').read()
+
+    val_text = val_text.strip() 
+    val_text = val_text.replace(" \n \n ", '\n<|endoftext|>')
+    val_text = "<|endoftext|>" + val_text
+    val_split = val_text.split("<|endoftext|>")
+
+    for i in reversed(range(len(val_split))):
+        if bool(re.match(r"^\s*= +(.{1,}) +=\s*$", val_split[i])):
+            val_split.pop(i)
+
+    val_text = "<|endoftext|>".join(val_split[i] for i in range(len(val_split)))
+    val_tokens = encode(val_text)
+    val_tokens_np = np.array(val_tokens, dtype = np.int32)
+
+    # now just dump the encoded tokens into binary files
+    train_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103_train.bin")
+    val_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103_val.bin")
+    with open(train_filename, "wb") as f:
+       f.write(train_tokens_np.tobytes())
+    with open(val_filename, "wb") as f:
+        f.write(val_tokens_np.tobytes())
+    
+    print(f"Saved {len(val_tokens_np)} tokens to {val_filename}")
+    print(f"Saved {len(train_tokens_np)} tokens to {train_filename}")
+
+if __name__ == "__main__":
+    download()
+    tokenize()


### PR DESCRIPTION
This PR enables the preprocessing and tokenization of the WikiText-103 dataset in response to  #246.

A few notes I would like to make on my preprocessing of the text:
- I considered two ways of downloading the dataset
  1. The dataset can be found on hugging face at [https://huggingface.co/datasets/wikitext](url) where going into the 
```wikitext-103-raw-v1``` folder shows 4 different parquet files (2 for training, 1 for test, 1 for val). I initially attempted to use this method to download the dataset but I quickly ran into trouble realizing that unless I used pandas, an extra dependency, this would look very messy (please correct me if I am wrong about this I am kinda new to this stuff so maybe there is actually a way to handle parquet files smoothly without pandas). Because of this I opted for the other option.
  2. As [https://github.com/tysam-code/hlb-gpt/tree/main](url) was mentioned, you can use the same download link used in this code which gives you a zipped folder containing three files of raw text (wiki.train.raw, wiki.val.raw, wiki.test.raw). I am not entirely sure but I got the impression that the text in these files was some sort of translation from the original parquet files from the hugging face version because there were these weird headers/titles that were enclosed in like "=" on both sides. I thought that this download option would be the best choice because it would go smoother based on my knowledge.

- To deal with the awkward headers/titles, I made the effort of removing these and leaving just the paragraphs of text/descriptions and separating what would have been paragraphs for a given topic into their own sections with the use of <|endoftext|>. I believe my code takes care of most, if not all, of these headers so that the model can just focus on the text itself and not be possibly confused by the unusual headers that would have had to be encapsulated in <|endoftext|> tokens anyways leaving the model in a position of uncertainty of whether the text to follow after an <|endoftext|> is a header or an actual paragraph. But now that I am writing this I realize that this actually is not that big of a problem because of it decides to do a header then it will follow with the paragraph anyways so I am now thinking that making this effort is pointless. I will just leave it as is in case you don't care although I am pretty sure you would probably prefer to just do simpler preprocessing so that benchmarking is more standardized. In that case, please let me know and I can fix it.

- There are possibly better ways of doing this than the way that I did it. If there are, please let me know, and again I can fix it.

That pretty much sums it up. On a rough skim, ```train_gpt2.cu``` looked like it could already handle using this dataset right away just by using the i flag and typing ```data/wikitext-103``` but I may have missed something. I thought before diving too deep into other parts that I would at least just get this code for the dataset in.