### PR TITLE
Fused layernorm residual

### DIFF
--- a/dev/cuda/Makefile
+++ b/dev/cuda/Makefile
@@ -29,6 +29,7 @@ encoder_forward: encoder_forward.cu
 gelu_backward: gelu_backward.cu
 gelu_forward: gelu_forward.cu
 layernorm_forward: layernorm_forward.cu
+fused_residual_forward: fused_residual_forward.cu
 residual_forward: residual_forward.cu
 softmax_forward: softmax_forward.cu
 trimat_forward: trimat_forward.cu

--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -245,14 +245,6 @@ __device__ float warpReduceMax(float val) {
     return val;
 }
 
-// warp-level reduction for summing values
-__device__ float warpReduceSum(float val) {
-    for (int offset = 16; offset > 0; offset /= 2) {
-        val += __shfl_down_sync(0xFFFFFFFF, val, offset);
-    }
-    return val;
-}
-
 __global__ void softmax_forward_kernel4(float* out, const float* inp, int N, int C) {
     // out is (N, C) just like inp. Each row of inp will get softmaxed.
     // same as kernel3, but can handle any block size (multiple of 32)

--- a/dev/cuda/classifier_fused.cu
+++ b/dev/cuda/classifier_fused.cu
@@ -87,14 +87,6 @@ void crossentropy_softmax_backward_cpu(float* dlogits,
 // ----------------------------------------------------
 // Kernel Utils
 
-// warp-level reduction for summing values
-__device__ float warpReduceSum(float val) {
-    for (int offset = 16; offset > 0; offset /= 2) {
-        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
-    }
-    return val;
-}
-
 // warp-level reduction for finding the maximum value
 __device__ float warpReduceMax(float val) {
     for (int offset = 16; offset > 0; offset /= 2) {

--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -56,7 +56,9 @@ int cuda_threads_per_SM = 0;    // needed to calculate how many blocks to launch
 
 template<class ElementType>
 struct alignas(16) Packed128 {
-    __device__ Packed128() = default;
+    // default gives implicit __device__.
+    // Making it explicit causes the compiler to emit warnings, so it is omitted here
+    Packed128() = default;
     __device__ explicit Packed128(int4 bits) {
         static_assert(sizeof(bits) == sizeof(payload), "Size mismatch.");
         memcpy(&payload, &bits, sizeof(bits));
@@ -168,36 +170,10 @@ template<class TargetType>
     return status;
 }
 
-void setup_main() {
-    srand(0);   // determinism
-
-    // set up the device
-    int deviceIdx = 0;
-    cudaCheck(cudaSetDevice(deviceIdx));
-    cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, deviceIdx);
-    cuda_num_SMs = deviceProp.multiProcessorCount;
-    cuda_threads_per_SM = deviceProp.maxThreadsPerMultiProcessor;
-    cuda_arch_major = deviceProp.major;
-    cuda_arch_minor = deviceProp.minor;
-
-    // setup cuBLAS and cuBLASLt
-    cublasCheck(cublasCreate(&cublas_handle));
-    cublasCheck(cublasLtCreate(&cublaslt_handle));
-    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
-
-    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
-    int enable_tf32 = cuda_arch_major >= 8 ? 1 : 0;
-    // TODO implement common CLI for all tests/benchmarks
-    // if (override_enable_tf32 == 0) { enable_tf32 = 0; } // force to zero via arg
-    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
-    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
-    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
-}
-
 template<class D, class T>
-void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements, T tolerance=1e-4) {
-    D* out_gpu = (D*)malloc(num_elements * sizeof(D));
+void validate_result(D* device_result, const T* cpu_reference, const char* name, std::size_t num_elements,
+                     T tolerance = 1e-4) {
+    D* out_gpu = (D*) malloc(num_elements * sizeof(D));
     cudaCheck(cudaMemcpy(out_gpu, device_result, num_elements * sizeof(D), cudaMemcpyDeviceToHost));
     int nfaults = 0;
     for (int i = 0; i < num_elements; i++) {
@@ -208,7 +184,7 @@ void validate_result(D* device_result, const T* cpu_reference, const char* name,
         // ensure correctness for all elements. We can set an "ignore" mask by writing NaN
         if (fabs(cpu_reference[i] - (T)out_gpu[i]) > tolerance && isfinite(cpu_reference[i])) {
             printf("Mismatch of %s at %d: CPU_ref: %f vs GPU: %f\n", name, i, cpu_reference[i], (T)out_gpu[i]);
-            nfaults ++;
+            nfaults++;
             if (nfaults >= 10) {
                 free(out_gpu);
                 exit(EXIT_FAILURE);
@@ -259,3 +235,132 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
 
     return elapsed_time / repeats;
 }
+
+
+// ----------------------------------------------------------------------------
+// common test/benchmark main implementation
+
+// usage: each test/benchmark file needs to provide a kernel dispatch function, whose first argument is a kernel
+//        number, and which will call the correct kernel implementation by passing on all the other arguments.
+//        individual kernels should be implemented as templates over the floating-point types they operate on.
+//        Then, the macro DECLARE_TEST should be called, with the kernel dispatch function as its sole argument.
+//        Next, the IMPLEMENT_TEST macro prepares the implementation of the actual test/benchmark. It is used like
+//        a function declaration, that is, it should be called like `int IMPLEMENT_TEST(int kernel_num) {`.
+//        The `kernel_num` argument contains the requested kernel, and inside the curly braces, a `floatX`
+//        type is available that specifies the requested floating point type.
+// For an explanation how these macros do their magic, see below.
+
+// generic setup function that prepares the device and sets up cublas
+void setup_main() {
+    srand(0);   // determinism
+
+    // set up the device
+    int deviceIdx = 0;
+    cudaCheck(cudaSetDevice(deviceIdx));
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, deviceIdx);
+    cuda_num_SMs = deviceProp.multiProcessorCount;
+    cuda_threads_per_SM = deviceProp.maxThreadsPerMultiProcessor;
+    cuda_arch_major = deviceProp.major;
+    cuda_arch_minor = deviceProp.minor;
+
+    // setup cuBLAS and cuBLASLt
+    cublasCheck(cublasCreate(&cublas_handle));
+    cublasCheck(cublasLtCreate(&cublaslt_handle));
+    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
+
+    // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
+    int enable_tf32 = cuda_arch_major >= 8 ? 1 : 0;
+    // TODO implement common CLI for all tests/benchmarks
+    // if (override_enable_tf32 == 0) { enable_tf32 = 0; } // force to zero via arg
+    cublas_compute_type = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
+    cublasMath_t cublas_math_mode = enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
+    cublasCheck(cublasSetMathMode(cublas_handle, cublas_math_mode));
+}
+
+// this defines the generic structure of the main function. This contains everything we can specify without
+// knowing the actual test, which is communicated through the TestCase class template.
+// Note: Since the TestCase itself has to be a template (needs to run on float, half, bfloat), we get the
+//       `template<class> class TestCase` syntax: TestCase is a class template, that takes a single class (floatX) as its
+//       template parameter.
+// You are not intended to invoke this function manually, nor to write a TestCase yourself; instead, this setup will
+// be handled by the macros below.
+template<template<class> class TestCase>
+int main_fn(int argc, const char** argv) {
+    setup_main();
+
+    // read kernel_num from command line
+    int kernel_num = 1;
+    if (argc > 1) {
+        kernel_num = atoi(argv[1]);
+    }
+    printf("Using kernel %d\n", kernel_num);
+
+    int dtype = 0;
+    if (argc > 2) {
+        if (strcmp(argv[2], "f32") == 0) {
+            dtype = 0;
+        } else if (strcmp(argv[2], "f16") == 0) {
+            dtype = 1;
+        } else if (strcmp(argv[2], "b16") == 0) {
+            dtype = 2;
+        } else {
+            fprintf(stderr, "Invalid dtype %s", argv[2]);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    switch (dtype) {
+        case 0:
+            printf("Using float\n");
+            return TestCase<float>::run(kernel_num);
+        case 1:
+            printf("Using half\n");
+            return TestCase<half>::run(kernel_num);
+        case 2:
+            printf("Using bfloat16\n");
+            return TestCase<nv_bfloat16>::run(kernel_num);
+        default:
+            exit(EXIT_FAILURE);
+    }
+}
+
+// We have one more challenge to overcome: The kernel dispatch function has to be a template,
+// but that prevents us from passing it around as a parameter (cannot take the address of an overloaded function)
+// to the `benchmark_kernel` function above.
+// What we can pass around instead is a function object; but we don't want to require the test files to implement
+// these (which are a bit unnatural, and really just a workaround), so instead we have this macro that creates
+// a helper type `dispatcher_s` whose call operator is just forwarding to the original kernel dispatch.
+#define DECLARE_DISPATCHER(fptr) \
+struct dispatcher_s {            \
+    template<class... Args>         \
+    void operator()(Args&&... args) {   \
+        fptr(std::forward<Args>(args)...);  \
+    }   \
+}; \
+
+// This macro declares the TestCase class. It is templated over the floating-point type `floatX`, and defines a
+// run function to actually run the test.  It also provides a `dispatcher_s` variable of name `dispatcher` (which
+// is the name of the original dispatch function template). Therefore, inside this class, the dispatcher function
+// template is shadowed by the `dispatcher_s` object of the same name, and `benchmark_kernel` calls work seamlessly.
+#define DECLARE_TEST(dispatcher)    \
+DECLARE_DISPATCHER(dispatcher)      \
+template<class floatX>              \
+struct TestCase {                   \
+    using x128 = Packed128<floatX>; \
+    static int run(int kernel_num); \
+    static dispatcher_s dispatcher; \
+}
+
+
+// Finally, the actual test implementation. This macro is designed to have minimal syntax effect, to make it look as
+// close to a "regular" test function. Therefore, the implementation below does not specify `int main` but just main---
+// the `int` part is expected to be provided as part of the macro invocation in the test file. Similarly, we do not
+// auto-generate the `int kernel_num` parameter, but instead expect it to be given as "function arguments" to the macro.
+// Thus, in the test file, the only thing that "magically" appears is the floatX type.
+#define IMPLEMENT_TEST(...)                 \
+main(int argc, const char** argv) {     \
+    return main_fn<TestCase>(argc, argv);   \
+}                                           \
+template<class floatX>                      \
+int TestCase<floatX>::run(__VA_ARGS__)

--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -10,6 +10,13 @@ __host__ __device__ T ceil_div(T dividend, T divisor) {
     return (dividend + divisor-1) / divisor;
 }
 
+__device__ float warpReduceSum(float val) {
+    for (int offset = 16; offset > 0; offset /= 2) {
+        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
+    }
+    return val;
+}
+
 // ----------------------------------------------------------------------------
 // checking utils
 

--- a/dev/cuda/encoder_forward.cu
+++ b/dev/cuda/encoder_forward.cu
@@ -20,22 +20,6 @@ version 3 is like version 2 but uses float4 reads/writes
 #include "common.h"
 #include <cassert>
 
-// turn on bf16 as default, done up here for now
-#define ENABLE_BF16
-
-#if defined(ENABLE_BF16)
-typedef __nv_bfloat16 floatX;
-typedef __nv_bfloat16 floatN;
-#elif defined(ENABLE_FP16)
-typedef half floatX;
-typedef half floatN;
-#else
-typedef float floatX;
-typedef float floatN;
-#endif
-
-typedef Packed128<floatX> x128;
-
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -60,6 +44,7 @@ void encoder_forward_cpu(float* out,
 // GPU kernels
 
 // naive implementation into kernel, parallelize over B,T, loop over C
+template<typename floatX>
 __global__ void encoder_forward_kernel1(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
@@ -80,6 +65,7 @@ __global__ void encoder_forward_kernel1(floatX* out,
 }
 
 // optimized implementation: parallelize over all of B,T,C
+template<typename floatX>
 __global__ void encoder_forward_kernel2(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
@@ -101,9 +87,11 @@ __global__ void encoder_forward_kernel2(floatX* out,
     }
 }
 
+template<typename floatX>
 __global__ void encoder_forward_kernel3(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
                                int B, int T, int C) {
+    using x128 = Packed128<floatX>;
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     int N = B * T * C;
     if (idx < N) {
@@ -132,6 +120,7 @@ __global__ void encoder_forward_kernel3(floatX* out,
 // ----------------------------------------------------------------------------
 // kernel launcher
 
+template<typename floatX>
 void encoder_forward1(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
@@ -142,6 +131,7 @@ void encoder_forward1(floatX* out,
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void encoder_forward2(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
@@ -152,17 +142,19 @@ void encoder_forward2(floatX* out,
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void encoder_forward3(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
                      int B, int T, int C,
                      const int block_size) {
     const int N = B * T * C;
-    const int grid_size = ceil_div(N, (int)(block_size * x128::size));
+    const int grid_size = ceil_div(N, (int)(block_size * Packed128<floatX>::size));
     encoder_forward_kernel3<<<grid_size, block_size>>>(out, inp, wte, wpe, B, T, C);
     cudaCheck(cudaGetLastError());
 }
 
 // kernel version dispatch
+template<typename floatX>
 void encoder_forward(int kernel_num,
                      floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,
@@ -186,16 +178,13 @@ void encoder_forward(int kernel_num,
 
 // ----------------------------------------------------------------------------
 
-int main(int argc, char **argv) {
-    setup_main();
+DECLARE_TEST(encoder_forward);
 
+int IMPLEMENT_TEST(int kernel_num) {
     int B = 8;
     int T = 1024;
     int C = 768;
     int V = 50257;
-
-    int deviceIdx = 0;
-    cudaCheck(cudaSetDevice(deviceIdx));
 
     // create host memory of random numbers
     float* out = (float*)malloc(B * T * C * sizeof(float));
@@ -216,13 +205,6 @@ int main(int argc, char **argv) {
     cudaCheck(memcpy_convert(d_wte, wte, V * C));
     cudaCheck(memcpy_convert(d_wpe, wpe, T * C));
 
-    // read kernel_num from command line
-    int kernel_num = 2;
-    if (argc > 1) {
-        kernel_num = atoi(argv[1]);
-    }
-    printf("Using kernel %d\n", kernel_num);
-
     // first check the correctness of the kernel
     encoder_forward_cpu(out, inp, wte, wpe, B, T, C);
 
@@ -233,11 +215,7 @@ int main(int argc, char **argv) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
         encoder_forward(kernel_num, d_out, d_inp, d_wte, d_wpe, B, T, C, block_size);
-#if !defined(ENABLE_BF16) && !defined(ENABLE_FP16)
-        float tol = 1e-5;
-#else
-        float tol = 1e-2f;
-#endif
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
         validate_result(d_out, out, "out", B * T * C, tol);
     }
 
@@ -252,12 +230,14 @@ int main(int argc, char **argv) {
                                               );
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 3 reads and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 3 reads and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 4 * 4;
+        long memory_ops = B * T * C * 4 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
-        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/fused_residual_forward.cu
+++ b/dev/cuda/fused_residual_forward.cu
@@ -284,7 +284,7 @@ __global__ void fused_residual_forward_kernel5(floatX* residual, floatX* normed,
 
     // load weights and biases into shared memory
     // do this before we allow any threads to exit!
-    extern __shared__ char* params[];
+    extern __shared__ char params[];
     // load128/store128 sometimes generated multiple instructions when the types here were floatX*, so
     // let's keep everything as x128
     x128* s_weight = reinterpret_cast<x128*>(params);
@@ -356,8 +356,12 @@ __global__ void fused_residual_forward_kernel5(floatX* residual, floatX* normed,
 }
 
 
-// one thread-block per token; much more smem friendly, but quite inefficient for small C (768).
-// probably a good idea once C gets larger, though.
+// using multiple warps per token, and keep threads persistent, so we never have to reload weights and biases
+// if we had one warp per token, though, this would require us to use a huge amount of shared memory. Therefore,
+// we use multiple warps per token; but generally we cannot use the entire block, because that would give too
+// little work per warp to be effective (each warp processes 256 bfloat16 elements, so for C=768 more than 3 warps
+// will just mean idle). Therefore, we add a z dimension, where warps with different z handle different tokens.
+// all this makes the launcher logic more complicated :(
 template<typename floatX>
 __global__ void fused_residual_forward_kernel6(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
                                                const floatX* inp1, const floatX* inp2,
@@ -369,14 +373,17 @@ __global__ void fused_residual_forward_kernel6(floatX* residual, floatX* normed,
 
     // load weights and biases into shared memory
     // do this before we allow any threads to exit!
-    __shared__ float s_mean[32];
-    __shared__ float s_var[32];
-    extern __shared__ char* params[];
+    extern __shared__ char params[];
     // load128/store128 sometimes generated multiple instructions when the types here were floatX*, so
     // let's keep everything as x128
+    // weights and biases are  shared among all tokens
     x128* s_weight = reinterpret_cast<x128*>(params);
-    x128* s_bias = reinterpret_cast<x128*>(params) + (C / x128::size);
-    x128* s_res = reinterpret_cast<x128*>(params) + (2 * C / x128::size);
+    x128* s_bias = reinterpret_cast<x128*>(params + C * sizeof(floatX));
+    // residual output (input to layernorm) is indpendent for each sub-block indicates by threadIdx.z
+    x128* s_res = reinterpret_cast<x128*>(params + (2 + threadIdx.z) * C * sizeof(floatX)  );
+    // similarly, each sub-block needs its own reduction buffers
+    float* s_mean = reinterpret_cast<float*>(params + (2 + blockDim.z) * C * sizeof(floatX) + threadIdx.z * 32 * sizeof(float));
+    float* s_var = reinterpret_cast<float*>(params + (2 + blockDim.z) * C * sizeof(floatX) + 32 * sizeof(float) * (blockDim.z + threadIdx.z));
 
     int cidx = (threadIdx.x + WarpSize * threadIdx.y) * x128::size;
     int step = blockDim.y * WarpSize * x128::size;
@@ -389,7 +396,7 @@ __global__ void fused_residual_forward_kernel6(floatX* residual, floatX* normed,
     // => no syncthreads needed here
 
     // loop over all tokens
-    for(int tidx = blockIdx.x; tidx < N; tidx += gridDim.x) {
+    for(int tidx = blockIdx.x * blockDim.z + blockIdx.z; tidx < N; tidx += gridDim.x * blockDim.z) {
         // adjust pointers to current token
         floatX* residual_bt = residual + C * tidx;
         floatX* normed_bt = normed + C * tidx;
@@ -415,6 +422,9 @@ __global__ void fused_residual_forward_kernel6(floatX* residual, floatX* normed,
         }
         __syncthreads();
         float m = warpReduceSum(threadIdx.x < blockDim.y ? s_mean[threadIdx.x] : 0.f) / C;
+        // normally, we'd syncthread here to make sure that no warp is already at the next
+        // iteration of the loop, messing with s_mean. The fact that we interleave s_mean and s_var means
+        // we don't need these additional syncs.
         float v = 0.f;
 
         for (int c = cidx; c < C; c += step) {
@@ -532,8 +542,11 @@ void fused_residual_forward6(floatX* residual, floatX* normed, floatX* mean, flo
                              const floatX* inp1, const floatX* inp2,
                              const floatX* weight, const floatX* bias,
                              int N, int C, const int block_size) {
-    int block_y = block_size / 32;
-    size_t smem = 3 * C * sizeof(floatX);
+    int warps_per_token = max(1, C / Packed128<floatX>::size / 32 / 2);
+    int total_warps = block_size / 32;
+    int block_z = max(1, total_warps / warps_per_token);
+    int block_y = max(1, total_warps / block_z);
+    size_t smem = (2 + block_z) * C * sizeof(floatX) + 64 * sizeof(float) * block_z;
 
     // in order to use more than 48 KiB of smem, need to call cudaFuncSetAttribute
     // this may fail, in which case we fall back to the smem free implementation.
@@ -542,11 +555,11 @@ void fused_residual_forward6(floatX* residual, floatX* normed, floatX* mean, flo
     cudaGetLastError();
     if(status == cudaSuccess) {
         const int num_blocks = max(1, cuda_threads_per_SM * cuda_num_SMs / block_size);
-        fused_residual_forward_kernel6<<<num_blocks, dim3(32, block_y), smem>>>(residual, normed, mean, rstd, inp1, inp2,
+        fused_residual_forward_kernel6<<<num_blocks, dim3(32, block_y, block_z), smem>>>(residual, normed, mean, rstd, inp1, inp2,
                                                                                weight, bias, N, C);
     } else {
-        const int grid_size = ceil_div(N, block_y);
-        fused_residual_forward_kernel4<<<grid_size, dim3(32, block_y)>>>(residual, normed, mean, rstd, inp1, inp2,
+        const int grid_size = ceil_div(N, total_warps);
+        fused_residual_forward_kernel4<<<grid_size, dim3(32, total_warps)>>>(residual, normed, mean, rstd, inp1, inp2,
                                                                          weight, bias, N, C);
     }
     cudaCheck(cudaGetLastError());
@@ -636,7 +649,7 @@ int IMPLEMENT_TEST(int kernel_num) {
         printf("Checking block size %d.\n", block_size);
         fused_residual_forward(kernel_num, d_residual, d_normed, d_mean, d_rstd, d_inp1, d_inp2, d_weight, d_bias,
                                B*T, C, block_size);
-        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 5e-2;
         validate_result(d_residual, residual, "residual", B * T * C, tol);
         validate_result(d_mean, mean, "mean", B * T, tol);
         validate_result(d_rstd, rstd, "rstd", B * T, tol);
@@ -655,7 +668,7 @@ int IMPLEMENT_TEST(int kernel_num) {
                                               );
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 2 read and 2 writes, plus 2 BT writes for mean/rstd
+        // for each (B,T,C) output element, we do 2 reads and 2 writes, plus 2 BT writes for mean/rstd
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
         long memory_ops = B * T * (C * 4 + 2) * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;

--- a/dev/cuda/fused_residual_forward.cu
+++ b/dev/cuda/fused_residual_forward.cu
@@ -1,0 +1,687 @@
+/*
+Kernels for residual forward pass fused with layernorm
+
+Compile example:
+nvcc -O3 --use_fast_math fused_residual_forward.cu -o fused_residual_forward
+
+version 1 is naive port from CPU code to kernel
+./fused_residual_forward 1
+version 2 packs input into 128 bit memory reads
+./fused_residual_forward 2
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "assert.h"
+#include <cuda_runtime.h>
+#include "common.h"
+
+// ----------------------------------------------------------------------------
+// CPU code reference lol
+
+void residual_forward_cpu(float* out, const float* inp1, const float* inp2, int N) {
+    for (int i = 0; i < N; i++) {
+        out[i] = inp1[i] + inp2[i];
+    }
+}
+
+void layernorm_forward_cpu(float* out, float* mean, float* rstd,
+                           const float* inp, const float* weight, const float* bias,
+                           int B, int T, int C) {
+    float eps = 1e-5f;
+    for (int b = 0; b < B; b++) {
+        for (int t = 0; t < T; t++) {
+            // seek to the input position inp[b,t,:]
+            const float* x = inp + b * T * C + t * C;
+            // calculate the mean
+            float m = 0.0f;
+            for (int i = 0; i < C; i++) {
+                m += x[i];
+            }
+            m = m/C;
+            // calculate the variance (without any bias correction)
+            float v = 0.0f;
+            for (int i = 0; i < C; i++) {
+                float xshift = x[i] - m;
+                v += xshift * xshift;
+            }
+            v = v/C;
+            // calculate the rstd
+            float s = 1.0f / sqrtf(v + eps);
+            // seek to the output position in out[b,t,:]
+            float* out_bt = out + b * T * C + t * C;
+            for (int i = 0; i < C; i++) {
+                float n = (s * (x[i] - m)); // normalized output
+                float o = n * weight[i] + bias[i]; // scale and shift it
+                out_bt[i] = o; // write
+            }
+            // cache the mean and rstd for the backward pass later
+            mean[b * T + t] = m;
+            rstd[b * T + t] = s;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// GPU kernels
+
+// elementwise ops are nice and ez
+template<typename floatX>
+__global__ void residual_forward_kernel1(floatX* out, const floatX* inp1, const floatX* inp2, int N) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < N) {
+        out[idx] = (floatX)((float)inp1[idx] + (float)inp2[idx]);
+    }
+}
+
+// naive drag and drop implementation into kernel, parallelize over B,T, loop over C
+template<typename floatX>
+__global__ void layernorm_forward_kernel1(floatX* out, floatX* mean, floatX* rstd,
+                                          const floatX* inp, const floatX* weight, const floatX* bias,
+                                          int N, int C) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    float eps = 1e-5f;
+
+    if (idx < N) {
+        // seek to the input position inp[idx,:]
+        const floatX* x = inp + idx * C;
+        // calculate the mean
+        float m = 0.0f;
+        for (int i = 0; i < C; i++) {
+            m += (float)x[i];
+        }
+        m = m / C;
+        // calculate the variance (without any bias correction)
+        float v = 0.0f;
+        for (int i = 0; i < C; i++) {
+            float xshift = (float)x[i] - m;
+            v += xshift * xshift;
+        }
+        v = v / C;
+        // calculate the rstd
+        float s = 1.0f / sqrtf(v + eps);
+        // seek to the output position in out[idx,:]
+        floatX* out_idx = out + idx * C;
+        for (int i = 0; i < C; i++) {
+            float n = (s * ((float)x[i] - m)); // normalized output
+            float o = n * (float)weight[i] + (float)bias[i]; // scale and shift it
+            out_idx[i] = o; // write
+        }
+        // cache the mean and rstd for the backward pass later
+        mean[idx] = m;
+        rstd[idx] = s;
+    }
+}
+
+// naive fusion; uncoalesced access pattern leads to terrible performance
+template<typename floatX>
+__global__ void fused_residual_forward2(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                        const floatX* inp1, const floatX* inp2,
+                                        const floatX* weight, const floatX* bias,
+                                        int N, int C) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx > N) return;
+
+    // adjust pointers to current token
+    residual += C * idx;
+    normed += C * idx;
+    inp1 += C * idx;
+    inp2 += C * idx;
+
+    float eps = 1e-5f;
+
+    float m = 0.0f;
+    for(int c = 0; c < C; ++c) {
+        float out = (float)inp1[c] + (float)inp2[c];
+        m += out;
+        residual[c] = out;
+    }
+
+    m = m / C;
+    float v = 0.0f;
+    for (int c = 0; c < C; c++) {
+        float xshift = (float)residual[c] - m;
+        v += xshift * xshift;
+    }
+    v = v / C;
+
+    // calculate the rstd
+    float s = 1.0f / sqrtf(v + eps);
+    for (int c = 0; c < C; c++) {
+        float n = (s * ((float)residual[c] - m)); // normalized output
+        float o = n * (float)weight[c] + (float)bias[c]; // scale and shift it
+        normed[c] = o; // write
+    }
+    // cache the mean and rstd for the backward pass later
+    mean[idx] = m;
+    rstd[idx] = s;
+}
+
+// handle one token per warp for coalesced access
+template<typename floatX>
+__global__ void fused_residual_forward3(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                        const floatX* inp1, const floatX* inp2,
+                                        const floatX* weight, const floatX* bias,
+                                        int N, int C) {
+    constexpr const int WarpSize = 32;
+    assert(blockDim.x == WarpSize);
+    int idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if(idx > N) return;
+
+    // adjust pointers to current token
+    residual += C * idx;
+    normed += C * idx;
+    inp1 += C * idx;
+    inp2 += C * idx;
+
+    float eps = 1e-5f;
+    float m = 0.0f;
+    for(int c = threadIdx.x; c < C; c += WarpSize) {
+        float out = (float)inp1[c] + (float)inp2[c];
+        m += out;
+        residual[c] = out;
+    }
+
+    m = warpReduceSum(m);
+
+    m = m / C;
+    float v = 0.0f;
+    for(int c = threadIdx.x; c < C; c += WarpSize) {
+        float xshift = (float)residual[c] - m;
+        v += xshift * xshift;
+    }
+
+    v = warpReduceSum(v);
+    v = v / C;
+
+    // calculate the rstd
+    float s = 1.0f / sqrtf(v + eps);
+    for(int c = threadIdx.x; c < C; c += WarpSize) {
+        float n = (s * ((float)residual[c] - m)); // normalized output
+        float o = n * (float)weight[c] + (float)bias[c]; // scale and shift it
+        normed[c] = o; // write
+    }
+    // cache the mean and rstd for the backward pass later
+    if(threadIdx.x == 0) {
+        mean[idx] = m;
+        rstd[idx] = s;
+    }
+}
+
+// vectorized loading, single pass stats, streaming access and zigzag loop
+template<typename floatX>
+__global__ void fused_residual_forward_kernel4(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                               const floatX* inp1, const floatX* inp2,
+                                               const floatX* weight, const floatX* bias,
+                                               int N, int C) {
+    using x128 = Packed128<floatX>;
+    constexpr const int WarpSize = 32;
+    assert(blockDim.x == WarpSize);
+    int idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if(idx > N) return;
+
+    // adjust pointers to current token
+    residual += C * idx;
+    normed += C * idx;
+    inp1 += C * idx;
+    inp2 += C * idx;
+
+    const float eps = 1e-5f;
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+    int c = threadIdx.x * x128::size;
+    for(; c < C; c += WarpSize * x128::size) {
+        const x128 in1 = load128cs(inp1 + c);
+        const x128 in2 = load128cs(inp2 + c);
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            out[k] = (float)in1[k] + (float)in2[k];
+            sum += (float)out[k];
+            sum_sq += (float)out[k] * (float)out[k];
+        }
+        store128(residual + c, out);
+    }
+
+    sum = warpReduceSum(sum);
+    sum_sq = warpReduceSum(sum_sq);
+
+    float m = sum / C;
+    float v = sum_sq / C - m * m;
+    float s = rsqrtf(v + eps);
+
+    c -= WarpSize * x128::size;
+    for(; c >= 0; c -= WarpSize * x128::size) {
+        const x128 res = load128cs(residual + c);
+        const x128 w = load128(weight + c);
+        const x128 b = load128(bias + c);
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            float n = s * ((float)res[k] - m); // normalized output
+            float o = n * (float)w[k] + (float)b[k]; // scale and shift it
+            out[k] = o;
+        }
+
+        store128cs(normed + c, out);
+    }
+    // cache the mean and rstd for the backward pass later
+    if(threadIdx.x == 0) {
+        mean[idx] = m;
+        rstd[idx] = s;
+    }
+}
+
+// what do you want in shared memory? EVERYTHING!
+// thus, we no longer require zigzag loops and can do the numerically more stable variance estimation
+// needs special attention in the kernel launcher to ensure we have enough smem.
+template<typename floatX>
+__global__ void fused_residual_forward_kernel5(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                               const floatX* inp1, const floatX* inp2,
+                                               const floatX* weight, const floatX* bias,
+                                               int N, int C) {
+    using x128 = Packed128<floatX>;
+    constexpr const int WarpSize = 32;
+    assert(blockDim.x == WarpSize);
+
+    // load weights and biases into shared memory
+    // do this before we allow any threads to exit!
+    extern __shared__ char* params[];
+    // load128/store128 sometimes generated multiple instructions when the types here were floatX*, so
+    // let's keep everything as x128
+    x128* s_weight = reinterpret_cast<x128*>(params);
+    x128* s_bias = reinterpret_cast<x128*>(params) + (C / x128::size);
+    x128* s_res = reinterpret_cast<x128*>(params) + ((2 + threadIdx.y) * C / x128::size);
+
+    int sidx = (threadIdx.x + WarpSize * threadIdx.y) * x128::size;
+    for(int i = sidx; i < C; i += blockDim.y * WarpSize * x128::size) {
+        s_weight[i/x128::size] = load128(weight + i);
+        s_bias[i/x128::size] = load128(bias + i);
+    }
+    __syncthreads();
+
+    int idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if(idx > N) return;
+
+    // adjust pointers to current token
+    residual += C * idx;
+    normed += C * idx;
+    inp1 += C * idx;
+    inp2 += C * idx;
+
+    const float eps = 1e-5f;
+    float sum = 0.0f;
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 in1 = load128cs(inp1 + c);
+        const x128 in2 = load128cs(inp2 + c);
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            out[k] = (float)in1[k] + (float)in2[k];
+            sum += (float)out[k];
+        }
+        store128cs(residual + c, out);
+        s_res[c / x128::size] = out;
+    }
+
+    sum = warpReduceSum(sum);
+    float m = sum / C;
+    float v = 0.f;
+
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 res = s_res[c / x128::size];
+        for(int k = 0; k < x128::size; ++k) {
+            v += ((float)res[k] - m) * ((float)res[k] - m);
+        }
+    }
+
+    v = warpReduceSum(v) / C;
+    float s = rsqrtf(v + eps);
+
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 res = s_res[c / x128::size];
+        const x128 w = s_weight[c / x128::size];
+        const x128 b = s_bias[c / x128::size];
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            float n = s * ((float)res[k] - m); // normalized output
+            float o = n * (float)w[k] + (float)b[k]; // scale and shift it
+            out[k] = o;
+        }
+
+        store128cs(normed + c, out);
+    }
+    // cache the mean and rstd for the backward pass later
+    if(threadIdx.x == 0) {
+        mean[idx] = m;
+        rstd[idx] = s;
+    }
+}
+
+
+// one thread-block per token; much more smem friendly, but quite inefficient for small C (768).
+// probably a good idea once C gets larger, though.
+template<typename floatX>
+__global__ void fused_residual_forward_kernel6(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                               const floatX* inp1, const floatX* inp2,
+                                               const floatX* weight, const floatX* bias,
+                                               int N, int C) {
+    using x128 = Packed128<floatX>;
+    constexpr const int WarpSize = 32;
+    assert(blockDim.x == WarpSize);
+
+    // load weights and biases into shared memory
+    // do this before we allow any threads to exit!
+    __shared__ float s_mean[32];
+    __shared__ float s_var[32];
+    extern __shared__ char* params[];
+    // load128/store128 sometimes generated multiple instructions when the types here were floatX*, so
+    // let's keep everything as x128
+    x128* s_weight = reinterpret_cast<x128*>(params);
+    x128* s_bias = reinterpret_cast<x128*>(params) + (C / x128::size);
+    x128* s_res = reinterpret_cast<x128*>(params) + (2 * C / x128::size);
+
+    int cidx = (threadIdx.x + WarpSize * threadIdx.y) * x128::size;
+    int step = blockDim.y * WarpSize * x128::size;
+
+    for(int c = cidx; c < C; c += step) {
+        s_weight[c / x128::size] = load128(weight + c);
+        s_bias[c / x128::size] = load128(bias + c);
+    }
+    // the block-level reductions will cause sync before the first time we read these
+    // => no syncthreads needed here
+
+    // loop over all tokens
+    for(int tidx = blockIdx.x; tidx < N; tidx += gridDim.x) {
+        // adjust pointers to current token
+        floatX* residual_bt = residual + C * tidx;
+        floatX* normed_bt = normed + C * tidx;
+        const floatX* inp1_bt = inp1 + C * tidx;
+        const floatX* inp2_bt = inp2 + C * tidx;
+
+        const float eps = 1e-5f;
+        float sum = 0.0f;
+        for (int c = cidx; c < C; c += step) {
+            const x128 in1 = load128cs(inp1_bt + c);
+            const x128 in2 = load128cs(inp2_bt + c);
+            x128 out;
+            for (int k = 0; k < x128::size; ++k) {
+                out[k] = (float) in1[k] + (float) in2[k];
+                sum += (float) out[k];
+            }
+            store128cs(residual_bt + c, out);
+            s_res[c / x128::size] = out;
+        }
+        sum = warpReduceSum(sum);
+        if(threadIdx.x == 0) {
+            s_mean[threadIdx.y] = sum;
+        }
+        __syncthreads();
+        float m = warpReduceSum(threadIdx.x < blockDim.y ? s_mean[threadIdx.x] : 0.f) / C;
+        float v = 0.f;
+
+        for (int c = cidx; c < C; c += step) {
+            const x128 res = s_res[c / x128::size];
+            for (int k = 0; k < x128::size; ++k) {
+                v += ((float) res[k] - m) * ((float) res[k] - m);
+            }
+        }
+
+        v = warpReduceSum(v);
+        if(threadIdx.x == 0) {
+            s_var[threadIdx.y] = v;
+        }
+        __syncthreads();
+        v = warpReduceSum(threadIdx.x < blockDim.y ? s_var[threadIdx.x] : 0.f) / C;
+        float s = rsqrtf(v + eps);
+
+        for (int c = cidx; c < C; c += step) {
+            const x128 res = s_res[c / x128::size];
+            const x128 w = s_weight[c / x128::size];
+            const x128 b = s_bias[c / x128::size];
+            x128 out;
+            for (int k = 0; k < x128::size; ++k) {
+                float n = s * ((float) res[k] - m); // normalized output
+                float o = n * (float) w[k] + (float) b[k]; // scale and shift it
+                out[k] = o;
+            }
+
+            store128(normed_bt + c, out);
+        }
+        // cache the mean and rstd for the backward pass later
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            mean[tidx] = m;
+            rstd[tidx] = s;
+        }
+    }
+}
+
+
+
+// ----------------------------------------------------------------------------
+// kernel launcher
+
+template<typename floatX>
+void fused_residual_forward1(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    const int grid_size_resid = ceil_div(N * C, block_size);
+    residual_forward_kernel1<<<grid_size_resid, block_size>>>(residual, inp1, inp2, N*C);
+    cudaCheck(cudaGetLastError());
+    const int grid_size_ln = ceil_div(N, block_size);
+    layernorm_forward_kernel1<<<grid_size_ln, block_size>>>(normed, mean, rstd, residual, weight, bias, N, C);
+    cudaCheck(cudaGetLastError());
+}
+
+template<typename floatX>
+void fused_residual_forward2(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    const int grid_size = ceil_div(N, (int)(block_size));
+    fused_residual_forward2<<<grid_size, block_size>>>(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C);
+    cudaCheck(cudaGetLastError());
+}
+
+template<typename floatX>
+void fused_residual_forward3(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    int block_y = block_size / 32;
+    const int grid_size = ceil_div(N, block_y);
+    fused_residual_forward3<<<grid_size, dim3(32, block_y)>>>(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C);
+    cudaCheck(cudaGetLastError());
+}
+
+template<typename floatX>
+void fused_residual_forward4(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    int block_y = block_size / 32;
+    const int grid_size = ceil_div(N, block_y);
+    fused_residual_forward_kernel4<<<grid_size, dim3(32, block_y)>>>(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C);
+    cudaCheck(cudaGetLastError());
+}
+
+template<typename floatX>
+void fused_residual_forward5(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    int block_y = block_size / 32;
+    const int grid_size = ceil_div(N, block_y);
+    size_t smem = (2 + block_y) * C * sizeof(floatX);
+
+    // in order to use more than 48 KiB of smem, need to call cudaFuncSetAttribute
+    // this may fail, in which case we fall back to the smem free implementation.
+    cudaCheck(cudaGetLastError());
+    auto status = cudaFuncSetAttribute(fused_residual_forward_kernel5<floatX>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    cudaGetLastError();
+    if(status == cudaSuccess) {
+        fused_residual_forward_kernel5<<<grid_size, dim3(32, block_y), smem>>>(residual, normed, mean, rstd, inp1, inp2,
+                                                                               weight, bias, N, C);
+    } else {
+        fused_residual_forward_kernel4<<<grid_size, dim3(32, block_y)>>>(residual, normed, mean, rstd, inp1, inp2,
+                                                                         weight, bias, N, C);
+    }
+    cudaCheck(cudaGetLastError());
+}
+
+template<typename floatX>
+void fused_residual_forward6(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C, const int block_size) {
+    int block_y = block_size / 32;
+    size_t smem = 3 * C * sizeof(floatX);
+
+    // in order to use more than 48 KiB of smem, need to call cudaFuncSetAttribute
+    // this may fail, in which case we fall back to the smem free implementation.
+    cudaCheck(cudaGetLastError());
+    auto status = cudaFuncSetAttribute(fused_residual_forward_kernel6<floatX>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    cudaGetLastError();
+    if(status == cudaSuccess) {
+        const int num_blocks = max(1, cuda_threads_per_SM * cuda_num_SMs / block_size);
+        fused_residual_forward_kernel6<<<num_blocks, dim3(32, block_y), smem>>>(residual, normed, mean, rstd, inp1, inp2,
+                                                                               weight, bias, N, C);
+    } else {
+        const int grid_size = ceil_div(N, block_y);
+        fused_residual_forward_kernel4<<<grid_size, dim3(32, block_y)>>>(residual, normed, mean, rstd, inp1, inp2,
+                                                                         weight, bias, N, C);
+    }
+    cudaCheck(cudaGetLastError());
+}
+
+// kernel version dispatch
+template<typename floatX>
+void fused_residual_forward(int kernel_num, floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                            const floatX* inp1, const floatX* inp2,
+                            const floatX* weight, const floatX* bias,
+                            int N, int C, const int block_size) {
+    switch (kernel_num) {
+        case 1:
+            fused_residual_forward1(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        case 2:
+            fused_residual_forward2(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        case 3:
+            fused_residual_forward3(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        case 4:
+            fused_residual_forward4(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        case 5:
+            fused_residual_forward5(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        case 6:
+            fused_residual_forward6(residual, normed, mean, rstd, inp1, inp2, weight, bias, N, C, block_size);
+            break;
+        default:
+            printf("Invalid kernel number\n");
+            exit(1);
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+DECLARE_TEST(fused_residual_forward);
+
+int IMPLEMENT_TEST(int kernel_num) {
+    int B = 8;
+    int T = 1024;
+    int C = 768;
+
+    // create host memory of random numbers
+    float* residual = (float*)malloc(B * T * C * sizeof(float));
+    float* normed = (float*)malloc(B * T * C * sizeof(float));
+    float* inp1 = make_random_float(B * T * C);
+    float* inp2 = make_random_float(B * T * C);
+    float* mean = (float*)malloc(B * T * sizeof(float));
+    float* rstd = (float*)malloc(B * T * sizeof(float));
+    float* weight = make_random_float(C);
+    float* bias = make_random_float(C);
+    
+    // move to GPU
+    floatX* d_residual;
+    floatX* d_normed;
+    floatX* d_inp1;
+    floatX* d_inp2;
+    floatX* d_mean;
+    floatX* d_rstd;
+    floatX* d_weight;
+    floatX* d_bias;
+    cudaCheck(cudaMalloc(&d_residual, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_normed, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_inp1, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_inp2, B * T * C * sizeof(floatX)));
+    cudaCheck(cudaMalloc(&d_mean, B * T * sizeof(float)));
+    cudaCheck(cudaMalloc(&d_rstd, B * T * sizeof(float)));
+    cudaCheck(cudaMalloc(&d_weight, C * sizeof(float)));
+    cudaCheck(cudaMalloc(&d_bias, C * sizeof(float)));
+    cudaCheck(memcpy_convert(d_inp1, inp1, B * T * C));
+    cudaCheck(memcpy_convert(d_inp2, inp2, B * T * C));
+    cudaCheck(memcpy_convert(d_weight, weight, C));
+    cudaCheck(memcpy_convert(d_bias, bias, C));
+
+    // first check the correctness of the kernel
+    residual_forward_cpu(residual, inp1, inp2, B * T * C);
+    layernorm_forward_cpu(normed, mean, rstd, residual, weight, bias, B, T, C);
+
+    // time the kernel at different block sizes
+    int block_sizes[] = {32, 64, 128, 256, 512, 1024};
+
+    for (int j = 0; j < sizeof(block_sizes) / sizeof(int); j++) {
+        int block_size = block_sizes[j];
+        printf("Checking block size %d.\n", block_size);
+        fused_residual_forward(kernel_num, d_residual, d_normed, d_mean, d_rstd, d_inp1, d_inp2, d_weight, d_bias,
+                               B*T, C, block_size);
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
+        validate_result(d_residual, residual, "residual", B * T * C, tol);
+        validate_result(d_mean, mean, "mean", B * T, tol);
+        validate_result(d_rstd, rstd, "rstd", B * T, tol);
+        validate_result(d_normed, normed, "normed", B * T * C, tol);
+    }
+
+    printf("All results match. Starting benchmarks.\n\n");
+
+    for (int j = 0; j < sizeof(block_sizes) / sizeof(int); j++) {
+        int block_size = block_sizes[j];
+
+        int repeat_times = 1000;
+        float elapsed_time = benchmark_kernel(repeat_times, fused_residual_forward, kernel_num,
+                                              d_residual, d_normed, d_mean, d_rstd, d_inp1, d_inp2, d_weight, d_bias,
+                                              B*T, C, block_size
+                                              );
+
+        // napkin math: estimate the memory bandwidth achieved
+        // for each (B,T,C) output element, we do 2 read and 2 writes, plus 2 BT writes for mean/rstd
+        // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
+        long memory_ops = B * T * (C * 4 + 2) * sizeof(floatX);
+        float memory_bandwidth = memory_ops / elapsed_time / 1e6;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
+
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
+    }
+
+    // free memory
+    free(residual);
+    free(normed);
+    free(mean);
+    free(rstd);
+    free(weight);
+    free(bias);
+    free(inp1);
+    free(inp2);
+    cudaCheck(cudaFree(d_residual));
+    cudaCheck(cudaFree(d_normed));
+    cudaCheck(cudaFree(d_mean));
+    cudaCheck(cudaFree(d_rstd));
+    cudaCheck(cudaFree(d_weight));
+    cudaCheck(cudaFree(d_bias));
+    cudaCheck(cudaFree(d_inp1));
+    cudaCheck(cudaFree(d_inp2));
+
+    return 0;
+}

--- a/dev/cuda/gelu_backward.cu
+++ b/dev/cuda/gelu_backward.cu
@@ -21,22 +21,6 @@ version 2 uses the Packed128 data structure
 #include <cuda_runtime.h>
 #include "common.h"
 
-// turn on bf16 as default, done up here for now
-#define ENABLE_BF16
-
-#if defined(ENABLE_BF16)
-typedef __nv_bfloat16 floatX;
-typedef __nv_bfloat16 floatN;
-#elif defined(ENABLE_FP16)
-typedef half floatX;
-typedef half floatN;
-#else
-typedef float floatX;
-typedef float floatN;
-#endif
-
-typedef Packed128<floatX> x128;
-
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -51,7 +35,7 @@ void gelu_backward_cpu(float* dinp, const float* inp, const float* dout, const i
         float coshf_out = coshf(tanh_arg);
         float sech_out = 1.0f / (coshf_out * coshf_out);
         float local_grad = 0.5f * (1.0f + tanh_out) + x * 0.5f * sech_out * GELU_SCALING_FACTOR * (1.0f + 3.0f * 0.044715f * x * x);
-        dinp[i] = (floatX)(local_grad * (float)dout[i]);
+        dinp[i] = local_grad * (float)dout[i];
     }
 }
 
@@ -59,6 +43,7 @@ void gelu_backward_cpu(float* dinp, const float* inp, const float* dout, const i
 // GPU kernels
 
 // elementwise ops are nice and ez
+template<typename floatX>
 __global__ void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* dout, int N) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < N) {
@@ -73,7 +58,9 @@ __global__ void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* do
     }
 }
 
+template<typename floatX>
 __global__ void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* dout, const int N) {
+    using x128 = Packed128<floatX>;
     int i = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     if (i < N) {
         x128 packed_dinp;
@@ -97,19 +84,22 @@ __global__ void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* do
 // ----------------------------------------------------------------------------
 // kernel launcher
 
+template<typename floatX>
 void gelu_backward1(floatX* dinp, const floatX* inp, const floatX* dout, int N, const int block_size) {
     const int grid_size = ceil_div(N, block_size);
     gelu_backward1<<<grid_size, block_size>>>(dinp, inp, dout, N);
     cudaCheck(cudaGetLastError());
 }
 
+template<typename floatX>
 void gelu_backward2(floatX* dinp, const floatX* inp, const floatX* dout, int N, const int block_size) {
-    const int grid_size = ceil_div(N, block_size * x128::size);
+    const int grid_size = ceil_div(N, block_size * Packed128<floatX>::size);
     gelu_backward2<<<grid_size, block_size>>>(dinp, inp, dout, N);
     cudaCheck(cudaGetLastError());
 }
 
 // kernel version dispatch
+template<typename floatX>
 void gelu_backward(int kernel_num,
                   floatX* dinp, 
                   const floatX* inp, 
@@ -131,8 +121,9 @@ void gelu_backward(int kernel_num,
 
 // ----------------------------------------------------------------------------
 
-int main(int argc, char **argv) {
-    setup_main();
+DECLARE_TEST(gelu_backward);
+
+int IMPLEMENT_TEST(int kernel_num) {
 
     int B = 8;
     int T = 1024;
@@ -142,13 +133,6 @@ int main(int argc, char **argv) {
     float* dinp = (float*)malloc(B * T * C * sizeof(float));
     float* inp = make_random_float(B * T * C);
     float* dout = make_random_float(B * T * C);
-
-    // read kernel_num from command line
-    int kernel_num = 1;
-    if (argc > 1) {
-        kernel_num = atoi(argv[1]);
-    }
-    printf("Using kernel %d\n", kernel_num);
 
     // first check the correctness of the kernel
     gelu_backward_cpu(dinp, inp, dout, B * T * C);
@@ -170,11 +154,7 @@ int main(int argc, char **argv) {
         int block_size = block_sizes[j];
         printf("Checking block size %d.\n", block_size);
         gelu_backward(kernel_num, d_dinp, d_inp, d_dout, B, T, C, block_size);
-#if !defined(ENABLE_BF16) && !defined(ENABLE_FP16)
-        float tol = 1e-5;
-#else
-        float tol = 1e-2f;
-#endif
+        float tol = std::is_same_v<floatX, float> ? 1e-5 : 1e-2;
         validate_result(d_dinp, dinp, "dinp", B * T * C, tol);
     }
 
@@ -190,12 +170,14 @@ int main(int argc, char **argv) {
                                               B, T, C, block_size);
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 1 read and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 1 read and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 2 * 4;
+        long memory_ops = B * T * C * 2 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
-        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
+        printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/gelu_forward.cu
+++ b/dev/cuda/gelu_forward.cu
@@ -154,10 +154,10 @@ int IMPLEMENT_TEST(int kernel_num) {
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
         long memory_ops = B * T * C * 2 * (int)sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
-        float toks_per_sec = B * T / elapsed_time / 1e3;
+        float toks_per_msec = B * T / elapsed_time / 1e3;
 
         printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s | elements: %.2f ktok/ms\n",
-               block_size, elapsed_time, memory_bandwidth, toks_per_sec);
+               block_size, elapsed_time, memory_bandwidth, toks_per_msec);
     }
 
     // free memory

--- a/dev/cuda/residual_forward.cu
+++ b/dev/cuda/residual_forward.cu
@@ -140,9 +140,9 @@ int IMPLEMENT_TEST(int kernel_num) {
                                               );
 
         // napkin math: estimate the memory bandwidth achieved
-        // for each (B,T,C) output element, we do 2 read and 1 write, 4 bytes each
+        // for each (B,T,C) output element, we do 2 read and 1 write
         // and e.g. A100 40GB PCIe is advertised at 1,555GB/s
-        long memory_ops = B * T * C * 3 * 4;
+        long memory_ops = B * T * C * 3 * sizeof(floatX);
         float memory_bandwidth = memory_ops / elapsed_time / 1e6;
         float toks_per_msec = B * T / elapsed_time / 1e3;
 

--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -182,14 +182,6 @@ __device__ float warpReduceMax(float val) {
     return val;
 }
 
-// warp-level reduction for summing values
-__device__ float warpReduceSum(float val) {
-    for (int offset = 16; offset > 0; offset /= 2) {
-        val += __shfl_down_sync(0xFFFFFFFF, val, offset);
-    }
-    return val;
-}
-
 __global__ void softmax_forward_kernel3(float* out, const float* inp, int N, int C) {
     // kernel must use block size of 32
     extern __shared__ float shared[];

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -884,6 +884,87 @@ __global__ void layernorm_forward_kernel3(floatX* __restrict__ out, floatX* __re
     }
 }
 
+__global__ void fused_residual_forward_kernel5(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                                               const floatX* inp1, const floatX* inp2,
+                                               const floatX* weight, const floatX* bias,
+                                               int N, int C) {
+    constexpr const int WarpSize = 32;
+    assert(blockDim.x == WarpSize);
+
+    // load weights and biases into shared memory
+    // do this before we allow any threads to exit!
+    extern __shared__ char* params[];
+    // load128/store128 sometimes generated multiple instructions when the types here were floatX*, so
+    // let's keep everything as x128
+    x128* s_weight = reinterpret_cast<x128*>(params);
+    x128* s_bias = reinterpret_cast<x128*>(params) + (C / x128::size);
+    x128* s_res = reinterpret_cast<x128*>(params) + ((2 + threadIdx.y) * C / x128::size);
+
+    int sidx = (threadIdx.x + WarpSize * threadIdx.y) * x128::size;
+    for(int i = sidx; i < C; i += blockDim.y * WarpSize * x128::size) {
+        s_weight[i/x128::size] = load128(weight + i);
+        s_bias[i/x128::size] = load128(bias + i);
+    }
+    __syncthreads();
+
+    int idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if(idx > N) return;
+
+    // adjust pointers to current token
+    residual += C * idx;
+    normed += C * idx;
+    inp1 += C * idx;
+    inp2 += C * idx;
+
+    const float eps = 1e-5f;
+    float sum = 0.0f;
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 in1 = load128cs(inp1 + c);
+        const x128 in2 = load128cs(inp2 + c);
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            out[k] = (float)in1[k] + (float)in2[k];
+            sum += (float)out[k];
+        }
+        store128cs(residual + c, out);
+        s_res[c / x128::size] = out;
+    }
+
+    sum = warpReduceSum(sum);
+    float m = sum / C;
+    float v = 0.f;
+
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 res = s_res[c / x128::size];
+        for(int k = 0; k < x128::size; ++k) {
+            v += ((float)res[k] - m) * ((float)res[k] - m);
+        }
+    }
+
+    v = warpReduceSum(v) / C;
+    float s = rsqrtf(v + eps);
+
+    for(int c = threadIdx.x * x128::size; c < C; c += WarpSize * x128::size) {
+        const x128 res = s_res[c / x128::size];
+        const x128 w = s_weight[c / x128::size];
+        const x128 b = s_bias[c / x128::size];
+        x128 out;
+        for(int k = 0; k < x128::size; ++k) {
+            float n = s * ((float)res[k] - m); // normalized output
+            float o = n * (float)w[k] + (float)b[k]; // scale and shift it
+            out[k] = o;
+        }
+
+        store128cs(normed + c, out);
+    }
+    // cache the mean and rstd for the backward pass later
+    if(threadIdx.x == 0) {
+        mean[idx] = m;
+        rstd[idx] = s;
+    }
+}
+
+
 // inputs floatX, outputs FP32 (for current FP32-only activation path for this WIP)
 __global__ void permute_kernel(floatX* q, floatX* k, floatX* v,
                                const floatX* inp,
@@ -1024,7 +1105,7 @@ __global__ void softmax_forward_kernel5(floatX* out, float inv_temperature, cons
     }
 }
 
-__global__ void residual_forward_kernel(floatX* out, floatX* inp1, floatX* inp2, int N) {
+__global__ void residual_forward_kernel(floatX* out, const floatX* inp1, const floatX* inp2, int N) {
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     if (idx < N) {
         x128 packed_out;
@@ -1414,7 +1495,7 @@ void encoder_backward(floatX* dwte, floatX* dwpe,
 }
 
 void layernorm_forward(floatX* out, floatX* mean, floatX* rstd,
-                       floatX* inp, floatX* weight, floatX* bias,
+                       floatX* inp, const floatX* weight, const floatX* bias,
                        int B, int T, int C) {
     NVTX_RANGE_FN();
     const int block_size = 512;
@@ -1581,13 +1662,38 @@ void attention_forward(floatX* out, floatX* qkvr, floatX* att,
     cudaCheck(cudaGetLastError());
 }
 
-void residual_forward(floatX* out, floatX* inp1, floatX* inp2, int N) {
+void residual_forward(floatX* out, const floatX* inp1, const floatX* inp2, int N) {
     NVTX_RANGE_FN();
     const int block_size = 256;
     const int grid_size = CEIL_DIV(N, block_size * x128::size);
     residual_forward_kernel<<<grid_size, block_size, 0, main_stream>>>(out, inp1, inp2, N);
     cudaCheck(cudaGetLastError());
 }
+
+void fused_residual_forward5(floatX* residual, floatX* normed, floatX* mean, floatX* rstd,
+                             const floatX* inp1, const floatX* inp2,
+                             const floatX* weight, const floatX* bias,
+                             int N, int C) {
+    const int block_size = 256;
+    int block_y = block_size / 32;
+    const int grid_size = CEIL_DIV(N, block_y);
+    size_t smem = (2 + block_y) * C * sizeof(floatX);
+
+    // in order to use more than 48 KiB of smem, need to call cudaFuncSetAttribute
+    // this may fail, in which case we fall back to the smem free implementation.
+    cudaCheck(cudaGetLastError());
+    auto status = cudaFuncSetAttribute(fused_residual_forward_kernel5, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    cudaGetLastError();
+    if(status == cudaSuccess) {
+        fused_residual_forward_kernel5<<<grid_size, dim3(32, block_y), smem>>>(residual, normed, mean, rstd, inp1, inp2,
+                                                                               weight, bias, N, C);
+    } else {
+        residual_forward(residual, inp1, inp2, N*C);
+        layernorm_forward(normed, mean, rstd, residual, weight, bias, N, 1, C);
+    }
+    cudaCheck(cudaGetLastError());
+}
+
 
 void gelu_forward(floatX* out, const floatX* inp, int N) {
     NVTX_RANGE_FN();
@@ -2125,17 +2231,17 @@ void gpt2_forward(GPT2 *model, int* inputs, int* targets, size_t B, size_t T, bo
     // forward pass
     ParameterTensors params = model->params; // for brevity
     ActivationTensors acts = model->acts;
-    floatX* residual;
     encoder_forward(acts.encoded, model->inputs, params.wte, params.wpe, B, T, C); // encoding goes into residual[0]
+
+    // first layernorm isn't fused
+    layernorm_forward(acts.ln1, acts.ln1_mean, acts.ln1_rstd, acts.encoded, params.ln1w, params.ln1b, B, T, C);
 
     for (int l = 0; l < L; l++) {
         NvtxRange layer_range("Layer", l);
 
-        residual = l == 0 ? acts.encoded : acts.residual3 + (l-1) * B * T * C;
+        floatX* residual = l == 0 ? acts.encoded : acts.residual3 + (l-1) * B * T * C;
 
         // get the pointers of the weights for this layer
-        floatX* l_ln1w = params.ln1w + l * C;
-        floatX* l_ln1b = params.ln1b + l * C;
         floatX* l_qkvw = params.qkvw + l * 3*C * C;
         floatX* l_qkvb = params.qkvb + l * 3*C;
         floatX* l_attprojw = params.attprojw + l * C * C;
@@ -2149,8 +2255,6 @@ void gpt2_forward(GPT2 *model, int* inputs, int* targets, size_t B, size_t T, bo
 
         // get the pointers of the activations for this layer
         floatX* l_ln1 = acts.ln1 + l * B * T * C;
-        floatX* l_ln1_mean = acts.ln1_mean + l * B * T;
-        floatX* l_ln1_rstd = acts.ln1_rstd + l * B * T;
         floatX* l_qkvr = acts.qkvr + l * B * T * 3*C;
         floatX* l_atty = acts.atty + l * B * T * C;
         floatX* l_attproj = acts.attproj + l * B * T * C;
@@ -2164,8 +2268,6 @@ void gpt2_forward(GPT2 *model, int* inputs, int* targets, size_t B, size_t T, bo
         floatX* l_residual3 = acts.residual3 + l * B * T * C;
 
         // now do the forward pass
-        layernorm_forward(l_ln1, l_ln1_mean, l_ln1_rstd, residual, l_ln1w, l_ln1b, B, T, C);
-
         #ifdef ENABLE_CUDNN
         float* l_att = (float*)acts.att + l * B * NH * T; // cuDNN needs a smaller FP32 tensor
         matmul_forward_cublaslt(l_qkvr, l_ln1, l_qkvw, l_qkvb, B, T, C, 3*C);
@@ -2180,16 +2282,27 @@ void gpt2_forward(GPT2 *model, int* inputs, int* targets, size_t B, size_t T, bo
         #endif
 
         matmul_forward_cublaslt(l_attproj, l_atty, l_attprojw, l_attprojb, B, T, C, C);
-        residual_forward(l_residual2, residual, l_attproj, B*T*C);
-        layernorm_forward(l_ln2, l_ln2_mean, l_ln2_rstd, l_residual2, l_ln2w, l_ln2b, B, T, C);
+        fused_residual_forward5(l_residual2, l_ln2, l_ln2_mean, l_ln2_rstd, residual, l_attproj, l_ln2w, l_ln2b, B*T, C);
         matmul_forward_cublaslt(l_fch, l_ln2, l_fcw, l_fcb, B, T, C, 4*C);
         gelu_forward(l_fch_gelu, l_fch, B*T*4*C);
         matmul_forward_cublaslt(l_fcproj, l_fch_gelu, l_fcprojw, l_fcprojb, B, T, 4*C, C);
-        residual_forward(l_residual3, l_residual2, l_fcproj, B*T*C);
+
+        // OK, fusion across blocks.
+        if(l+1 != L) {
+            floatX* l_ln1 = acts.ln1 + (l + 1) * B * T * C;
+            floatX* l_ln1_mean = acts.ln1_mean + (l + 1) * B * T;
+            floatX* l_ln1_rstd = acts.ln1_rstd + (l + 1) * B * T;
+            const floatX* l_ln1w = params.ln1w + (l + 1) * C;
+            const floatX* l_ln1b = params.ln1b + (l + 1) * C;
+            fused_residual_forward5(l_residual3, l_ln1, l_ln1_mean, l_ln1_rstd, l_residual2, l_fcproj, l_ln1w, l_ln1b,
+                                    B * T, C);
+        } else {
+            fused_residual_forward5(l_residual3, acts.lnf, acts.lnf_mean, acts.lnf_rstd, l_residual2, l_fcproj,
+                                    params.lnfw, params.lnfb,
+                                    B * T, C);
+        }
     }
 
-    residual = acts.residual3 + (L-1) * B * T * C; // last residual is in residual3
-    layernorm_forward(acts.lnf, acts.lnf_mean, acts.lnf_rstd, residual, params.lnfw, params.lnfb, B, T, C);
     matmul_forward_cublaslt(acts.output, acts.lnf, params.wte, NULL, B, T, C, Vp);
 
     // also forward the cross-entropy loss function if we have the targets


### PR DESCRIPTION
currently based on top of #352 
I'm not using  kernel 6, because
a) the performance seems to be really sensitive to parameters
b) ~i don't understand the performance measurements/are not 100% sure if it is actually correct despite passing our tests~

Update: The bug was I had `blockDim.z` where there  should be `threadIdx.z`, but since the first block_size=32 call writes correct results everywhere, all the untouched things were considered correct by the test.

Now, I get kernel 6 as a bit slower than kernel 5, but with a smaller shared memory footprint, so it  might be interesting for smaller cards or larger C.