### PR TITLE
considerably speed up CPU matmul

### DIFF
--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -237,10 +237,10 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
     #pragma omp parallel for collapse(2)
     for (int b = 0; b < B; b++) {
         for (int t = 0; t < T; t++) {
-            float* dout_bt = dout + b * T * OC + t * OC;
+            const float* dout_bt = dout + b * T * OC + t * OC;
             float* dinp_bt = dinp + b * T * C + t * C;
             for (int o = 0; o < OC; o++) {
-                float* wrow = weight + o*C;
+                const float* wrow = weight + o*C;
                 float d = dout_bt[o];
                 for (int i = 0; i < C; i++) {
                     dinp_bt[i] += wrow[i] * d;
@@ -253,8 +253,8 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
     for (int o = 0; o < OC; o++) {
         for (int b = 0; b < B; b++) {
             for (int t = 0; t < T; t++) {
-                float* dout_bt = dout + b * T * OC + t * OC;
-                float* inp_bt = inp + b * T * C + t * C;
+                const float* dout_bt = dout + b * T * OC + t * OC;
+                const float* inp_bt = inp + b * T * C + t * C;
                 float* dwrow = dweight + o*C;
                 float d = dout_bt[o];
                 if (dbias != NULL) { dbias[o] += d; }


### PR DESCRIPTION
Not sure how much we care about perf of the CPU version. This is trying to give a substantial boost, while still keeping complexity in check: without the comments, the  matmul still fits on a single screen.

While it would have been possible to either just print an error message for "bad" shapes, or write a function that is more generic and handles the unrollable part followed by an epilogue loop, I think the approach of having a slow, but very simple version, and a fast, but shape-restricted version is better. It keeps the fast algorithm more readable, and having the slow version there as a reference has pedagogical value in itself.

I have also removed the helper row pointers (`out_bt`), because they make it more difficult to see the strides of the individual memory accesses.

On my system, I observed about 20% end-to-end speedup (~5s to ~4s per step) with this change.