### PR TITLE
Make ceil_div constexpr and inline

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -6,7 +6,7 @@
 
 
 template<class T>
-__host__ __device__ T ceil_div(T dividend, T divisor) {
+constexpr __host__ __device__ inline T ceil_div(T dividend, T divisor) {
     return (dividend + divisor-1) / divisor;
 }
 


### PR DESCRIPTION
The constexpr keyword allows the function to be evaluated at compile time if the arguments are known at compile time, which can eliminate the function call overhead.