### PR TITLE
Flashattention

### DIFF
--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -24,9 +24,8 @@ version 4 is a further optimized kernel that fuses the scale operation,
 uses a directly autoregressive softmax, and uses the online softmax algorithm.
 ./attention_forward 4
 
-version 6 is a flashattention kernel in pure cuda C fusing all operations and seperating computation 
-across tiles and computation is threadcoarsened. This is much faster then version 2 and 
-slightly slower than version 3 and 4 but uses much less memory.
+version 6 is a flashattention kernel in pure CUDA + C that try to fuse all operations and 
+distribute computations across tiles as well as applying thread coarsening.
 ./attention_forward 6
 */
 
@@ -877,8 +876,8 @@ void attention_forward5(float* out, float* preatt, float* att,
 }
 
 __global__ void flashattention(float *out, float *K, float *Q, float* V, float scaling, int T_r, int T_c, int seq_len)
-{   
-    // define constants
+{   // used by attention_forward6
+    // define constants, could be adjusted for different hardware specs
     const int d = 64;
     const int B_c = 32;
     const int B_r = 32;
@@ -888,15 +887,15 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
     const int batch_offset = d * seq_len * blockIdx.x;
     const int TN = 4;
     const int TM = 4;
-    const int num_tiles = d/32; // d/BK;
+    const int num_tiles = d/32; // or d/BK, number of tiles that the attention computation is split into
     /*
-    all are fully loaded into shared memory SMEM, I think we should adjust this as second step to only loading it in tiles of B_r x 32 
+    NOTE: all are fully loaded into shared memory SMEM, I think we should adjust this as second step to only loading it in tiles of B_r x 32 
     and iterating the mults over the 32 sized tiles this way we can have a larger d, while keeping occupancy high
     */
-    // define static smem such that i can still adress it with indices
     int tid_x = threadIdx.x;
     int tid_y = threadIdx.y;
 
+    // statically define in SMEM and still address it with indices
     //__shared__ float Q_i[B_r][d]; // uncomment only if you want to cache over full d (if CACHE_Q = 1)
     __shared__ float Q_i[B_r][BK]; // if you want to save SMEM loads and keep the full Q loaded then change this to [B_r][d]
     
@@ -908,25 +907,23 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
     
     const uint totalResultsBlocktile = B_r * B_c; // number of results to calculate per block
     const uint numThreadsBlocktile = totalResultsBlocktile / (TM * TN); // number of threads needed
-    const int threadId_flat = threadIdx.y * blockDim.x + threadIdx.x; // flattened thread id  (used for loading tiles coalesced)
+    const int threadId_flat = threadIdx.y * blockDim.x + threadIdx.x; // flattened thread id  (used for coalesced loading of tiles)
 
-    // each thread process 1 block at position:
+    // each thread process one block at position:
     const int threadCol = threadId_flat % (B_c / TN);
     const int threadRow = threadId_flat / (B_c / TN);
-
-    //const int num_tiles = d/BK; // how many tiles are the computationof the attention is split into
-    
-    float l_i[TM]= {0.0};; // storing the intermediate sum of exp per row
-    float m_i[TM]; // storing the intermediate max of the rows
-    float last_m[TM]; // storing the last max of the rows
+        
+    float l_i[TM]= {0.0};; // storing the intermediate sum of exponentials per row
+    float m_i[TM]; // storing the intermediate max value of the rows
+    float last_m[TM]; // storing the last max value of the rows
     float O_i[num_tiles * TN * TM] = {0.0}; // storing the intermediate results of the Outputs (each thread stores a chunk TM x TN per tile)
     
-    // rset to min
+    // reset to min
     for (int ii = 0; ii < TM; ii++) {
         m_i[ii] = -INFINITY;
     }
 
-    //WARNING due to coalsecing I should probably add a second set of variables for using BK+1
+    //WARNING: due to coalsecing I should probably add a second set of variables for using BK+1
     const uint strideK = numThreadsBlocktile / BK; // 64 / 64 = 1
     const uint innerRowK = threadId_flat / BK; // 0-63 / 64, 0000000000000...0
     const uint innerColK = threadId_flat % BK; // 0-63 % 64, 0123456789101112...63
@@ -936,8 +933,9 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
     const uint innerRowQ = threadId_flat / d; // 0-63 / 64, 0000000000000...0
     const uint innerColQ = threadId_flat % d; // 0-63 % 64, 0123456789012...63
     const uint nr_loads = B_r * d / numThreadsBlocktile;
+
     for (int t=0; t<nr_loads; t++){
-      // need to laod block of size B_r x d (64 x 64) with numThreadsBlocktile threads
+      // need to load block of size B_r x d (64 x 64) with numThreadsBlocktile threads
       // if (blockIdx.y * B_r + innerRowQ) * d + innerColQ + t * numThreadsBlocktile / d
       id = (blockIdx.y * B_r + innerRowQ) * d + innerColQ + t * numThreadsBlocktile;
       // 4 x 4 then this is 5 thus 5/
@@ -951,127 +949,123 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
 
     __syncthreads();
 
-    // scratchboard register for registertiling (coarsening of the matrix mults)
+    // scratchpad register for register-tiling (coarsening of the matrix mults)
     float regM[TM] = {0.0};
     float regN[TN] = {0.0};
-
-    
 
     for (int j = 0; j < T_c && j <= blockIdx.y ; j++) { // iterate of ver the chunks of K and V
         float threadResults[TM * TN] = {0.0}; // storing the intermediate outputs
         S_i[tid_y][tid_x] = 0.f;
         
         for (int t=0; t<num_tiles; t++){
-        // load K_j and V_j, thread idx, idy loads idy,idx
-        // we load a tile
-        for (int i=0; i<B_r; i+=strideK){
-            // load Q, K and V in tiles (for now we are loading the full V)
-            if (not CACHE_Q){Q_i[innerRowK+i][innerColK] = Q[batch_offset + (innerRowK + blockIdx.y * B_r) * d  + i * d + innerColK + t * B_c];
-            } // if you cache Q over whole d then remove this line
-            id = (innerRowK + j * B_c) * d + i * d + innerColK + t * B_c;
-            if (id < d*seq_len){
-            K_j[innerRowK+i][innerColK] = K[batch_offset + id];
-            V_j[innerRowK+i][innerColK+t*B_c] = V[batch_offset + id];
-            }
-            else {
-            K_j[innerRowK+i][innerColK] = 0.0;
-            V_j[innerRowK+i][innerColK+t*B_c] = 0.0;
-            }
-        
-        }
-        __syncthreads();
-        
-        for (int dd=0; dd<BK; dd++){ // load elements of Q_i and K_j^T into registers
-            for (uint i = 0; i < TM; ++i) {
-                if (CACHE_Q){
-                regM[i] = Q_i[(threadRow * TM + i)][dd+t*BK]; // uncomment if you cache Q over full d
+            // load K_j and V_j, thread idx, idy loads idy,idx
+            // we load a tile
+            for (int i=0; i<B_r; i+=strideK){
+                // load Q, K and V in tiles (for now we are loading the full V)
+                if (not CACHE_Q){Q_i[innerRowK+i][innerColK] = Q[batch_offset + (innerRowK + blockIdx.y * B_r) * d  + i * d + innerColK + t * B_c];
+                } // if you cache Q over whole d then remove this line
+                id = (innerRowK + j * B_c) * d + i * d + innerColK + t * B_c;
+                if (id < d*seq_len){
+                    K_j[innerRowK+i][innerColK] = K[batch_offset + id];
+                    V_j[innerRowK+i][innerColK+t*B_c] = V[batch_offset + id];
                 } else {
-                regM[i] = Q_i[(threadRow * TM + i)][dd];
+                    K_j[innerRowK+i][innerColK] = 0.0;
+                    V_j[innerRowK+i][innerColK+t*B_c] = 0.0;
+                }
+        
             }
+            __syncthreads();
+        
+            for (int dd=0; dd<BK; dd++){ // load elements of Q_i and K_j^T into registers
+                for (uint i = 0; i < TM; ++i) {
+                    if (CACHE_Q){
+                        regM[i] = Q_i[(threadRow * TM + i)][dd+t*BK]; // uncomment if you cache Q over full d
+                    } else {
+                        regM[i] = Q_i[(threadRow * TM + i)][dd];
+                    }
+                }
+                for (uint i = 0; i < TN; ++i) {
+                    regN[i] = K_j[threadCol * TN + i][dd];
+                }
+                for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
+                    for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
+                        threadResults[resIdxM * TN + resIdxN] += regM[resIdxM] * regN[resIdxN];
+                    }
+                }
             }
-            for (uint i = 0; i < TN; ++i) {
-            regN[i] = K_j[threadCol * TN + i][dd];
-            }
-            for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
-            for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
-                threadResults[resIdxM * TN + resIdxN] += regM[resIdxM] * regN[resIdxN];
-            }
-            }
-        }
-        __syncthreads();
+            __syncthreads();
         }
         
 
-        // store the results in S_i
+        // store the results in S_i, account for causal masking
         for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
-        for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
-            if (j*B_c + threadCol * TN + resIdxN <= blockIdx.y * B_r + threadRow * TM + resIdxM){
-            S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = threadResults[resIdxM * TN + resIdxN] *scaling;
-            }
-            else{
-            S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = -INFINITY;
-            }      
+            for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
+                if (j*B_c + threadCol * TN + resIdxN <= blockIdx.y * B_r + threadRow * TM + resIdxM){
+                    S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = threadResults[resIdxM * TN + resIdxN] *scaling;
+                } else {
+                    S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = -INFINITY;
+                }      
             }
         }
         __syncthreads();
 
         for (int i=0;i<TM;++i){
-        last_m[i] = m_i[i];
-        float m = m_i[i];
-        for (int jj = 0; jj < B_c; jj += 1) {
-            if (m < S_i[threadRow*TM+i][jj]) {
-            m = S_i[threadRow*TM+i][jj];
+            last_m[i] = m_i[i];
+            float m = m_i[i];
+            for (int jj = 0; jj < B_c; jj += 1) {
+                if (m < S_i[threadRow*TM+i][jj]) {
+                    m = S_i[threadRow*TM+i][jj];
+                }
             }
+            m_i[i] = m;
         }
-        m_i[i] = m;
-        }
-
 
         // 2) renormalize current O
         if (j > 0) {
-        for (int t = 0; t < num_tiles; t++){
-        for (int i=0;i<TM;++i){
-            for (int jj=0;jj<TN;++jj){
-            O_i[t*TN*TM + i*TN + jj] *= exp(last_m[i] - m_i[i]);
+            for (int t = 0; t < num_tiles; t++){
+                for (int i=0;i<TM;++i){
+                    for (int jj=0;jj<TN;++jj){
+                        O_i[t*TN*TM + i*TN + jj] *= exp(last_m[i] - m_i[i]);
+                    }
+                }
             }
-        }
-        }
         }
 
         // 3) renormalize the sum l_i
         for (int i=0;i<TM;++i){
-        l_i[i] *= exp(last_m[i] - m_i[i]);
+            l_i[i] *= exp(last_m[i] - m_i[i]);
         }
 
-        // 4) compute \exp(Q_iK^T_{j+1} - m^{j+1}) = \exp(S_i-m^{j+1}) // TO OPTIMIZE!!
+        // 4) compute \exp(Q_iK^T_{j+1} - m^{j+1}) = \exp(S_i-m^{j+1}) // TODO: TO OPTIMIZE
         for (int dd = 0; dd < B_c; dd++) {
-        for (int ii=0;ii<TN;ii++){ // calculate new sum and load exp(Attention) weights
-            //check wether thus is in range  or not (if not we set it to 0)
-            //if (idrow+ii < seq_len && idcol+dd < seq_len){
-            regM[ii] = exp(S_i[threadRow*TM+ii][dd] - m_i[ii]);
-            l_i[ii] += regM[ii];
-        }
-        for (int t = 0; t < num_tiles; t++){
-            for (int ii=0;ii<TN;ii++){
-            for (int jj=0;jj<TM;jj++){ // calculate output elements
-                regN[jj] = V_j[dd][t * B_c + threadCol * TN + jj];
-                O_i[t*TN*TM + ii*TM + jj] += regM[ii] * regN[jj];
+            for (int ii = 0; ii < TN; ii++){ 
+                // calculate new sum and load exp(Attention) weights
+                //check whether thus is in range or not (if not we set it to 0)
+                //if (idrow+ii < seq_len && idcol+dd < seq_len){
+                regM[ii] = exp(S_i[threadRow*TM+ii][dd] - m_i[ii]);
+                l_i[ii] += regM[ii];
             }
+            for (int t = 0; t < num_tiles; t++){
+                for (int ii=0;ii<TN;ii++){
+                    for (int jj=0;jj<TM;jj++){ // calculate output elements
+                        regN[jj] = V_j[dd][t * B_c + threadCol * TN + jj];
+                        O_i[t*TN*TM + ii*TM + jj] += regM[ii] * regN[jj];
+                    }
+                }
             }
-        }
         __syncthreads();
         }
 
     }
 
-    // normalize the whole thing by the output sum and write to out
+    // normalize by the output sum and write to out matrix
     for (int t = 0; t < num_tiles; t++){
         for (int ii=0;ii<TM;ii++){
-        for (int jj=0;jj<TN;jj++){
-            if(blockIdx.y*B_r+threadRow*TM+ii < seq_len){
-            out[batch_offset + (blockIdx.y * B_r + threadRow*TM + ii) * d + t * B_c + threadCol*TN + jj] = O_i[t*TN*TM+ii*TM+jj] / l_i[ii];
+            for (int jj=0;jj<TN;jj++){
+                if(blockIdx.y*B_r+threadRow*TM+ii < seq_len){
+                    out[batch_offset + (blockIdx.y * B_r + threadRow*TM + ii) * d + t * B_c + threadCol*TN + jj] = O_i[t*TN*TM+ii*TM+jj] / l_i[ii];
+                }
             }
-        }
         } 
     }
 }
@@ -1080,32 +1074,33 @@ void attention_forward6(float* out,
                        const float* inp,
                        int B, int T, int C, int NH,
                        const int block_size) {
-    // TODO there should be no mallocs inside any of these functions!
+    // TODO: there should be no mallocs inside any of these functions!
 
     // these are hardcoded to 32 for now
     const int B_r = 32;
     const int B_c = 32;
+
     // renaming these to be consistent with the kernel
     // const int B = B;
     const int nh = NH;
     const int N = T;
     const int d = C / NH;
-    // more
     
     int TM = 4;
     int TN = 4;
 
     const float softmax_scale = 1.0 / sqrt(d);
 
-    // calculate SRAM size needed per block, ensure we have enough shared memory
+    // calculate SRAM size needed per block
     int col_tile_size = B_r * d;  // size of Kj, Vj
     int row_tile_size = B_c * d;  // size of Qi
     const int sram_size =
         (col_tile_size * sizeof(float))  // SRAM size for Vj
         + (row_tile_size * sizeof(float))  // SRAM size for Qi
         + (B_c * (B_c+1) * sizeof(float)) // SRAM size for S
-        + (B_c * (B_c+1) * sizeof(float)); // SRAM size for Kj, 
+        + (B_c * (B_c+1) * sizeof(float)); // SRAM size for Kj
 
+    // ensure we have enough shared memory
     int max_sram_size;
     cudaDeviceGetAttribute(&max_sram_size, cudaDevAttrMaxSharedMemoryPerBlock, 0);
     if (sram_size > max_sram_size) {
@@ -1115,7 +1110,7 @@ void attention_forward6(float* out,
         exit(1);
     }
 
-    // okay so now, this kernel wants Q,K,V to all be of shape (B, nh, N, d)
+    // This kernel wants Q,K,V to all be of shape (B, nh, N, d)
     // but instead, we have a single tensor QKV (inp) of shape (B, N, 3, nh, d)
     // so we have to permute the tensor using a kernel with block_size
     float *q, *k, *v;
@@ -1131,7 +1126,7 @@ void attention_forward6(float* out,
     
     permute_kernel<<<num_blocks, block_size>>>(q, k, v, inp, B, N, nh, d);
 
-    // now actually call the flash attention kernel
+    // now call the flash attention kernel
     flashattention<<<gridDim, blockDim>>>(out, k, q, v, softmax_scale, (N+B_r-1)/B_r, (N+B_c-1)/B_c, N);
     cudaDeviceSynchronize();
 
@@ -1142,6 +1137,7 @@ void attention_forward6(float* out,
     cudaDeviceSynchronize();
     cudaCheck(cudaMemcpy(out, q, B * T * C * sizeof(float), cudaMemcpyDeviceToDevice));
     cudaDeviceSynchronize();
+
     // free memory
     cudaCheck(cudaFree(q));
     cudaCheck(cudaFree(k));

--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -883,6 +883,7 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
     const int B_c = 32;
     const int B_r = 32;
     const int BK = B_c;
+    const int CACHE_Q = 0; // if 1 then cache Q in SMEM otherwise reload it over the tiles
 
     const int batch_offset = d * seq_len * blockIdx.x;
     const int TN = 4;
@@ -896,46 +897,42 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
     int tid_x = threadIdx.x;
     int tid_y = threadIdx.y;
 
-  __shared__ float Q_i[B_r][d]; // uncomment only if you want to cache over full d (if CACHE_Q = 1), also + 1 seems to help SMEM latency here too
-  //__shared__ float Q_i[B_r][BK]; // if you want to save SMEM loads and keep the full Q loaded then change this to [B_r][d]
-  __shared__ float K_j[B_c][BK+1]; // reduce SMEM bank conflicts by adding 1 column as K will be loaded transposed!
-  __shared__ float V_j[B_c][d];
-  
-  // attention result
-  __shared__ float S_i[B_r][B_c+1]; // reduce SMEM bank conflicts by adding 1 column (in the naive softmax part)
-  
-  const uint totalResultsBlocktile = B_r * B_c; // number of results to calculate per block
-  const uint numThreadsBlocktile = totalResultsBlocktile / (TM * TN); // number of threads needed
-  const int threadId_flat = threadIdx.y * blockDim.x + threadIdx.x; // flattened thread id  (used for loading tiles coalesced)
+    //__shared__ float Q_i[B_r][d]; // uncomment only if you want to cache over full d (if CACHE_Q = 1)
+    __shared__ float Q_i[B_r][BK]; // if you want to save SMEM loads and keep the full Q loaded then change this to [B_r][d]
+    
+    __shared__ float K_j[B_c][BK+1]; // reduce SMEM bank conflicts by adding 1 column as K will be loaded transposed!
+    __shared__ float V_j[B_c][d];
+    
+    // attention result
+    __shared__ float S_i[B_r][B_c+1]; // reduce SMEM bank conflicts by adding 1 column (in the naive softmax part)
+    
+    const uint totalResultsBlocktile = B_r * B_c; // number of results to calculate per block
+    const uint numThreadsBlocktile = totalResultsBlocktile / (TM * TN); // number of threads needed
+    const int threadId_flat = threadIdx.y * blockDim.x + threadIdx.x; // flattened thread id  (used for loading tiles coalesced)
 
-  // each thread process 1 block at position:
-  const int threadCol = threadId_flat % (B_c / TN); // 0-63 % 8 => 0,1,2,3,4...7,0,1,2,3,4...7,... 0,1,2,3,4...7
-  const int threadRow = threadId_flat / (B_c / TN); // 0-63 / 8 => 0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,..., 7,7,7,7,7,7,7,7
+    // each thread process 1 block at position:
+    const int threadCol = threadId_flat % (B_c / TN);
+    const int threadRow = threadId_flat / (B_c / TN);
 
-  //const int num_tiles = d/BK; // how many tiles are the computationof the attention is split into
-  
-  float l_i[TM]= {0.0};; // storing the intermediate sum of exp per row
-  float m_i[TM]; // storing the intermediate max of the rows
-  float last_m[TM]; // storing the last max of the rows
-  float O_i[num_tiles * TN * TM] = {0.0}; // storing the intermediate results of the Outputs (each thread stores a chunk TM x TN per tile)
-  
-  // rset to min
-  for (int ii = 0; ii < TM; ii++) {
-    m_i[ii] = -INFINITY;
-  }
+    //const int num_tiles = d/BK; // how many tiles are the computationof the attention is split into
+    
+    float l_i[TM]= {0.0};; // storing the intermediate sum of exp per row
+    float m_i[TM]; // storing the intermediate max of the rows
+    float last_m[TM]; // storing the last max of the rows
+    float O_i[num_tiles * TN * TM] = {0.0}; // storing the intermediate results of the Outputs (each thread stores a chunk TM x TN per tile)
+    
+    // rset to min
+    for (int ii = 0; ii < TM; ii++) {
+        m_i[ii] = -INFINITY;
+    }
 
-  //WARNING due to coalsecing I should probably add a second set of variables for using BK+1
-  const uint strideK = numThreadsBlocktile / BK; // 64 / 64 = 1
-  const uint innerRowK = threadId_flat / BK; // 0-63 / 64, 0000000000000...0
-  const uint innerColK = threadId_flat % BK; // 0-63 % 64, 0123456789101112...63
+    //WARNING due to coalsecing I should probably add a second set of variables for using BK+1
+    const uint strideK = numThreadsBlocktile / BK; // 64 / 64 = 1
+    const uint innerRowK = threadId_flat / BK; // 0-63 / 64, 0000000000000...0
+    const uint innerColK = threadId_flat % BK; // 0-63 % 64, 0123456789101112...63
 
-
-  // do if: blockIdx.y * B_r + innerRowK * TM + row < seq_len
-  // or: j * B_c + innerColK * TN + col < seq_len
-
-  int id;
-  // load Q_i, UNCOMMENT only if your Q is caching over full d
-  
+    int id;
+    // load Q_i, UNCOMMENT only if your Q is caching over full d
     const uint innerRowQ = threadId_flat / d; // 0-63 / 64, 0000000000000...0
     const uint innerColQ = threadId_flat % d; // 0-63 % 64, 0123456789012...63
     const uint nr_loads = B_r * d / numThreadsBlocktile;
@@ -952,125 +949,131 @@ __global__ void flashattention(float *out, float *K, float *Q, float* V, float s
       }
     }
 
-  __syncthreads();
+    __syncthreads();
 
-  // scratchboard register for registertiling (coarsening of the matrix mults)
-  float regM[TM] = {0.0};
-  float regN[TN] = {0.0};
+    // scratchboard register for registertiling (coarsening of the matrix mults)
+    float regM[TM] = {0.0};
+    float regN[TN] = {0.0};
 
-  for (int j = 0; j < T_c; j++) { // iterate of ver the chunks of K and V
-    float threadResults[TM * TN] = {0.0}; // storing the intermediate outputs
-    S_i[tid_y][tid_x] = 0.f;
     
-    for (int t=0; t<num_tiles; t++){
-      // load K_j and V_j, thread idx, idy loads idy,idx
-      // we load a tile
-      for (int i=0; i<B_r; i+=strideK){
-        // load Q, K and V in tiles (for now we are loading the full V)
-        // if (not CACHE_Q){Q_i[innerRowK+i][innerColK] = Q[batch_offset + (innerRowK + blockIdx.y * B_r) * d  + i * d + innerColK + t * B_c];
-        // } // if you cache Q over whole d then remove this line
-        id = (innerRowK + j * B_c) * d + i * d + innerColK + t * B_c;
-        if (id < d*seq_len){
-          K_j[innerRowK+i][innerColK] = K[batch_offset + id];
-          V_j[innerRowK+i][innerColK+t*B_c] = V[batch_offset + id];
+
+    for (int j = 0; j < T_c && j <= blockIdx.y ; j++) { // iterate of ver the chunks of K and V
+        float threadResults[TM * TN] = {0.0}; // storing the intermediate outputs
+        S_i[tid_y][tid_x] = 0.f;
+        
+        for (int t=0; t<num_tiles; t++){
+        // load K_j and V_j, thread idx, idy loads idy,idx
+        // we load a tile
+        for (int i=0; i<B_r; i+=strideK){
+            // load Q, K and V in tiles (for now we are loading the full V)
+            if (not CACHE_Q){Q_i[innerRowK+i][innerColK] = Q[batch_offset + (innerRowK + blockIdx.y * B_r) * d  + i * d + innerColK + t * B_c];
+            } // if you cache Q over whole d then remove this line
+            id = (innerRowK + j * B_c) * d + i * d + innerColK + t * B_c;
+            if (id < d*seq_len){
+            K_j[innerRowK+i][innerColK] = K[batch_offset + id];
+            V_j[innerRowK+i][innerColK+t*B_c] = V[batch_offset + id];
+            }
+            else {
+            K_j[innerRowK+i][innerColK] = 0.0;
+            V_j[innerRowK+i][innerColK+t*B_c] = 0.0;
+            }
+        
         }
-        else {
-          K_j[innerRowK+i][innerColK] = 0.0;
-          V_j[innerRowK+i][innerColK+t*B_c] = 0.0;
+        __syncthreads();
+        
+        for (int dd=0; dd<BK; dd++){ // load elements of Q_i and K_j^T into registers
+            for (uint i = 0; i < TM; ++i) {
+                if (CACHE_Q){
+                regM[i] = Q_i[(threadRow * TM + i)][dd+t*BK]; // uncomment if you cache Q over full d
+                } else {
+                regM[i] = Q_i[(threadRow * TM + i)][dd];
+            }
+            }
+            for (uint i = 0; i < TN; ++i) {
+            regN[i] = K_j[threadCol * TN + i][dd];
+            }
+            for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
+            for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
+                threadResults[resIdxM * TN + resIdxN] += regM[resIdxM] * regN[resIdxN];
+            }
+            }
         }
-       
-      }
-      __syncthreads();
-      
-      for (int dd=0; dd<BK; dd++){ // load elements of Q_i and K_j^T into registers
-        for (uint i = 0; i < TM; ++i) {
-            regM[i] = Q_i[(threadRow * TM + i)][dd+t*BK]; // uncomment if you cache Q over full d
+        __syncthreads();
         }
-        for (uint i = 0; i < TN; ++i) {
-          regN[i] = K_j[threadCol * TN + i][dd];
-        }
+        
+
+        // store the results in S_i
         for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
-          for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
-            threadResults[resIdxM * TN + resIdxN] += regM[resIdxM] * regN[resIdxN];
-          }
+        for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
+            if (j*B_c + threadCol * TN + resIdxN <= blockIdx.y * B_r + threadRow * TM + resIdxM){
+            S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = threadResults[resIdxM * TN + resIdxN] *scaling;
+            }
+            else{
+            S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = -INFINITY;
+            }      
+            }
         }
-      }
-      __syncthreads();
+        __syncthreads();
+
+        for (int i=0;i<TM;++i){
+        last_m[i] = m_i[i];
+        float m = m_i[i];
+        for (int jj = 0; jj < B_c; jj += 1) {
+            if (m < S_i[threadRow*TM+i][jj]) {
+            m = S_i[threadRow*TM+i][jj];
+            }
+        }
+        m_i[i] = m;
+        }
+
+
+        // 2) renormalize current O
+        if (j > 0) {
+        for (int t = 0; t < num_tiles; t++){
+        for (int i=0;i<TM;++i){
+            for (int jj=0;jj<TN;++jj){
+            O_i[t*TN*TM + i*TN + jj] *= exp(last_m[i] - m_i[i]);
+            }
+        }
+        }
+        }
+
+        // 3) renormalize the sum l_i
+        for (int i=0;i<TM;++i){
+        l_i[i] *= exp(last_m[i] - m_i[i]);
+        }
+
+        // 4) compute \exp(Q_iK^T_{j+1} - m^{j+1}) = \exp(S_i-m^{j+1}) // TO OPTIMIZE!!
+        for (int dd = 0; dd < B_c; dd++) {
+        for (int ii=0;ii<TN;ii++){ // calculate new sum and load exp(Attention) weights
+            //check wether thus is in range  or not (if not we set it to 0)
+            //if (idrow+ii < seq_len && idcol+dd < seq_len){
+            regM[ii] = exp(S_i[threadRow*TM+ii][dd] - m_i[ii]);
+            l_i[ii] += regM[ii];
+        }
+        for (int t = 0; t < num_tiles; t++){
+            for (int ii=0;ii<TN;ii++){
+            for (int jj=0;jj<TM;jj++){ // calculate output elements
+                regN[jj] = V_j[dd][t * B_c + threadCol * TN + jj];
+                O_i[t*TN*TM + ii*TM + jj] += regM[ii] * regN[jj];
+            }
+            }
+        }
+        __syncthreads();
+        }
+
     }
-    
 
-    // store the results in S_i
-    for (uint resIdxM = 0; resIdxM < TM; ++resIdxM) {
-      for (uint resIdxN = 0; resIdxN < TN; ++resIdxN) {
-        if (j*B_c + threadCol * TN + resIdxN <= blockIdx.y * B_r + threadRow * TM + resIdxM){
-          S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = threadResults[resIdxM * TN + resIdxN] *scaling;
-        }
-        else{
-          S_i[(threadRow * TM + resIdxM)][threadCol * TN + resIdxN] = -INFINITY;
-        }      
-        }
-    }
-    __syncthreads();
-
-    for (int i=0;i<TM;++i){
-      last_m[i] = m_i[i];
-      float m = m_i[i];
-      for (int jj = 0; jj < B_c; jj += 1) {
-        if (m < S_i[threadRow*TM+i][jj]) {
-          m = S_i[threadRow*TM+i][jj];
-        }
-      }
-      m_i[i] = m;
-    }
-
-
-    // 2) renormalize current O
-    if (j > 0) {
+    // normalize the whole thing by the output sum and write to out
     for (int t = 0; t < num_tiles; t++){
-      for (int i=0;i<TM;++i){
-        for (int jj=0;jj<TN;++jj){
-          O_i[t*TN*TM + i*TN + jj] *= exp(last_m[i] - m_i[i]);
+        for (int ii=0;ii<TM;ii++){
+        for (int jj=0;jj<TN;jj++){
+            if(blockIdx.y*B_r+threadRow*TM+ii < seq_len){
+            out[batch_offset + (blockIdx.y * B_r + threadRow*TM + ii) * d + t * B_c + threadCol*TN + jj] = O_i[t*TN*TM+ii*TM+jj] / l_i[ii];
+            }
         }
-      }
+        } 
     }
-    }
-
-    // 3) renormalize the sum l_i
-    for (int i=0;i<TM;++i){
-      l_i[i] *= exp(last_m[i] - m_i[i]);
-    }
-
-    // 4) compute \exp(Q_iK^T_{j+1} - m^{j+1}) = \exp(S_i-m^{j+1}) // TO OPTIMIZE!!
-    for (int dd = 0; dd < B_c; dd++) {
-      for (int ii=0;ii<TN;ii++){ // calculate new sum and load exp(Attention) weights
-        //check wether thus is in range  or not (if not we set it to 0)
-        //if (idrow+ii < seq_len && idcol+dd < seq_len){
-          regM[ii] = exp(S_i[threadRow*TM+ii][dd] - m_i[ii]);
-          l_i[ii] += regM[ii];
-      }
-      for (int t = 0; t < num_tiles; t++){
-        for (int ii=0;ii<TN;ii++){
-          for (int jj=0;jj<TM;jj++){ // calculate output elements
-            regN[jj] = V_j[dd][t * B_c + threadCol * TN + jj];
-            O_i[t*TN*TM + ii*TM + jj] += regM[ii] * regN[jj];
-          }
-        }
-      }
-    __syncthreads();
-    }
-
-  }
-
-  // normalize the whole thing by the output sum and write to out
-  for (int t = 0; t < num_tiles; t++){
-    for (int ii=0;ii<TM;ii++){
-      for (int jj=0;jj<TN;jj++){
-        if(blockIdx.y*B_r+threadRow*TM+ii < seq_len){
-          out[batch_offset + (blockIdx.y * B_r + threadRow*TM + ii) * d + t * B_c + threadCol*TN + jj] = O_i[t*TN*TM+ii*TM+jj] / l_i[ii];
-        }
-      }
-    } 
-  }
 }
 
 void attention_forward6(float* out,


### PR DESCRIPTION
## Faster Flash Attention Implementation

Added `attention_forward6` to `src/attention_forward`: A fast flash attention forward pass to `src/attention_forward` written without any dependencies. We are assuming using a causal mask here.

This kernel fuses all attention operations, as described in [Flash Attention 2](https://crfm.stanford.edu/2023/07/17/flash2.html), without realization the entire attention matrix, which reduces the memory boundedness of the attention operation.

<!-- Github handles -->
This PR is made by @kilianhae and @simonguozirui.

## Implementation
<!-- The way the computation is decomposed is by tiling the attention computation onto the streaming processor blocks (B_r x B_c) and exploiting data locality by letting each thread be responsible for calculating a chunk of attention values (TM x TN). The tiling enables us to reduce the stalls caused by GMEM loads at the cost of more SMEM stalls. The thread coarsening then lowers the amount of SMEM stalls at the cost of higher register usage, which we found to be quite robust.
 -->
 
Here are a few steps we took to optimize attention
 1. Computation is first decomposed by tiling the attention computation onto the streaming processor blocks (`B_r` x `B_c`). Tiling enables us to reduce the stalls caused by GMEM loads at the cost of more SMEM stalls.
 2. To exploit data locality, we let each thread be responsible for calculating a chunk of attention values of size (`TM` x `TN`). This lowers the amount of SMEM stalls at the cost of higher register usage, which we found to be quite robust.
 3. We use sequence level parallelism over the blocks of Q as done in flash attention 2
 4. Do not compute masked attention values
 5. We dont cache over tiles of Q in order to reduce SMEM usage and increase occupancy

This blog on [optimizing CUDA MatMul kernel](https://siboehm.com/articles/22/CUDA-MMM) by @siboehm was incredibly helpful for our understanding and inspired many of our techniques. 


## Profiling & Performance
So far we tested this `attention_forward6` implementation compared to other existing implementations. It is correct for the cases we tested, but let us know if you run into issues.

**On RTX 3060 (Amphere)**
TODO: @Kilian if you wanna run some more numbers on 3060
On a RTX 3060, we obtain the following times:
- B = 8, T = 1024, C = 768, NH = 12: 7.343360 ms
- B = 6, T = 4096, C = 768, NH = 12, 61.922577 ms 
- B = 1, T = 8192, C = 768, NH = 12: 37.887924 ms

For smaller sequence lengths <= 1024 we empirically found that our kernel matches the performance of attention_forward4(), however on larger sequence lengths it outperforms it: 
- 4096: 61.922577 ms vs 84.654724 ms
- 8192: 37.887924 ms vs 57.476559 ms


**On Tesla T4 (Turing)**

We ran against all existing `attention_forward` implementations currently in the repo, and we found our implementation slightly faster in almost all settings. We don't know whether this behavior is specific for T4 GPU or Turing architecture.
![upload_c8dcec5f6a061f8492a6510babf427ae](https://github.com/karpathy/llm.c/assets/44493092/2e312b36-091d-4867-9ff7-a1338ebee029)


We also tried to do some scaling test comparing `attention_forward4` (current fastest) vs `attention_forward6` (this PR), increasing context length until running out of memory (at seq_len = 8k). It seems that `attention_forward6` might have lower scaling overhead, but we need to test up to longer sequence length to confirm.
![upload_d06c48b99c34ed1df88e50a03957f16e](https://github.com/karpathy/llm.c/assets/44493092/76864c44-c91d-47a2-a2d7-151c3ebf2057)

**On A100 (Amphere) / H100 (Hopper)**
We currently do not have access to such resources. We would really appreciate and be curious to see the performance on those hardware!

### Compare to PyTorch
To be more fair towards non-jit compiled pytorch we provide more detailed comparisons against pytorch in our repo: https://github.com/kilianhae/FlashAttention.C.git. There we also provide a profiling script to compare with torch.

## Known Issues & Next Steps
Currently we assume fixed hidden head dimension to 64 following GPT-2 architecture. We do support any multiple of 32, to do so you need to change the d constant in the flashattention kernel.

Further optimizations:
* Reduce smem complexity: Maybe reload V tiles instead of caching fully over hidden dimension at the cost of more GMEM loads.
* Enable larger coarsening where TN,TM > 4 to further reduce SMEM loads.
* Autotuning different tiling size at various levels for different hardware -> also test tiles of B_r, B_c = 64, 64 on gpus with sufficient SMEM size