### PR TITLE
grid-stride loop for residual_forward.cu

### DIFF
--- a/dev/cuda/residual_forward.cu
+++ b/dev/cuda/residual_forward.cu
@@ -33,7 +33,7 @@ __global__ void residual_forward_kernel1(float* out, const float* inp1, const fl
     }
 }
 
-// loop unrolling
+// grid-stride loop
 __global__ void residual_forward_kernel2(float* out, const float* inp1, const float* inp2, int N) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     for (int i = idx; i < N; i += blockDim.x * gridDim.x) {


### PR DESCRIPTION
Tried float4 vectorization, which does not improve the performance.

Grid-stride loop (with grid_size = ceil_div(N / 2, block_size) or grid_size = ceil_div(N / 4, block_size) on 3070) does help a bit.

On 3070
kernel 1
```
block_size   32 | time 0.2750 ms | bandwidth 274.56 GB/s
block_size   64 | time 0.1879 ms | bandwidth 401.74 GB/s      <<<
block_size  128 | time 0.1925 ms | bandwidth 392.10 GB/s
block_size  256 | time 0.1912 ms | bandwidth 394.87 GB/s
block_size  512 | time 0.1911 ms | bandwidth 395.04 GB/s
block_size 1024 | time 0.1905 ms | bandwidth 396.25 GB/s
```
kernel 2
```
block_size   32 | time 0.2044 ms | bandwidth 369.45 GB/s
block_size   64 | time 0.1912 ms | bandwidth 394.85 GB/s
block_size  128 | time 0.1920 ms | bandwidth 393.29 GB/s
block_size  256 | time 0.1931 ms | bandwidth 391.01 GB/s
block_size  512 | time 0.1914 ms | bandwidth 394.37 GB/s
block_size 1024 | time 0.1876 ms | bandwidth 402.35 GB/s      <<<
```
