### PR TITLE
NCCL only multi gpu training for slurm enabled cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ OMP_NUM_THREADS=8 ./train_gpt2
 
 The above lines (1) download the [tinyshakespeare](https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt) dataset, tokenize it with the GPT-2 Tokenizer, (2) download and save the GPT-2 (124M) weights, (3) init from them in C and train for 40 steps on tineshakespeare with AdamW (using batch size 4, context length only 64), evaluate validation loss, and sample some text. Honestly, unless you have a beefy CPU (and can crank up the number of OMP threads in the launch command), you're not going to get that far on CPU training LLMs, but it might be a good demo/reference.
 
-## quick start (multiple GPUs)
+## quick start (multiple GPUs, multiple nodes)
 
 You'll be using the (more bleeding edge) mixed precision version of the code:
 
+Download and install [nccl](https://docs.nvidia.com/deeplearning/nccl/install-guide/index.html#down).
 ```
 sudo apt install openmpi-bin openmpi-doc libopenmpi-dev
 pip install -r requirements.txt
@@ -83,6 +84,25 @@ mpirun -np <number of GPUs on your machine> ./train_gpt2cu
 ```
 
 Sub in the number of GPUs you'd like to run on in the last command.
+
+For the slurm enabled GPU cluster use following sbatch script sample for the multinode training: 
+
+```
+#!/bin/bash
+#SBATCH --job-name=llmc-multinode
+#SBATCH --output=/dfs/llm.c/multinode/%x_%j_%t.log
+#SBATCH --ntasks=32                                 # total number of processes to launch 
+#SBATCH --ntasks-per-node=8                         # assuming each node has 8 gpus
+#SBATCH --gres=gpu:8                                # request 8 gpus from each node
+#SBATCH --nodelist=node[001-003]                    # list of the nodes to dispatch processes 
+
+export DFS_PATH="/dfs/llm.c/multinode"              # this path will be used to save nccl unique id and sync it between processes
+# export NCCL_SOCKET_IFNAME=ib0                     # network interface Ethernet or InifiniBand which enables gpu direct rdma
+# export NCCL_IB_HCA=mlx5_0,mlx5_1                  # list of all InfiniBand devices available
+cd /dfs/llm.c/
+
+srun ./train_gpt2cu -i ./data/TinyStories -e ./gpt2_1558M_bf16.bin -v 250 -s 250 -g 250 -o /dfs/llm.c/logs/train_stories_${SLURM_JOB_ID}.log -b 12 -x 200 -z 1
+```
 
 ## training: more detail
 


### PR DESCRIPTION
Scheduling jobs using Slurm seems much easier in a multi-node training setup compared to setting up MPI for the cluster.
This draft contains the changes to use mpirun for single-node training and Slurm for multi-node training.

PyTorch uses one of the backends from Gloo, MPI, and NCCL for DDP. Maybe we don't need to use both MPI and NCCL together. It should be either CUDA-aware MPI or NCCL. Something to discuss further.

I got some interesting performance numbers in a large-scale training setup using llm.c.
I used the Ahrefs DGX H100 (80GB) Superpod. The cluster uses NVLINK for intra-node communications and InfiniBand RDMA for inter-node communications.

Without CUDNN we can reach up to batch_size=12
```
NumNodes    NumProcess  Latency(ms) tokens/sec(k)
1           8           395         249
2           16          674         296
4           32          817         484
8           64          1056        748
16          128         1087        1455
24          192         1320        1794
48          384         2054        2303
```
![oreo-multinode-llmc](https://github.com/karpathy/llm.c/assets/14182512/de9f8094-6572-4476-be89-91f9783c57d8)

Without CUDNN we can reach up to batch_size=24
```
NumNodes    NumProcess  Latency(ms) tokens/sec(k)
1           8           539         366
2           16          798         498
4           32          991         798
8           64          1158        1365
16          128         1247        2531
24          192         1478        3198
```
![oreo-multinode-llmc-cudnn](https://github.com/karpathy/llm.c/assets/14182512/dd9b0df7-cc0a-4efc-8595-dcd29584b2ab)