### PR TITLE
Adds cuDNN install instructions for a smaller but sufficient package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,7 @@ endif
 
 # Check and include cudnn if available
 # You can override the path to cudnn frontend by setting CUDNN_FRONTEND_PATH=your_path on the make command line
-# You need cuDNN from: https://developer.nvidia.com/cudnn
-# Follow the apt-get instructions or Windows instructions to install the cuDNN library
-# And the cuDNN front-end from: https://github.com/NVIDIA/cudnn-frontend/tree/main
-# For this there is no installation, just download the repo to your home directory or directory of your choice
-# and then we include it below (see currently hard-coded path assumed in home directory)
+# Refer to the README for cuDNN install instructions
 ifeq ($(USE_CUDNN), 1)
   ifeq ($(SHELL_UNAME), Linux)
     # hard-coded path for now in either . or ($HOME) directory 
@@ -103,7 +99,7 @@ ifeq ($(USE_CUDNN), 1)
       $(info ✓ cuDNN found, will run with flash-attention)
       CUDNN_FRONTEND_PATH ?= cudnn-frontend/include
     else
-      $(error ✗ cuDNN not found. See the Makefile for our currently hard-coded paths / install instructions)
+      $(error ✗ cuDNN not found. See the README for install instructions and the Makefile for hard-coded paths)
     endif
     NVCC_INCLUDES += -I$(CUDNN_FRONTEND_PATH)
     NVCC_LDFLAGS += -lcudnn
@@ -119,7 +115,7 @@ ifeq ($(USE_CUDNN), 1)
       else ifeq ($(shell if exist "cudnn-frontend\include" (echo exists)),exists)
         CUDNN_FRONTEND_PATH ?= cudnn-frontend\include #override on command line if different location
       else
-        $(error ✗ cuDNN not found. See the Makefile for our currently hard-coded paths / install instructions) 
+        $(error ✗ cuDNN not found. See the README for install instructions and the Makefile for hard-coded paths) 
       endif
       CUDNN_INCLUDE_PATH ?= -I"C:\Program Files\NVIDIA\CUDNN\v9.1\include\12.4"
       CUDNN_FRONTEND_PATH += $(CUDNN_INCLUDE_PATH)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make train_gpt2cu
 ./train_gpt2cu
 ```
 
-If you additionally install cuDNN (see `Makefile` for instructions), you can also go faster with flash attention
+If you additionally install cuDNN (see the CUDA section below), you can also go faster with flash attention
 
 ```bash
 make train_gpt2cu USE_CUDNN=1
@@ -256,7 +256,16 @@ If you have the latest CUDA you should expect this to compile OK, and you should
 make train_gpt2cu USE_CUDNN=1
 ```
 
-This will try to compile with cudnn and run it. You have to have cuDNN installed on your system. Follow the [cuDNN installation instructions](https://developer.nvidia.com/cudnn) to install cuDNN with apt-get. On top of this you need the [cuDNN frontend](https://github.com/NVIDIA/cudnn-frontend/tree/main), but this is just header files. So simply download the repo to your disk, currently assumed to be in your home directory (i.e. the Makefile looks for `~/cudnn-frontend/include`).
+This will try to compile with cudnn and run it. You have to have cuDNN installed on your system. The [cuDNN installation instructions](https://developer.nvidia.com/cudnn) with apt-get will grab the default set of cuDNN packages. For a minimal setup, the cuDNN dev package is sufficient, e.g. on Ubuntu 22.04 for CUDA 12.x:
+
+```bash
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo apt-get -y install libcudnn9-dev-cuda-12
+```
+
+On top of this you need the [cuDNN frontend](https://github.com/NVIDIA/cudnn-frontend/tree/main), but this is just header files. So simply download the repo to your disk, currently assumed to be in your home directory (i.e. the Makefile looks for `~/cudnn-frontend/include`).
 
 **Multi-GPU training**. As of April 26, 2024 there is now also support for multi-GPU training using MPI and NCCL. Make sure you install MPI, e.g. on Linux:
 

--- a/dev/cuda/attention_forward.cu
+++ b/dev/cuda/attention_forward.cu
@@ -2,8 +2,8 @@
 Kernels for attention forward pass.
 
 If you do not have CUDNN, you can remove ENABLE_CUDNN to run the other kernels
-You need cuDNN from: https://developer.nvidia.com/cudnn
-And the cuDNN front-end from: https://github.com/NVIDIA/cudnn-frontend/tree/main
+
+See the README for cuDNN install instructions
 
 Compile example with cuDNN:
 nvcc -I/PATH/TO/cudnn-frontend/include -DENABLE_CUDNN -O3 --use_fast_math -lcublas -lcudnn attention_forward.cu -o attention_forward


### PR DESCRIPTION
- Modifies `README.md` to provide example apt-get cuDNN install instructions that install the cuDNN dev package. `sudo apt-get install -y cudnn` will install the default cuDNN packages, but for a minimal setup, installing the dev package will see a 50% reduction in both, download size (~850MB to 425MB now) and local storage size (~2GB to ~1GB now).

- Modifies the `Makefile` to point users to the README for cuDNN install instructions (through comments and the cuDNN install error message)

- Modifies `attention_forward.cu` comments to point users to the README for cuDNN install instructions