### PR TITLE
[#243] Init From Scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Allay
 
 I like how Netflix comes up, it's clear that the shadow of the training past is still lurking in the model. I did not attempt to tune the finetuning hyperparameters so it's quite likely this can be improved quite a bit. I also noticed that slightly different platforms (e.g. MacOS / Linux) will (sadly) give very slightly different results, so perhaps don't expect to get the exact numbers or generation above. Also note that if you are seeing token ids instead of text in the generation, it might be because your code is out of date, as Tokenizer decoding was added April 14, 2024. `git pull` the updates, and then re-run `python train_gpt2.py`, which will now also save the tokenizer, which C can read and then use to print text instead of token ids.
 
+## training from scratch
+
+Training in the current "mainline", [train_gpt2.cu](train_gpt2.cu), requires a model weights checkpoint to be created by first running [train_gpt2.py](train_gpt2.py) which will run a training session on the base weights before writing to a checkpoint. If you want to train in the "mainline" with a model initialized from scratch then the provided [gen_base_weights_checkpoint.py](gen_base_weights_checkpoint.py) can generate the unmodified checkpoint. Compile and run with:
+
+```bash
+pip install -r requirements.txt
+python prepro_tinyshakespeare.py
+python gen_base_weights_checkpoint.py --model_type gpt2
+make train_gpt2cu
+./train_gpt2cu -base gpt2_124M_base_bf16.bin
+```
+
+At this time only 124M parameter model is supported although [gen_base_weights_checkpoint.py](gen_base_weights_checkpoint.py) is capable of generating all available sizes of model checkpoints.
+
 ## test
 
 I am also attaching a simple unit test for making sure our C code agrees with the PyTorch code. Compile and run with:

--- a/gen_base_weights_checkpoint.py
+++ b/gen_base_weights_checkpoint.py
@@ -1,0 +1,41 @@
+"""
+A script to create base model weight files for gpt2 training from scratch.
+- Makes use of GPT class and write_model function from train_gpt2.py.
+- Base model weights are sourced from HuggingFace's transformer library.
+
+Usage: python ./gen_base_weights_checkpoint.py [OPTION]
+    --model_type [ gpt2 | gpt2-medium | gpt2-large | gpt2-xl ]
+        defaults to gpt2
+
+NOTE: This script supports creation of base weights for all model sizes but 
+currently only 124M parameter model ("gpt2") is supported by train_gpt2.cu.
+"""
+
+if __name__ == "__main__":
+    import argparse
+    from train_gpt2 import GPT, write_model
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_type", type=str, default="gpt2", help="by default we generate weights for 124M param model")
+    args = parser.parse_args()
+
+    # only allow valid model types
+    assert args.model_type in {"gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl"}
+
+    # get base model weights using the same method as GPT.from_pretrained() in train_gpt2.py
+    model = GPT.from_pretrained(args.model_type)
+
+    # mapping from model type to # of model params in millions
+    model_to_param_mapping = {
+        "gpt2": 124, 
+        "gpt2-medium": 350,
+        "gpt2-large": 774, 
+        "gpt2-xl": 1558, 
+    }
+
+    # create filename using # of params
+    filename = "gpt2_{}M_base".format((model_to_param_lookup[args.model_type]))
+
+    # write out model weights in f32 and bf16 formats for use by train_gpt2.cu
+    write_model(model, filename + ".bin", dtype="float32")
+    write_model(model, filename + "_bf16.bin", dtype="bfloat16")

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2177,6 +2177,7 @@ int main(int argc, char *argv[]) {
         else if (argv[i][1] == 'm') { val_max_batches = atoi(argv[i+1]); }
         else if (argv[i][1] == 's') { sample_every = atoi(argv[i+1]); }
         else if (argv[i][1] == 'g') { genT = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'c') { load_filename = argv[i + 1]; }
         else { error_usage(); }
     }
     printf0("+-----------------------+----------------------------------------------------+\n");
@@ -2191,6 +2192,7 @@ int main(int argc, char *argv[]) {
     printf0("| val_max_batches       | %-50d |\n", val_max_batches);
     printf0("| sample_every          | %-50d |\n", sample_every);
     printf0("| genT                  | %-50d |\n", genT);
+    printf0("| checkpoint file       | %-50s |\n", load_filename);
     printf0("+-----------------------+----------------------------------------------------+\n");
 
     // set up the device


### PR DESCRIPTION
    Added gen_base_weights_checkpoint.py to create base weight checkpoints
    Added -c option to train_gpt2.cu to overwrite load_filename value
        This allows usage of generated base weight checkpoint instead of
        weights outputted from train_gpt2.py.