### PR TITLE
slight memory management improvements

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2409,8 +2409,6 @@ void common_start(bool override_enable_tf32 = true, bool print_device_info = tru
     bool enable_tf32 = PRECISION_MODE == PRECISION_FP32 && deviceProp.major >= 8 && override_enable_tf32;
     cublasCheck(cublasSetMathMode(cublas_handle, enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH));
     cublas_compute = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
-    // setup the (global) cuBLASLt workspace
-    cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
 
     create_cudnn();
 }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2340,12 +2340,11 @@ void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, flo
     floatX* grads_memory = (floatX*)model->grads_memory + multi_gpu_config->shard_offset;
 
     if (model->m_memory == NULL) {
-        cudaCheck(cudaMalloc((void**)&model->m_memory, num_parameters * sizeof(float)));
-        cudaCheck(cudaMalloc((void**)&model->v_memory, num_parameters * sizeof(float)));
-        cudaCheck(cudaMemset(model->m_memory, 0, num_parameters * sizeof(float)));
-        cudaCheck(cudaMemset(model->v_memory, 0, num_parameters * sizeof(float)));
-        printf0("allocated %zu MiB for AdamW optimizer state m\n", (num_parameters * sizeof(float)) >> 20);
-        printf0("allocated %zu MiB for AdamW optimizer state v\n", (num_parameters * sizeof(float)) >> 20);
+        size_t alloc_bytes = 2 * num_parameters * sizeof(float);
+        cudaCheck(cudaMalloc((void**)&model->m_memory, alloc_bytes));
+        model->v_memory = model->m_memory + num_parameters;
+        cudaCheck(cudaMemset(model->m_memory, 0, alloc_bytes));
+        printf0("allocated %zu MiB for AdamW optimizer state\n", alloc_bytes >> 20);
         if (model->use_master_weights == 1) {
             cudaCheck(cudaMalloc((void**)&model->master_weights, num_parameters * sizeof(float)));
             copy_and_cast_kernel<<<CEIL_DIV(num_parameters, 512), 512>>>(model->master_weights, params_memory, num_parameters);


### PR DESCRIPTION
small changes to how we handle gpu memory:
* allocate just once for the adam state
* print before allocation => makes it easier to see how things go wrong in OOM situations
* fixed memleak/duplicate allocation of cublaslt_workspace