### PR TITLE
Small update of matmul_backward_bias_kernel1

### DIFF
--- a/dev/cuda/matmul_backward_bias.cu
+++ b/dev/cuda/matmul_backward_bias.cu
@@ -72,7 +72,7 @@ __global__ void matmul_backward_bias_kernel1(floatX* dbias, const floatX* dout, 
     }
     // write the final result (at thread 0) to global memory
     if (tid == 0) {
-        dbias[o] = (float)dbias[o] + shared[0];
+        dbias[o] = shared[0];
     }
 }
 


### PR DESCRIPTION
Results are not changed after the change.

Logically, it should be the same as
https://github.com/karpathy/llm.c/blob/master/dev/cuda/matmul_backward.cu#L102

Did I miss anything? @ngc92 