### PR TITLE
Make the fp32 function in pack128 const

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -52,7 +52,7 @@ struct alignas(16) Packed128 {
     __device__ const ElementType& operator[](int index) const {
         return payload[index];
     }
-    __device__ float fp32(int index) {
+    __device__ float fp32(int index) const {
         return static_cast<float>(payload[index]);
     }
     __device__ int4 get_bits() const {


### PR DESCRIPTION
The function should be marked as const. 
Otherwise, the .fp32 function is limited in its proper usage.
For example
```
float get_zero_index(const f128& x) {
       return x.fp32(0);  -------------> not allowed
}
```