### PR TITLE
Zero update

### DIFF
--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -27,7 +27,8 @@ the profile.ncu-rep from a cloud box to local to pretty view.
 #define TESTING
 #include "train_gpt2.cu"
 
-int main() {
+int main(int argc, char *argv[]) {
+    multi_gpu_config = multi_gpu_config_init(&argc, &argv);
     common_start(true, true);
 
     // build the GPT-2 model from a checkpoint
@@ -53,7 +54,7 @@ int main() {
     gpt2_forward(&model, x, y, B, T);
     gpt2_zero_grad(&model);
     gpt2_backward(&model);
-    gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, 1);
+    gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, 1, &multi_gpu_config);
     cudaCheck(cudaDeviceSynchronize()); // finish all CUDA work to get correct precise timings
 
     // free

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -83,6 +83,7 @@ float* float_cpu_malloc_and_point_parameters(FloatParameterTensors* params, size
 }
 
 int main(int argc, char *argv[]) {
+    multi_gpu_config = multi_gpu_config_init(&argc, &argv);
     common_start(false, true);
 
     // set the right paths
@@ -118,6 +119,8 @@ int main(int argc, char *argv[]) {
     printf("[State]\n");
     printf("batch_size: %d\n", B);
     printf("seq_len: %d\n", T);
+
+    set_zero_configs(&multi_gpu_config, 0, model.num_parameters);
 
     // read reference information from the file saved from Python/PyTorch side
     // 1) input x and y
@@ -263,7 +266,7 @@ int main(int argc, char *argv[]) {
             allok = allok & check_tensor(tensors1[15], tensors2[15], C, "lnfb", 3e-2f);
         }
 
-        gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.01f, step+1);
+        gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.01f, step+1, &multi_gpu_config);
 
         // print the timing information at the end
         printf("step %d: loss %f (took %f ms)\n", step+1, model.mean_loss, time_elapsed_s * 1000);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -458,28 +458,26 @@ void set_zero_configs(MultiGpuConfig* multi_gpu_config, int zero_stage, size_t t
     multi_gpu_config->shard_num_parameters = total_parameters;
     multi_gpu_config->shard_offset = 0;
 
-#ifdef MULTI_GPU
-        // Check the Zero Stage and define sharding parameters
-        if (zero_stage == 0) {
-            printf0("| Zero Optimization is disabled                                              |\n");
-        }
-        else if (zero_stage == 1) {
-            if (total_parameters % multi_gpu_config->num_processes != 0) {
-                printf0("| Zero Optimization is disabled, Can't equally partition parameters          |\n");
-                multi_gpu_config->zero_stage = 0;
-            }
-            else {
-                printf0("| Zero Stage1 is enabled                                                     |\n");
-                multi_gpu_config->zero_stage = 1;
-                multi_gpu_config->shard_num_parameters = total_parameters / multi_gpu_config->num_processes;
-                multi_gpu_config->shard_offset = multi_gpu_config->process_rank * (total_parameters / multi_gpu_config->num_processes);
-            }
-        }
-        else{
-            printf0("| Disabling Zero Optimization, Zero Stage2 and Stage3 are not yet supported  |\n");
+    // Check the Zero Stage and define sharding parameters
+    if (zero_stage == 0) {
+        printf0("| Zero Optimization is disabled                                              |\n");
+    }
+    else if (zero_stage == 1) {
+        if (total_parameters % multi_gpu_config->num_processes != 0) {
+            printf0("| Zero Optimization is disabled, Can't equally partition parameters          |\n");
             multi_gpu_config->zero_stage = 0;
         }
-#endif
+        else {
+            printf0("| Zero Stage1 is enabled                                                     |\n");
+            multi_gpu_config->zero_stage = 1;
+            multi_gpu_config->shard_num_parameters = total_parameters / multi_gpu_config->num_processes;
+            multi_gpu_config->shard_offset = multi_gpu_config->process_rank * multi_gpu_config->shard_num_parameters;
+        }
+    }
+    else{
+        printf0("| Disabling Zero Optimization, Zero Stage2 and Stage3 are not yet supported  |\n");
+        multi_gpu_config->zero_stage = 0;
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -2306,40 +2304,7 @@ void gpt2_multi_gpu_accumulate(GPT2* model, MultiGpuConfig* multi_gpu_config) {
 #endif
 }
 
-void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, float eps, float weight_decay, int t) {
-    NVTX_RANGE_FN();
-    // reference: https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html
-
-    // lazily allocate the memory for m_memory and v_memory
-    if (model->m_memory == NULL) {
-        cudaCheck(cudaMalloc((void**)&model->m_memory, model->num_parameters * sizeof(float)));
-        cudaCheck(cudaMalloc((void**)&model->v_memory, model->num_parameters * sizeof(float)));
-        cudaCheck(cudaMemset(model->m_memory, 0, model->num_parameters * sizeof(float)));
-        cudaCheck(cudaMemset(model->v_memory, 0, model->num_parameters * sizeof(float)));
-        printf0("allocated %zu MiB for AdamW optimizer state m\n", (model->num_parameters * sizeof(float)) >> 20);
-        printf0("allocated %zu MiB for AdamW optimizer state v\n", (model->num_parameters * sizeof(float)) >> 20);
-        if (model->use_master_weights == 1) {
-            // allocate one more buffer to keep the master copy of weights as float, and copy the weights over
-            cudaCheck(cudaMalloc((void**)&model->master_weights, model->num_parameters * sizeof(float)));
-            copy_and_cast_kernel<<<CEIL_DIV(model->num_parameters, 512), 512>>>(model->master_weights, (floatX*)model->params_memory, model->num_parameters);
-            cudaCheck(cudaGetLastError());
-            printf0("allocated %zu MiB for master copy of params\n", (model->num_parameters * sizeof(float)) >> 20);
-        }
-    }
-
-    int block_size = 512;
-    int num_blocks = CEIL_DIV(model->num_parameters, block_size);
-    float beta1_correction = 1.0f - powf(beta1, t);
-    float beta2_correction = 1.0f - powf(beta2, t);
-    unsigned int seed = random_u32(&model->rng_state);
-    adamw_kernel3<<<num_blocks, block_size>>>((floatX*)model->params_memory, model->master_weights,
-                                              (floatX*)model->grads_memory, model->m_memory, model->v_memory,
-                                              model->num_parameters,
-                                              learning_rate, beta1, beta2, beta1_correction, beta2_correction, eps, weight_decay, seed);
-    cudaCheck(cudaGetLastError());
-}
-
-void gpt2_multi_gpu_update(GPT2 *model, float learning_rate, float beta1, float beta2, float eps, float weight_decay, int t, MultiGpuConfig* multi_gpu_config) {
+void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, float eps, float weight_decay, int t, MultiGpuConfig* multi_gpu_config) {
     NVTX_RANGE_FN();
     size_t num_parameters = multi_gpu_config->shard_num_parameters;
     floatX* params_memory = (floatX*)model->params_memory + multi_gpu_config->shard_offset;
@@ -2828,13 +2793,9 @@ int main(int argc, char *argv[]) {
         // this is esp important to do here in multigpu update below, where model.mean_loss gets allreduced
         model.mean_loss = lossf;
         // update the parameters
-#ifndef MULTI_GPU
-        gpt2_update(&model, learning_rate, 0.9f, 0.999f, 1e-8f, 0.0f, step+1);
-#else
         gpt2_multi_gpu_accumulate(&model, &multi_gpu_config);
-        gpt2_multi_gpu_update(&model, learning_rate, 0.9f, 0.999f, 1e-8f, 0.0f, step+1, &multi_gpu_config);
+        gpt2_update(&model, learning_rate, 0.9f, 0.999f, 1e-8f, 0.0f, step+1, &multi_gpu_config);
         gpt2_multi_gpu_gather(&model, &multi_gpu_config);
-#endif
         // zero out the gradients for the next iteration
         gpt2_zero_grad(&model);
         cudaEventRecord(end);


### PR DESCRIPTION
First, clean up the multi-gpu code a bit. We only need to `#ifdef` away sections that would lead to compile errors, anything else can be handled with a regular plain if, making the code more readable. Also gets rid of the two copies of the update function, let's keep the unified as long as we can.

the current ZERO-1 implementation performs an all-reduce on the gradients, but only one shard is actually needed per rank.
As per the zero paper, 
> State-of-art implementation of all-reduce uses a two-step approach, where the first step is a reduce-scatter operation, which reduces different part of the data on different process. The next step is an all-gather operation where each process gathers the reduced data on all the process. The result of these two steps is an all-reduce.

The claim that ZERO-1 does not introduce communication overhead hinges on the fact that we just insert the adam update between these two ops. So we go from `reduce-scatter -> all-gather -> adam` to  `reduce-scatter -> adam -> all-gather`.