### PR TITLE
Fix the unsupported block_size in matmul_backward_bias kernel 1

### DIFF
--- a/dev/cuda/matmul_backward_bias.cu
+++ b/dev/cuda/matmul_backward_bias.cu
@@ -421,6 +421,9 @@ __global__ void reduce_add_sum_kernel(floatX* dst, const float* src, size_t n, s
 // version1: simple cuBLAS calls
 void matmul_backward_bias1(floatX* dbias, const floatX* dout,
                       int B, int T, int OC, int block_size) {
+    if (block_size == 768) {
+        block_size = 1024;      // block_size needs to be power of 2 due to the reduction
+    }
     dim3 block_dim(block_size);
     dim3 grid_dim(OC);
     size_t shared_mem_size = block_size * sizeof(float);

--- a/dev/cuda/matmul_backward_bias.cu
+++ b/dev/cuda/matmul_backward_bias.cu
@@ -27,6 +27,26 @@ sudo ncu --set full --import-source yes -o bias -f ./matmul_backward_bias 1
 #define ENABLE_BF16
 #include "common.h"
 
+
+// ----------------------------------------------------------------------------
+// utility functions
+__host__ __device__ bool isPowerOfTwo(int n) {
+    return (n > 0) && ((n & (n - 1)) == 0);
+}
+
+__host__ __device__ int largestPowerOfTwoLessOrEqual(int n) {
+    // Return the largest power of 2 less than or equal to n
+    if (n < 1) {
+        return 0;
+    }
+
+    while ((n & (n - 1)) > 0) {
+        n = n & (n - 1);
+    }
+
+    return n;
+}
+
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -421,9 +441,8 @@ __global__ void reduce_add_sum_kernel(floatX* dst, const float* src, size_t n, s
 // version1: simple cuBLAS calls
 void matmul_backward_bias1(floatX* dbias, const floatX* dout,
                       int B, int T, int OC, int block_size) {
-    if (block_size == 768) {
-        block_size = 1024;      // block_size needs to be power of 2 due to the reduction
-    }
+    block_size = largestPowerOfTwoLessOrEqual(block_size);
+    assert(isPowerOfTwo(block_size)); // block_size needs to be power of 2 due to the reduction
     dim3 block_dim(block_size);
     dim3 grid_dim(OC);
     size_t shared_mem_size = block_size * sizeof(float);


### PR DESCRIPTION
Due to the reduction in line https://github.com/karpathy/llm.c/blob/master/dev/cuda/matmul_backward_bias.cu#L67 
The block size needs to be the power of 2 for the `kernel 1`. Otherwise the GPU result is wrong:

```
Using kernel 1
Checking correctness...
1.125032 1.054688
26.328930 26.375000
11.523789 11.437500
17.523972 17.500000
16.781761 16.750000
All results match for block_size=32.

Checking correctness...
1.125032 1.054688
26.328930 26.375000
11.523789 11.437500
17.523972 17.500000
16.781761 16.750000
All results match for block_size=64.

Checking correctness...
1.125032 1.054688
26.328930 26.375000
11.523789 11.437500
17.523972 17.500000
16.781761 16.750000
All results match for block_size=128.

Checking correctness...
1.125032 1.054688
26.328930 26.375000
11.523789 11.437500
17.523972 17.500000
16.781761 16.750000
All results match for block_size=256.

Checking correctness...
1.125032 1.054688
26.328930 26.375000
11.523789 11.437500
17.523972 17.500000
16.781761 16.750000
All results match for block_size=512.

Checking correctness...
1.125032 3.562500
Mismatch of dbias at 0: CPU_ref: 1.125032 vs GPU: 3.562500
26.328930 19.500000
Mismatch of dbias at 1: CPU_ref: 26.328930 vs GPU: 19.500000
11.523789 2.765625
Mismatch of dbias at 2: CPU_ref: 11.523789 vs GPU: 2.765625
17.523972 8.125000
Mismatch of dbias at 3: CPU_ref: 17.523972 vs GPU: 8.125000
16.781761 -1.429688
Mismatch of dbias at 4: CPU_ref: 16.781761 vs GPU: -1.429688
Mismatch of dbias at 5: CPU_ref: -6.718957 vs GPU: 10.437500
Mismatch of dbias at 6: CPU_ref: 10.953457 vs GPU: -3.593750
Mismatch of dbias at 7: CPU_ref: 14.391066 vs GPU: -98.500000
Mismatch of dbias at 9: CPU_ref: -34.071350 vs GPU: -23.625000
Mismatch of dbias at 10: CPU_ref: -0.218756 vs GPU: -22.000000
```

[The reduction for non-power-2 blocksize is more complicated and may not be suitable for kernel 1 as the demonstration].