### PR TITLE
Remove parallel CUDA streams while keeping main_stream and loss_event(?)

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2045,8 +2045,8 @@ void gpt2_forward(GPT2 *model, int* inputs, int* targets, size_t B, size_t T, bo
 
     // todo - the 1st optional memcpy is async relative to CPU, but fully serialised on GPU (default legacy stream 0)
     // the 2nd memcpy is fully synchronous, so this creates a full "CPU waits until GPU is idle" dependency here!
-    // if both were cudaMemcpyAsync, need to guarantee GPU has read CPU inputs/targets buffers before overwriting them
-    // so this is 100% safe, and better than 2 separate non-sync memcpy serialising CPU/GPU twice, but far from optimal
+    // if both were cudaMemcpyAsync we'd need to guarantee GPU read CPU inputs/targets buffers before overwriting them!
+    // but this is 100% safe, better than 2 separate non-sync memcpy serialising CPU/GPU twice, though far from optimal
     // memcpy non-async with cudaMemcpyHostToDevice is blocking on CPU because of read-after-write hazards on the input
     // but memset non-async is NOT blocking on CPU, so memsetAsync with legacy stream 0 is the same as regular memset
 


### PR DESCRIPTION
See discussion on Discord, I think whatever we eventually architect that's better than my naive folly will probably still need something similar to "main_stream" that's the default for everything, so I kept that (and added it for the one kernel where it was missing)

Also loss_event is a good example of something that kinda works as intended and it allows forward and backward to overlap, so kept it for now, to show this CPU/GPU parallelism can work even with just a single "main_stream" (we should be able to do the same for the main loop to avoid syncing for timing). But it'd be good to abstract it in a safer way somehow, so definitely wouldn't disagree if you wanted to remove it too!