### PR TITLE
Make the cudamemset byte value explicit

### DIFF
--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -736,7 +736,7 @@ void attention_forward2(float* out,
     cudaCheck(cudaMalloc(&l, B * nh * N * sizeof(float)));
     cudaCheck(cudaMalloc(&m, B * nh * N * sizeof(float)));
     cudaCheck(cudaMemset(l, 0, B * nh * N * sizeof(float)));
-    cudaCheck(cudaMemset(m, -10000.0f, B * nh * N * sizeof(float)));
+    cudaCheck(cudaMemset(m, 0xF0, B * nh * N * sizeof(float)));
 
     // calculate SRAM size needed per block, ensure we have enough shared memory
     int col_tile_size = Bc * d;  // size of Kj, Vj


### PR DESCRIPTION
To improve the readability for the general audience.

A float number -10000.0f in cudaMemset involves converting to byte and truncation, the goal is to 
have large negative float value (when readin 4 bytes): the sentinel value to -INF .

When input -10000.0f, the actual byte value gets set is 0XF0.

CPU version testing:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main(void)
{
    const int n = 1;
    const size_t sz = size_t(n) * sizeof(float);
    float *Junk = (float*)malloc(sz);

    memset(Junk, 0, sz);
    memset(Junk, -10000.0f, sz); // memset(Junk, 0xF0, sz); yields the same outcome

    float value = Junk[0];
    unsigned int* p = reinterpret_cast<unsigned int*>(&value);
    fprintf(stdout, "%x\n", *p);
    fprintf(stdout, "%f\n", value);

    free(Junk);
    return 0;
}
```

Output
```
f0f0f0f0
-596541423374289729685825781760.000000             ---> sentinel value to -INF
```

