### PR TITLE
Stochastic rounding for all non-matmul activation gradients

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -489,7 +489,7 @@ __device__ void atomicStochasticAdd(__nv_bfloat16* address, float val0, float va
     } while (assumed != old);
 }
 
-__device__ void atomicStochasticAdd(float* address, float val0, float val1, uint seed, uint random) {
+__device__ void atomicStochasticAdd(float* address, float val0, float val1, uint seed) {
     atomicAdd(address, val0);
     atomicAdd(address + 1, val1);
 }


### PR DESCRIPTION
I'd suggest trying this before the gazillion of inevitable f128-based performance optimisations in the next few days that will create a huge number of merge conflicts :) I wouldn't bother integrating this right now given that, but it'd be great to know if it helps the loss or not when pre-training from scratch.

---

Stochastic rounding is now implemented for the activation gradients in the backward pass for:
1. Adam (as before)
2. GELU
3. Layernorm
4. Softmax for attention
5. Fused classifier (activation gradients for logits only)
6. EDIT/NEW: The final encoder_backward kernel using atomicCAS and a retry loop (performance is better than what we currently have on main branch).

It is *NOT* implemented for:
- Any of the matmuls (impossible until we move away from cuBLAS unfortunately).
- Any of the weight/parameter gradients (useful with grandient accumulation?) and forward pass activations, etc...

The performance cost seems to be fairly negligible so we could integrate it elsewhere if it helps.