### PR TITLE
utilities for mixed-precision tests/benchmarks

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -56,7 +56,9 @@ int cuda_threads_per_SM = 0;    // needed to calculate how many blocks to launch
 
 template<class ElementType>
 struct alignas(16) Packed128 {
-    __device__ Packed128() = default;
+    // default gives implicit __device__.
+    // Making it explicit causes the compiler to emit warnings, so it is omitted here
+    Packed128() = default;
     __device__ explicit Packed128(int4 bits) {
         static_assert(sizeof(bits) == sizeof(payload), "Size mismatch.");
         memcpy(&payload, &bits, sizeof(bits));
@@ -168,36 +170,10 @@ template<class TargetType>
     return status;
 }
 
-void setup_main() {
-    srand(0);   // determinism
-
-    // set up the device
-    int deviceIdx = 0;
-    cudaCheck(cudaSetDevice(deviceIdx));
-    cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, deviceIdx);
-    cuda_num_SMs = deviceProp.multiProcessorCount;
-    cuda_threads_per_SM = deviceProp.maxThreadsPerMultiProcessor;
-    cuda_arch_major = deviceProp.major;
-    cuda_arch_minor = deviceProp.minor;
-
-    // setup cuBLAS and cuBLASLt
-    cublasCheck(cublasCreate(&cublas_handle));
-    cublasCheck(cublasLtCreate(&cublaslt_handle));
-    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
-
-    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
-    int enable_tf32 = cuda_arch_major >= 8 ? 1 : 0;
-    // TODO implement common CLI for all tests/benchmarks
-    // if (override_enable_tf32 == 0) { enable_tf32 = 0; } // force to zero via arg
-    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
-    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
-    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
-}
-
 template<class D, class T>
-void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements, T tolerance=1e-4) {
-    D* out_gpu = (D*)malloc(num_elements * sizeof(D));
+void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements,
+                     T tolerance = 1e-4) {
+    D* out_gpu = (D*) malloc(num_elements * sizeof(D));
     cudaCheck(cudaMemcpy(out_gpu, device_result, num_elements * sizeof(D), cudaMemcpyDeviceToHost));
     int nfaults = 0;
     for (int i = 0; i < num_elements; i++) {
@@ -208,7 +184,7 @@ void validate_result(D* device_result, const T* cpu_reference, const char* name,
         // ensure correctness for all elements. We can set an "ignore" mask by writing NaN
         if (fabs(cpu_reference[i] - (T)out_gpu[i]) > tolerance && isfinite(cpu_reference[i])) {
             printf("Mismatch of %s at %d: CPU_ref: %f vs GPU: %f\n", name, i, cpu_reference[i], (T)out_gpu[i]);
-            nfaults ++;
+            nfaults++;
             if (nfaults >= 10) {
                 free(out_gpu);
                 exit(EXIT_FAILURE);
@@ -259,3 +235,132 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
 
     return elapsed_time / repeats;
 }
+
+
+// ----------------------------------------------------------------------------
+// common test/benchmark main implementation
+
+// usage: each test/benchmark file needs to provide a kernel dispatch function, whose first argument is a kernel
+//        number, and which will call the correct kernel implementation by passing on all the other arguments.
+//        individual kernels should be implemented as templates over the floating-point types they operate on.
+//        Then, the macro DECLARE_TEST should be called, with the kernel dispatch function as its sole argument.
+//        Next, the IMPLEMENT_TEST macro prepares the implementation of the actual test/benchmark. It is used like
+//        a function declaration, that is, it should be called like `int IMPLEMENT_TEST(int kernel_num) {`.
+//        The `kernel_num` argument contains the requested kernel, and inside the curly braces, a `floatX`
+//        type is available that specifies the requested floating point type.
+// For an explanation how these macros do their magic, see below.
+
+// generic setup function that prepares the device and sets up cublas
+void setup_main() {
+    srand(0);   // determinism
+
+    // set up the device
+    int deviceIdx = 0;
+    cudaCheck(cudaSetDevice(deviceIdx));
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, deviceIdx);
+    cuda_num_SMs = deviceProp.multiProcessorCount;
+    cuda_threads_per_SM = deviceProp.maxThreadsPerMultiProcessor;
+    cuda_arch_major = deviceProp.major;
+    cuda_arch_minor = deviceProp.minor;
+
+    // setup cuBLAS and cuBLASLt
+    cublasCheck(cublasCreate(&cublas_handle));
+    cublasCheck(cublasLtCreate(&cublaslt_handle));
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
+
+    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
+    int enable_tf32 = cuda_arch_major >= 8 ? 1 : 0;
+    // TODO implement common CLI for all tests/benchmarks
+    // if (override_enable_tf32 == 0) { enable_tf32 = 0; } // force to zero via arg
+    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
+    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
+    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
+}
+
+// this defines the generic structure of the main function. This contains everything we can specify without
+// knowing the actual test, which is communicated through the TestCase class template.
+// Note: Since the TestCase itself has to be a template (needs to run on float, half, bfloat), we get the
+//       `template<class> class TestCase` syntax: TestCase is a class template, that takes a single class (floatX) as its
+//       template parameter.
+// You are not intended to invoke this function manually, nor to write a TestCase yourself; instead, this setup will
+// be handled by the macros below.
+template<template<class> class TestCase>
+int main_fn(int argc, const char** argv) {
+    setup_main();
+
+    // read kernel_num from command line
+    int kernel_num = 1;
+    if (argc > 1) {
+        kernel_num = atoi(argv[1]);
+    }
+    printf("Using kernel %d\n", kernel_num);
+
+    int dtype = 0;
+    if (argc > 2) {
+        if (strcmp(argv[2], "f32") == 0) {
+            dtype = 0;
+        } else if (strcmp(argv[2], "f16") == 0) {
+            dtype = 1;
+        } else if (strcmp(argv[2], "b16") == 0) {
+            dtype = 2;
+        } else {
+            fprintf(stderr, "Invalid dtype %s", argv[2]);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    switch (dtype) {
+        case 0:
+            printf("Using float\n");
+            return TestCase<float>::run(kernel_num);
+        case 1:
+            printf("Using half\n");
+            return TestCase<half>::run(kernel_num);
+        case 2:
+            printf("Using bfloat16\n");
+            return TestCase<nv_bfloat16>::run(kernel_num);
+        default:
+            exit(EXIT_FAILURE);
+    }
+}
+
+// We have one more challenge to overcome: The kernel dispatch function has to be a template,
+// but that prevents us from passing it around as a parameter (cannot take the address of an overloaded function)
+// to the `benchmark_kernel` function above.
+// What we can pass around instead is a function object; but we don't want to require the test files to implement
+// these (which are a bit unnatural, and really just a workaround), so instead we have this macro that creates
+// a helper type `dispatcher_s` whose call operator is just forwarding to the original kernel dispatch.
+#define DECLARE_DISPATCHER(fptr) \
+struct dispatcher_s {            \
+    template<class... Args>         \
+    void operator()(Args&&... args) {   \
+        fptr(std::forward<Args>(args)...);  \
+    }   \
+}; \
+
+// This macro declares the TestCase class. It is templated over the floating-point type `floatX`, and defines a
+// run function to actually run the test.  It also provides a `dispatcher_s` variable of name `dispatcher` (which
+// is the name of the original dispatch function template). Therefore, inside this class, the dispatcher function
+// template is shadowed by the `dispatcher_s` object of the same name, and `benchmark_kernel` calls work seamlessly.
+#define DECLARE_TEST(dispatcher)    \
+DECLARE_DISPATCHER(dispatcher)      \
+template<class floatX>              \
+struct TestCase {                   \
+    using x128 = Packed128<floatX>; \
+    static int run(int kernel_num); \
+    static dispatcher_s dispatcher; \
+}
+
+
+// Finally, the actual test implementation. This macro is designed to have minimal syntax effect, to make it look as
+// close to a "regular" test function. Therefore, the implementation below does not specify `int main` but just main---
+// the `int` part is expected to be provided as part of the macro invocation in the test file. Similarly, we do not
+// auto-generate the `int kernel_num` parameter, but instead expect it to be given as "function arguments" to the macro.
+// Thus, in the test file, the only thing that "magically" appears is the floatX type.
+#define IMPLEMENT_TEST(...)                 \
+main(int argc, const char** argv) {     \
+    return main_fn<TestCase>(argc, argv);   \
+}                                           \
+template<class floatX>                      \
+int TestCase<floatX>::run(__VA_ARGS__)

--- a/dev/cuda/encoder_forward.cu
+++ b/dev/cuda/encoder_forward.cu
@@ -20,22 +20,6 @@ version 3 is like version 2 but uses float4 reads/writes
 #include "common.h"
 #include <cassert>
 
-// turn on bf16 as default, done up here for now
-#define ENABLE_BF16
-
-#if defined(ENABLE_BF16)
-typedef __nv_bfloat16 floatX;
-typedef __nv_bfloat16 floatN;
-#elif defined(ENABLE_FP16)
-typedef half floatX;
-typedef half floatN;
-#else
-typedef float floatX;
-typedef float floatN;
-#endif
-
-typedef Packed128<floatX> x128;
-
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -60,6 +44,7 @@ void encoder_forward_cpu(float* out,
 // GPU kernels
 
 // naive implementation into kernel, parallelize over B,T, loop over C
+template<typename floatX>
 __global__ void encoder_forward_kernel1(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
@@ -80,6 +65,7 @@ __global__ void encoder_forward_kernel1(floatX* out,
 }
 
 // optimized implementation: parallelize over all of B,T,C
+template<typename floatX>
 __global__ void encoder_forward_kernel2(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
@@ -101,9 +87,11 @@ __global__ void encoder_forward_kernel2(floatX* out,
     }
 }
 
+template<typename floatX>
 __global__ void encoder_forward_kernel3(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
+    using x128 = Packed128<floatX>;
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     int N = B * T * C;
     if (idx < N) {
@@ -132,6 +120,7 @@ __global__ void encoder_forward_kernel3(floatX* out,
 // ----------------------------------------------------------------------------
 // kernel launcher
 
+template<typename floatX>
 void encoder_forward1(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
@@ -142,6 +131,7 @@ void encoder_forward1(floatX* out,
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void encoder_forward2(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
@@ -152,17 +142,19 @@ void encoder_forward2(floatX* out,
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void encoder_forward3(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
                      const int block_size) {
     const int N = B * T * C;
-    const int grid_size = ceil_div(N, (int)(block_size * x128::size));
+    const int grid_size = ceil_div(N, (int)(block_size * Packed128<floatX>::size));
     encoder_forward_kernel3<<<grid_size, block_size>>>(out, inp, wte, wpe, B, T, C);
     cudaCheck(cudaGetLastError());
 }
 
 // kernel version dispatch
+template<typename floatX>
 void encoder_forward(int kernel_num,
                      floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
@@ -186,16 +178,13 @@ void encoder_forward(int kernel_num,
 
 // ----------------------------------------------------------------------------
 
-int main(int argc, char **argv) {
-    setup_main();
+DECLARE_TEST(encoder_forward);
 
+int IMPLEMENT_TEST(int kernel_num) {
     int B = 8;
     int T = 1024;
     int C = 768;
     int V = 50257;
-
-    int deviceIdx = 0;
-    cudaCheck(cudaSetDevice(deviceIdx));
 
     // create host memory of random numbers
     float* out = (float*)malloc(B * T * C * sizeof(float));
@@ -216,13 +205,6 @@ int main(int argc, char **argv) {
     cudaCheck(memcpy_convert(d_wte, wte, V * C));
     cudaCheck(memcpy_convert(d_wpe, wpe, T * C));
 
-    // read kernel_num from command line
-    int kernel_num = 2;
-    if (argc > 1) {
-        kernel_num = atoi(argv[1]);
-    }
-    printf("Using kernel %d\n", kernel_num);
-
     // first check the correctness of the kernel
     encoder_forward_cpu(out, inp, wte, wpe, B, T, C);
 
@@ -233,11 +215,7 @@ int main(int argc, char **argv) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
         encoder_forward(kernel_num, d_out, d_inp, d_wte, d_wpe, B, T, C, block_size);
-#if !defined(ENABLE_BF16) && !defined(ENABLE_FP16)
-        float tol = 1e-5;
-#else
-        float tol = 1e-2f;
-#endif
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
         validate_result(d_out, out, "out", B * T * C, tol);
     }
 
@@ -252,12 +230,14 @@ int main(int argc, char **argv) {
                                               );
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 3 reads and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 3 reads and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 4 * 4;
+        long memory_ops = B * T * C * 4 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
-        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/gelu_backward.cu
+++ b/dev/cuda/gelu_backward.cu
@@ -21,22 +21,6 @@ version 2 uses the Packed128 data structure
 #include <cuda_runtime.h>
 #include "common.h"
 
-// turn on bf16 as default, done up here for now
-#define ENABLE_BF16
-
-#if defined(ENABLE_BF16)
-typedef __nv_bfloat16 floatX;
-typedef __nv_bfloat16 floatN;
-#elif defined(ENABLE_FP16)
-typedef half floatX;
-typedef half floatN;
-#else
-typedef float floatX;
-typedef float floatN;
-#endif
-
-typedef Packed128<floatX> x128;
-
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -51,7 +35,7 @@ void gelu_backward_cpu(float* dinp, const float* inp, const float* dout, const i
         float coshf_out = coshf(tanh_arg);
         float sech_out = 1.0f / (coshf_out * coshf_out);
         float local_grad = 0.5f * (1.0f + tanh_out) + x * 0.5f * sech_out * GELU_SCALING_FACTOR * (1.0f + 3.0f * 0.044715f * x * x);
-        dinp[i] = (floatX)(local_grad * (float)dout[i]);
+        dinp[i] = local_grad * (float)dout[i];
     }
 }
 
@@ -59,6 +43,7 @@ void gelu_backward_cpu(float* dinp, const float* inp, const float* dout, const i
 // GPU kernels
 
 // elementwise ops are nice and ez
+template<typename floatX>
 __global__ void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* dout, int N) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < N) {
@@ -73,7 +58,9 @@ __global__ void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* do
     }
 }
 
+template<typename floatX>
 __global__ void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* dout, const int N) {
+    using x128 = Packed128<floatX>;
     int i = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     if (i < N) {
         x128 packed_dinp;
@@ -97,19 +84,22 @@ __global__ void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* do
 // ----------------------------------------------------------------------------
 // kernel launcher
 
+template<typename floatX>
 void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* dout, int N, const int block_size) {
     const int grid_size = ceil_div(N, block_size);
     gelu_backward1<<<grid_size, block_size>>>(dinp, inp, dout, N);
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* dout, int N, const int block_size) {
-    const int grid_size = ceil_div(N, block_size * x128::size);
+    const int grid_size = ceil_div(N, block_size * Packed128<floatX>::size);
     gelu_backward2<<<grid_size, block_size>>>(dinp, inp, dout, N);
     cudaCheck(cudaGetLastError());
 }
 
 // kernel version dispatch
+template<typename floatX>
 void gelu_backward(int kernel_num,
                   floatX* dinp, 
                   const floatX* inp, 
@@ -131,8 +121,9 @@ void gelu_backward(int kernel_num,
 
 // ----------------------------------------------------------------------------
 
-int main(int argc, char **argv) {
-    setup_main();
+DECLARE_TEST(gelu_backward);
+
+int IMPLEMENT_TEST(int kernel_num) {
 
     int B = 8;
     int T = 1024;
@@ -142,13 +133,6 @@ int main(int argc, char **argv) {
     float* dinp = (float*)malloc(B * T * C * sizeof(float));
     float* inp = make_random_float(B * T * C);
     float* dout = make_random_float(B * T * C);
-
-    // read kernel_num from command line
-    int kernel_num = 1;
-    if (argc > 1) {
-        kernel_num = atoi(argv[1]);
-    }
-    printf("Using kernel %d\n", kernel_num);
 
     // first check the correctness of the kernel
     gelu_backward_cpu(dinp, inp, dout, B * T * C);
@@ -170,11 +154,7 @@ int main(int argc, char **argv) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
         gelu_backward(kernel_num, d_dinp, d_inp, d_dout, B, T, C, block_size);
-#if !defined(ENABLE_BF16) && !defined(ENABLE_FP16)
-        float tol = 1e-5;
-#else
-        float tol = 1e-2f;
-#endif
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
         validate_result(d_dinp, dinp, "dinp", B * T * C, tol);
     }
 
@@ -190,12 +170,14 @@ int main(int argc, char **argv) {
                                               B, T, C, block_size);
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 1 read and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 1 read and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 2 * 4;
+        long memory_ops = B * T * C * 2 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
-        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -154,10 +154,10 @@ int IMPLEMENT_TEST(int kernel_num) {
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
         long memory_ops = B * T * C * 2 * (int)sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
-        float toks_per_sec = B * T / elapsed_time / 1e3;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
         printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
-               block_size, elapsed_time, memory_bandwidth, toks_per_sec);
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/residual_forward.cu
+++ b/dev/cuda/residual_forward.cu
@@ -140,9 +140,9 @@ int IMPLEMENT_TEST(int kernel_num) {
                                               );
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 2 read and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 2 read and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 3 * 4;
+        long memory_ops = B * T * C * 3 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
         float toks_per_msec = B * T / elapsed_time / 1e3;
 


### PR DESCRIPTION
This allows us to compile a single executable that can serve as test/benchmark for f32, f16, and bf16 versions of the kernels. So far, I've updated only those test files which already defined a BF16 macro.

Caveat:
This will try to compile float, half, and  bfloat16 versions into a single exe, so the compilation fails if any of these isn't available at the moment. This is something we need to improve at some  point, once we have a general strategy in place how to handle older hardware.