### PR TITLE
Remove the cooperative groups in matmul_backward_bias.cu

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -634,7 +634,7 @@ __global__ void gelu_backward_kernel(floatX* dinp, const floatX* inp, const floa
 // the idea is to employ one block to reduce along several columns,
 // where each block has a width of 32 columns to ensure coalesced access.
 // at the end we accumulate the reductions performed by the warps in each block via shared memory
-__global__ void matmul_backward_bias_kernel4(floatX* dbias, const floatX* dout, int B, int T, int OC) {
+__global__ void matmul_backward_bias_kernel2(floatX* dbias, const floatX* dout, int B, int T, int OC) {
     // this kernel is launched with 1D grid_dim of OC/32
     // for example let's say block_size is 128
     extern __shared__ float smem[]; // of size block_size (128)
@@ -1160,7 +1160,7 @@ void matmul_backward(floatX* dinp, floatX* dweight, floatX* dbias,
     if (dbias != NULL) {
         const int block_size = 1024;
         const int grid_size = OC / 32; // for now, OC must be divisible by 32 for this kernel to work
-        matmul_backward_bias_kernel4<<<grid_size, block_size, block_size * sizeof(float)>>>(dbias, dout, B, T, OC);
+        matmul_backward_bias_kernel2<<<grid_size, block_size, block_size * sizeof(float)>>>(dbias, dout, B, T, OC);
         cudaCheck(cudaGetLastError());
     }
 }

--- a/train_gpt2_fp32.cu
+++ b/train_gpt2_fp32.cu
@@ -338,7 +338,7 @@ __global__ void gelu_backward_kernel(float* dinp, const float* inp, const float*
 // the idea is to employ one block to reduce along several columns,
 // where each block has a width of 32 columns to ensure coalesced access.
 // at the end we accumulate the reductions performed by the warps in each block via shared memory
-__global__ void matmul_backward_bias_kernel4(float* dbias, const float* dout, int B, int T, int OC) {
+__global__ void matmul_backward_bias_kernel2(float* dbias, const float* dout, int B, int T, int OC) {
     // this kernel is launched with 1D grid_dim of OC/32
     // for example let's say block_size is 128
     extern __shared__ float smem[]; // of size block_size (128)
@@ -797,7 +797,7 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
     if (dbias != NULL) {
         const int block_size = 1024;
         const int grid_size = OC / 32; // for now, OC must be divisible by 32 for this kernel to work
-        matmul_backward_bias_kernel4<<<grid_size, block_size, block_size * sizeof(float)>>>(dbias, dout, B, T, OC);
+        matmul_backward_bias_kernel2<<<grid_size, block_size, block_size * sizeof(float)>>>(dbias, dout, B, T, OC);
         cudaCheck(cudaGetLastError());
     }
 }


### PR DESCRIPTION
https://github.com/karpathy/llm.c/issues/292
Given the fastest one is kernel 4 which is also used in train_gpt2
1. Remove the old kernels 2 and 3, which are using cg
2. Re-index the kernel4 to kernel2