### PR TITLE
Improve tanh derivative in backward gelu

### DIFF
--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -379,8 +379,7 @@ void gelu_backward(float* dinp, float* inp, float* dout, int N) {
         float cube = 0.044715f * x * x * x;
         float tanh_arg = GELU_SCALING_FACTOR * (x + cube);
         float tanh_out = tanhf(tanh_arg);
-        float coshf_out = coshf(tanh_arg);
-        float sech_out = 1.0f / (coshf_out * coshf_out);
+        float sech_out = 1.0f - (tanh_out * tanh_out);
         float local_grad = 0.5f * (1.0f + tanh_out) + x * 0.5f * sech_out * GELU_SCALING_FACTOR * (1.0f + 3.0f * 0.044715f * x * x);
         dinp[i] += local_grad * dout[i];
     }


### PR DESCRIPTION
It is cheaper to compute the derivative of tanh as 1 - tanh^2 than computing 1/(cosh^2). This will probably not make a measurable difference.