### PR TITLE
Set GPU compute capability dynamically in Cuda makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,7 @@ name: Build and test
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   build-and-test-cpu:

--- a/dev/cuda/Makefile
+++ b/dev/cuda/Makefile
@@ -9,7 +9,9 @@ ifeq ($(NVCC),)
 endif
 
 # get GPU compute capability utility value
-GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) # assume if NVCC is present, then this likely is
+ifeq ($(MAKELEVEL),0) # detect if we are in CI or not
+	GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) # assume if NVCC is present, then this likely is too
+endif
 
 # Compiler flags
 ifeq ($(GPU_COMPUTE_CAPABILITY),) # set to defaults if: make GPU_COMPUTE_CAPABILITY= 

--- a/dev/cuda/Makefile
+++ b/dev/cuda/Makefile
@@ -8,8 +8,7 @@ ifeq ($(NVCC),)
 		$(error nvcc not found.)
 endif
 
-# get GPU compute capability utility value
-ifeq ($(MAKELEVEL),0) # detect if we are in CI or not
+ifneq ($(CI),true) # if not in CI, then use the GPU query
 	GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) # assume if NVCC is present, then this likely is too
 endif
 

--- a/dev/cuda/Makefile
+++ b/dev/cuda/Makefile
@@ -8,8 +8,16 @@ ifeq ($(NVCC),)
 		$(error nvcc not found.)
 endif
 
+# get GPU compute capability utility value
+GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) # assume if NVCC is present, then this likely is
+
 # Compiler flags
-CFLAGS = -O3 --use_fast_math
+ifeq ($(GPU_COMPUTE_CAPABILITY),) # set to defaults if: make GPU_COMPUTE_CAPABILITY= 
+	CFLAGS = -O3 --use_fast_math 
+else
+	CFLAGS = -O3 --use_fast_math --generate-code=arch=compute_$(GPU_COMPUTE_CAPABILITY),code=[compute_$(GPU_COMPUTE_CAPABILITY),sm_$(GPU_COMPUTE_CAPABILITY)]
+endif
+
 NVCCFLAGS = -lcublas -lcublasLt
 MPI_PATHS = -I/usr/lib/x86_64-linux-gnu/openmpi/include -L/usr/lib/x86_64-linux-gnu/openmpi/lib/
 


### PR DESCRIPTION
This is a draft proposal in case there is interest for kernel builds.

Usage:

Auto detect GPU capability:
>make
(e.g. if your GPU capability type is 80 then --generate-code=arch=compute_80,code=[compute_80,sm_80] is used with CFLAGS)

Do not specify capability:
>make GPU_COMPUTE_CAPABILITY=
(CFLAGS = -O3 --use_fast_math)

Override capability:
>make GPU_COMPUTE_CAPABILITY=86
(e.g. even if your GPU capability type is 80 then --generate-code=arch=compute_86,code=[compute_86,sm_86] is used with CFLAGS)

Tested on Linux Ubuntu 22.04 only. 

