### PR TITLE
Adding GPT2 model evaluation on WikiText-103 with optional preprocessing in dev/model-eval/

### DIFF
--- a/dev/model_eval/prepro_wikitext-103.py
+++ b/dev/model_eval/prepro_wikitext-103.py
@@ -1,0 +1,121 @@
+"""
+Downloads and tokenizes the WikiText-103 validation split.
+- The download is from "https://wikitext.smerity.com/wikitext-103-raw-v1.zip"
+ following https://github.com/tysam-code/hlb-gpt/tree/main
+- The tokenization is GPT-2 tokenizer with tiktoken
+
+The output is written to a newly created data/ folder.
+
+And runs in a few seconds depending on your internet
+connection and computer. The .bin files are raw byte
+streams of int32 numbers indicating the token ids.
+
+Usage: python prepro_wikitext-103.py [-p|--preprocess]
+"""
+
+import os
+import re
+import requests
+import argparse
+import zipfile
+import numpy as np
+from tqdm import tqdm
+
+import tiktoken
+
+DATA_CACHE_DIR = "data"
+enc = tiktoken.get_encoding("gpt2")
+encode = lambda s: enc.encode(s, allowed_special = {"<|endoftext|>"})
+
+def download_file(url : str, fname : str, chunk_size = 1024):
+    """Helper function to download a file from a given url"""
+    resp = requests.get(url, stream = True)
+    total = int(resp.headers.get("content-length", 0))
+    with open(fname, "wb") as file, tqdm(
+        desc = fname,
+        total = total,
+        unit = "iB",
+        unit_scale = True,
+        unit_divisor = 1024,
+    ) as bar:
+        for data in resp.iter_content(chunk_size = chunk_size):
+            size = file.write(data)
+            bar.update(size)
+
+def download():
+    """Downloads the WikiText-103 dataset to DATA_CACHE_DIR"""
+    os.makedirs(DATA_CACHE_DIR, exist_ok = True)
+
+    # download the WikiText-103 dataset, unless it's already downloaded
+    data_url = "https://wikitext.smerity.com/wikitext-103-raw-v1.zip"
+    data_filename = os.path.join(DATA_CACHE_DIR, "WikiText-103.zip")
+    if not os.path.exists(data_filename):
+        print(f"Downloading {data_url} to {data_filename}...")
+        download_file(data_url, data_filename)
+    else:
+        print(f"{data_filename} already exists, skipping download...")
+
+    # unzip the file
+    data_dir = os.path.join(DATA_CACHE_DIR, "wikitext-103")
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir, exist_ok = True)
+        print(f"Unzipping {data_filename}...")
+        with zipfile.ZipFile(data_filename, "r") as zip_ref:
+            zip_ref.extractall(data_dir)
+    else:
+        print(f"{data_dir} already exists, skipping unzipping...")
+
+def tokenize(preprocess : bool):
+    # special token
+    eot = enc._special_tokens["<|endoftext|>"]
+
+    # fetch validation text
+    val_data_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103/wikitext-103-raw/wiki.valid.raw")
+    val_text = open(val_data_filename, "r", encoding = "utf-8").read()
+
+    if preprocess:
+        print("Cleaning validation data...")
+        # cleanup the validation text
+        val_text = val_text.strip() # remove leading and trailing whitespace
+        val_text = val_text.replace(" \n \n ", "\n<|endoftext|>") # injecting special token in between sections
+        # removing some low hanging fruit artifacts
+        val_text = val_text.replace("@-@", "-")
+        val_text = val_text.replace("@.@", ".")
+        val_text = val_text.replace("@,@", ",")
+        val_text = "<|endoftext|>" + val_text # adding special token at start
+        val_split = val_text.split("<|endoftext|>") # splitting the text by special token to remove the extraneous headers/titles
+
+        # remove the awkward headers/titles that came from the original parquet format
+        for chunk in tqdm([item for item in reversed(range(len(val_split)))], desc = "Removing artifacts", unit = "iB"):
+            # if the chunk is of the form of the headers/titles we will pop this chunk out
+            if bool(re.match(r"^\s*= +(.{1,}) +=\s*$", val_split[chunk])):
+                val_split.pop(chunk)
+
+        # now join the remaining chunks via eot
+        val_text = "<|endoftext|>".join(val_split[i] for i in range(len(val_split)))
+        print("Validation data cleaned")
+
+    print("Tokenizing validation text...")
+    val_tokens = encode(val_text)
+    print("Validation text tokenized")
+    val_tokens_np = np.array(val_tokens, dtype = np.int32)
+
+    print("Dumping text into text files to observe readable output")
+    with open(os.path.join(DATA_CACHE_DIR, "wikitext-103_val.txt"), "w") as f:
+        f.write(val_text)
+
+    # now just dump the encoded tokens into binary files
+    val_filename = os.path.join(DATA_CACHE_DIR, "wikitext-103_val.bin")
+
+    with open(val_filename, "wb") as f:
+        for chunk in tqdm([val_tokens_np[i : i + 1024] for i in range(0, len(val_tokens_np), 1024)], desc = "Writing validation data to wikitext-103_val.bin", unit = "iB"):
+            f.write(chunk.tobytes())
+    
+    print(f"Saved {len(val_tokens_np)} tokens to {val_filename}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--preprocess", action = "store_true", help = "Preprocesses the dataset")
+    args = parser.parse_args()
+    download()
+    tokenize(args.preprocess)

--- a/dev/model_eval/target_eval_gpt2.py
+++ b/dev/model_eval/target_eval_gpt2.py
@@ -1,0 +1,80 @@
+"""
+Evauates GPT2 models. This code specifically
+checks the perplexity score of the model on the wikitext-103
+dataset. 
+
+In the original paper, the perplexity scores on WikiText-103:
+GPT2-small (117M): 37.50
+GPT2-medium (345M): 26.37
+GPT2-large (762M): 22.05
+GPT2-xl (1542M): 17.48
+
+Again from paper, the perplexity scores on WikiText-2:
+GPT2-small (117M): 29.41
+GPT2-medium (345M): 22.76
+GPT2-large (762M): 19.93
+GPT2-xl (1542M): 18.34
+
+Usage: python target_eval_gpt2.py
+"""
+
+import os
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from transformers import GPT2LMHeadModel
+
+assert os.path.isfile("data/wikitext-103_val.bin"), "you must first run python prepro_wikitext-103.py [-p|--preprocess]"
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+models = {
+    "small": "openai-community/gpt2",
+    "medium": "openai-community/gpt2-medium",
+    "large": "openai-community/gpt2-large",
+    "xl": "openai-community/gpt2-xl"
+}
+
+print("Loading dataset...")
+with open("data/wikitext-103_val.bin", "rb") as f:
+    eval_text = np.frombuffer(f.read(), dtype = np.int32)
+    eval_text = torch.tensor(eval_text, dtype = torch.long).unsqueeze(0)
+print("Dataset loaded")
+
+# evaluate each model size
+for size in models:
+    print(f"Loading gpt2-{size}...")
+    model = GPT2LMHeadModel.from_pretrained(models[size]).to(device)
+    print(f"gpt2-{size} loaded")
+
+    # constants of perplexity score evaluation
+    max_length = model.config.n_positions # context_length/block_size
+    stride = max_length # stride_length (GPT2 was likely evaluated on stride_length = max_length)
+    seq_len = eval_text.shape[1] # size of evaluation text
+
+    nlls = [] # negative log likelihoods
+    prev_end_loc = 0
+    for begin_loc in tqdm(range(0, seq_len, stride), desc = f"Evaluating gpt2-{size}"):
+        end_loc = min(begin_loc + max_length, seq_len) # always use full context length unless fewer remaining tokens
+        trg_len = end_loc - prev_end_loc # this is used for when stride_length < context_length
+        input_ids = eval_text[:, begin_loc:end_loc].to(device) # pick the tokens to eval on and move to device
+        target_ids = input_ids.clone() # clone them to targets
+        target_ids[:, :-trg_len] = -100 # using a label of -100 tells pytorch not to calculate loss for the label
+
+        with torch.no_grad():
+            outputs = model(input_ids, labels = target_ids)
+
+            # loss is calculated using CrossEntropyLoss which averages over valid labels
+            # N.B. the model only calculates loss over trg_len - 1 labels, because it internally shifts the labels
+            # to the left by 1.
+            neg_log_likelihood = outputs.loss
+
+        nlls.append(neg_log_likelihood)
+
+        prev_end_loc = end_loc
+        if end_loc == seq_len:
+            break
+            
+    # get mean of negative log likelihoods and exponentiate to get perplexity
+    ppl = torch.exp(torch.stack(nlls).mean())
+    print(f"gpt2-{size} perplexity score:", ppl.item())


### PR DESCRIPTION
**Ultimately in response to #246:**

In regards to this specific PR, I propose the addition of two files in a new ```dev/model_eval/``` folder. One file prepares wikitext-103 for a model's evaluation with an optional argument that preprocesses the text. The other file evaluates each gpt2 model size on the prepared evaluation data thanks to the help of huggingface.

Also, please refer to my latest message at the bottom of #276 where I describe some contradictions that I found regarding the topic of reproducing numbers. Also, please refer to the repo on my profile called gpt2eval where I have provided two folders, in each is a python notebook where I run some tests and compute perplexity scores for each gpt2 model size on different preparations of the wikitext dataset. I suggest reading my report at the bottom of the last PR first, then seeing the repo on my profile, then finally viewing this code that I am offering in this PR.

For convenience I am providing this table that summarizes the computations from the tests I ran and compares them to the reported GPT2 numbers:

**Perplexity Scores from GPT2 Paper:**
| Model Size  | WikiText-2 | WikiText-103 |
| ------------- | ------------- | ------------- |
| 117M | 29.41 | 37.50 |
| 345M | 22.76 | 26.37 |
| 762M | 19.93 | 22.05 |
| 1542M | 18.34 | 17.48 |

_All the following numbers are evaluated on WikiText-103 validation split:_

**Huggingface Dataset:**
| Model Size  | Raw | Bare Minimum Preprocessing | 
| ------------- | ------------- | ------------- |
| 124M | 30.59 | 31.04 |
| 355M | 22.35 | 22.51 |
| 774M | 19.33 | 20.09 |
| 1558M | 17.46 | 17.91 |

**Smerity Dataset:**
| Model Size  | Raw | My Extensive Preprocessing | 
| ------------- | ------------- | ------------- |
| 124M | 30.13 | 33.19 |
| 355M | 21.77 | 24.31 |
| 774M | 18.74 | 21.39 |
| 1558M | 16.91 | 19.32 |

My analysis of the results:
- These tests seem to confirm that something unusual is going on with the number reporting in the GPT2 paper because as I mention in my report, the evaluations on WikiText-2 and WikiText-103 should be identical because the val/test splits of the datasets are respectively identical.
- Assuming that the numbers we want to replicate are those in the WikiText-2 column of the GPT2 paper, I believe the most similar results are from the bare minimum preprocessing of the huggingface dataset (I say this off of a quick glance and no supporting calculations to verify this claim). To see the exact differences in the preparations of each test's dataset, you would have to analyze the code in the notebooks on my gpt2eval repo.