### PR TITLE
Fix the complier warning wrf packed128

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -40,7 +40,7 @@ void cublasCheck(cublasStatus_t status, const char *file, int line)
 
 template<class ElementType>
 struct alignas(16) Packed128 {
-    __device__ Packed128() = default;
+    Packed128() = default;
     __device__ explicit Packed128(int4 bits) {
         static_assert(sizeof(bits) == sizeof(payload), "Size mismatch.");
         memcpy(&payload, &bits, sizeof(bits));

--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -40,7 +40,7 @@ void cublasCheck(cublasStatus_t status, const char *file, int line)
 
 template<class ElementType>
 struct alignas(16) Packed128 {
-    Packed128() = default;
+    __device__ Packed128() = default;
     __device__ explicit Packed128(int4 bits) {
         static_assert(sizeof(bits) == sizeof(payload), "Size mismatch.");
         memcpy(&payload, &bits, sizeof(bits));

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -2,7 +2,10 @@
 Kernels for gelu forward pass.
 
 Compile example:
-nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward
+nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward 
+
+If encountering "warning #20012-D: __device__ annotation is ignored on a function("Packed128") that is explicitly defaulted on its first declaration":
+nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward  -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
 
 If encountering "error: identifier "M_PI" is undefined", add the following lines to the top of the file:
 

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -2,7 +2,7 @@
 Kernels for gelu forward pass.
 
 Compile example:
-nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward 
+nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward
 
 If encountering "warning #20012-D: __device__ annotation is ignored on a function("Packed128") that is explicitly defaulted on its first declaration":
 nvcc -O3 --use_fast_math gelu_forward.cu -o gelu_forward  -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored


### PR DESCRIPTION
WRT warning common.h(43): warning #20012-D: __device__ annotation is ignored on a function("Packed128") that is explicitly defaulted on its first declaration
      __attribute__((device)) Packed128() = default;

The warning can be suppressed by passing the flag `-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored`