### PR TITLE
main Makefile auto-detect GPU capability and allow overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ define file_exists_in_path
   $(shell where $(1) 2>nul || which $(1) 2>/dev/null)
 endef
 
-ifndef GPU_COMPUTE_CAPABILITY # set to defaults if: make GPU_COMPUTE_CAPABILITY= 
-  ifneq ($(call file_exists_in_path, __nvcc_device_query),)
-    GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) 
-    GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
+ifneq ($(CI),true) # if not in CI, then use the GPU query
+  ifndef GPU_COMPUTE_CAPABILITY # set to defaults if: make GPU_COMPUTE_CAPABILITY= 
+    ifneq ($(call file_exists_in_path, __nvcc_device_query),)
+      GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) 
+      GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
+    endif
   endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,23 @@ NVCC_CUDNN =
 # because it bloats up the compile time from a few seconds to ~minute
 USE_CUDNN ?= 0
 
+# Function to check if a file exists in the PATH
+define file_exists_in_path
+  $(shell where $(1) 2>nul || which $(1) 2>/dev/null)
+endef
+
+ifndef GPU_COMPUTE_CAPABILITY # set to defaults if: make GPU_COMPUTE_CAPABILITY= 
+  ifneq ($(call file_exists_in_path, __nvcc_device_query),)
+    GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query) 
+    GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
+  endif
+endif
+
+# set to defaults if - make GPU_COMPUTE_CAPABILITY= otherwise use the compute capability detected above
+ifneq ($(GPU_COMPUTE_CAPABILITY),) 
+  NVCC_FLAGS += --generate-code arch=compute_$(GPU_COMPUTE_CAPABILITY),code=[compute_$(GPU_COMPUTE_CAPABILITY),sm_$(GPU_COMPUTE_CAPABILITY)]
+endif
+
 # autodect a lot of various supports on current platform
 $(info ---------------------------------------------)
 


### PR DESCRIPTION
Using the same code from the latest kernel Makefile changes from https://github.com/karpathy/llm.c/pull/341,  this auto-detects the GPU or lets you override the GPU capabilities. This PR is small and independent of the upcoming cuDNN Makefile changes.

Usage:

Auto detect GPU capability:

make
(e.g. if your GPU capability type is 80 then --generate-code=arch=compute_80,code=[compute_80,sm_80] is used with CFLAGS)

Do not specify capability:

make GPU_COMPUTE_CAPABILITY=
(CFLAGS = -O3 --use_fast_math)

Override capability:

make GPU_COMPUTE_CAPABILITY=86
(e.g. even if your GPU capability type is 80 then --generate-code=arch=compute_86,code=[compute_86,sm_86] is used with CFLAGS)

Tested on Windows 11 and Linux Ubuntu 22.04. Has the extra space fix (uses strip()) from the kernel Makefile.