### PR TITLE
[ModuleNotFoundError]: Solution - add required package (requests) into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 torch
 tiktoken
 transformers
+requests


### PR DESCRIPTION
When run `quick start (GPU)`
```bash
pip install -r requirements.txt
python prepro_tinyshakespeare.py
python train_gpt2.py
make train_gpt2fp32cu
./train_gpt2fp32cu
```

It has the ModuleNotFoundError `No module named requests`, thus, I edit `requirements.txt` to solve this issue.

Original `requirements.txt`L
```bash
tqdm
numpy
torch
tiktoken
transformers
```

Fixed `requirements.txt`:
```bash
tqdm
numpy
torch
tiktoken
transformers
requests
```

