### PR TITLE
Free cooperative groups implementation of online softmax forward

### DIFF
--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -515,84 +515,58 @@ __global__ void softmax_forward_kernel7(float* out, const float* inp, int N, int
 }
 
 __global__ void softmax_forward_online_kernel8(float* out, const float* inp, int N, int C) {
-    // do the same job as softmax_forward_online_kernel1()
-    // further combines unrolling, shared memory and warp reduce utilities in CUDA
-    extern __shared__ float shared[];
-    const int UNROLL_FACTOR = 8;
-    // FAKE_MAXVAL is set empirically to mimic the maxval that would appear in real situation
-    const float FAKE_MAXVAL = 10.f; 
     const int warpsPerBlock = blockDim.x / warpSize;
-    int idx = blockIdx.x;
     int tid = threadIdx.x;
-    int laneId = tid % warpSize;
-    int warpId = tid / warpSize;
-    float* maxvals = shared;
-    float* sumvals = &shared[warpsPerBlock];
 
     if (tid >= C) {
-        maxvals[warpId] = -INFINITY;
-        sumvals[warpId] = 0.0f;
         return;
     }
-    
-    const float* x = inp + idx * C;
-    float* y = out + idx * C;
 
-    // each thread computes partial maxval and sumval in range [::blockDim.x]
-    // after finished this part, each thread in block-0 holds partial maxval and sumval
-    float maxval = -INFINITY, sumval = 0.0f;
-    for (int i = tid; i < C; i += blockDim.x * UNROLL_FACTOR) {
-        #pragma unroll
-        for (int j = 0; j < UNROLL_FACTOR && i + j * blockDim.x < C; ++j) {   
-            maxval = fmaxf(maxval, x[i + j * blockDim.x]);
-            // using FAKE_MAXVAL to avoid keeping updating inter-maxvals
-            sumval += expf(x[i + j * blockDim.x] - FAKE_MAXVAL);
-        }
+    int warpId = tid / warpSize;
+    int laneId = tid % warpSize;
+    int row = blockIdx.x * warpsPerBlock + warpId;
+
+    if (row >= N) {
+        return;
     }
-    sumval *= expf(FAKE_MAXVAL - maxval);
 
-    // computes sumval and maxval of each warp (32 threads)
-    // after finished this part, shared memory holds maxval and sumval of each warp
-    
-    float offset_maxval, offset_sumval, tmp_maxval;
+    const float* x = inp + row * C;
+    float* const y = out + row * C;
+
+    // merging calculating maxval and sumval in one loop
+    // which is an arithmetic improvment from online softmax over normal softmax
+    float maxval = -INFINITY, sumval = 0.0f, bigger;
+    for (int i = laneId; i < C; i += warpSize) {
+        // when updating the maxval, dynamically updates the previous sumval by
+        // multiplying e^{previous_maxval - current_maxval}
+        bigger = fmaxf(maxval, x[i]);
+        sumval = sumval * expf(maxval - bigger) + expf(x[i] - bigger);
+        maxval = bigger;
+    }
+
+    // using warp functions instead of cooperative groups for better readibility
+    // calculate the warp wised maxval and sumval
+    float offsetMaxval, offsetSumval;
     for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
-        offset_maxval = __shfl_down_sync(0xFFFFFFFF, maxval, offset);
-        offset_sumval = __shfl_down_sync(0xFFFFFFFF, sumval, offset);
-        tmp_maxval = fmaxf(maxval, offset_maxval);
-        sumval = sumval * expf(maxval - tmp_maxval) +
-                offset_sumval * expf(offset_maxval - tmp_maxval);
-        maxval = tmp_maxval;
-    }
-    if (laneId == 0) {
-        sumvals[warpId] = sumval;
-        maxvals[warpId] = maxval;
-    }
-    __syncthreads();
-
-    // computes the global maxval and sumval of row `idx`
-    if (tid < warpsPerBlock / 2) {
-        #pragma unroll
-        for (int offset = warpsPerBlock / 2; offset > 0; offset >>= 1) {
-            if (tid < offset) {
-                tmp_maxval = fmaxf(maxvals[tid], maxvals[tid + offset]);
-                sumvals[tid] = sumvals[tid] * expf(maxvals[tid] - tmp_maxval) +
-                            sumvals[tid + offset] *
-                                expf(maxvals[tid + offset] - tmp_maxval);
-                maxvals[tid] = tmp_maxval;
-            }
+        __syncwarp();
+        offsetMaxval = __shfl_down_sync(0xFFFFFFFF, maxval, offset);
+        offsetSumval = __shfl_down_sync(0xFFFFFFFF, sumval, offset);
+        if (offsetMaxval > maxval) {
+            sumval *= expf(maxval - offsetMaxval);
+            maxval = offsetMaxval;
+        } else {
+            offsetSumval *= expf(offsetMaxval - maxval);
         }
+        sumval += offsetSumval;
     }
-    __syncthreads();
 
-    // write the final results into `out`
-    maxval = maxvals[0];
-    float sum = sumvals[0];
-    for (int i = tid; i < C; i += blockDim.x * UNROLL_FACTOR) {
-        #pragma unroll
-        for (int j = 0; j < UNROLL_FACTOR && i + j * blockDim.x < C; ++j) {
-            // __stcs(&y[i + j * blockDim.x], expf(x[i + j * blockDim.x] - maxval) / sum);
-            y[i + j * blockDim.x] = expf(x[i + j * blockDim.x] - maxval) / sum;
-        }
+    // retrive the warp wised maxval and sumval
+    // which are also the maxval and sumval of one row in C
+    maxval = __shfl_sync(0xFFFFFFFF, maxval, 0);
+    sumval = __shfl_sync(0xFFFFFFFF, sumval, 0);
+
+    for (int i = laneId; i < C; i += warpSize) {
+        y[i] = expf(x[i] - maxval) / sumval;
     }
 }
 
@@ -643,9 +617,8 @@ void softmax_forward7(float* out, const float* inp, int N, int C, int block_size
 }
 
 void softmax_forward_online8(float* out, const float* inp, int N, int C, int block_size) {
-    const int grid_size = N;
-    size_t shared_mem_size = 2 * block_size / 32 * sizeof(float);
-    softmax_forward_online_kernel8<<<grid_size, block_size, shared_mem_size>>>(out, inp, N, C);
+    const int grid_size = ceil_div(N * 32, block_size);
+    softmax_forward_online_kernel8<<<grid_size, block_size>>>(out, inp, N, C);
     cudaCheck(cudaGetLastError());
 }
 


### PR DESCRIPTION
Following the instructions in #292, I implement [online softmax forward](http://arxiv.org/abs/1805.02867) kernel that without cooperative groups (`softmax_forward_online_kernel2()` used).

About the performance, this implementation is close to `softmax_forward_online2()` and faster than `softmax_forward_online1()` (online softmax without optimizations)
and 
`softmax_forward7()` (normal softmax with optimizations). 

My GPU: 3070 Laptop
My OS: Ubuntu 22.04

## Benchmark Results

`softmax_forward_online8()` (This implementation)
```
block_size   32 | time 14.1648 ms | per token 1.73 µs
block_size   64 | time 13.0965 ms | per token 1.60 µs
block_size  128 | time 12.7798 ms | per token 1.56 µs
block_size  256 | time 13.1108 ms | per token 1.60 µs
block_size  512 | time 14.8191 ms | per token 1.81 µs
block_size 1024 | time 15.5168 ms | per token 1.89 µs
```

`softmax_forward_online2()` (with cooperative groups)
```
block_size   32 | time 14.2590 ms | per token 1.74 µs
block_size   64 | time 13.2162 ms | per token 1.61 µs
block_size  128 | time 13.6913 ms | per token 1.67 µs
block_size  256 | time 15.6696 ms | per token 1.91 µs
block_size  512 | time 16.4984 ms | per token 2.01 µs
block_size 1024 | time 17.0234 ms | per token 2.08 µs
```

`softmax_forward7()`
```
block_size   32 | time 19.7650 ms | per token 2.41 µs
block_size   64 | time 22.8819 ms | per token 2.79 µs
block_size  128 | time 27.1873 ms | per token 3.32 µs
block_size  256 | time 30.7437 ms | per token 3.75 µs
block_size  512 | time 34.6858 ms | per token 4.23 µs
block_size 1024 | time 35.5845 ms | per token 4.34 µs
```

`softmax_forward_online1()`
```
block_size   32 | time 70.8872 ms | per token 8.65 µs
block_size   64 | time 93.5169 ms | per token 11.42 µs
block_size  128 | time 100.5090 ms | per token 12.27 µs
block_size  256 | time 106.6460 ms | per token 13.02 µs
block_size  512 | time 179.6892 ms | per token 21.93 µs
block_size 1024 | time 315.1779 ms | per token 38.47 µs
```