### PR TITLE
Fully deterministic encoder backward kernels

### DIFF
--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     // do a training step
     gpt2_forward(&model, x, y, B, T);
     gpt2_zero_grad(&model);
-    gpt2_backward(&model);
+    gpt2_backward(&model, x);
     gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, 1.f, 1, &multi_gpu_config);
     cudaCheck(cudaDeviceSynchronize()); // finish all CUDA work to get correct precise timings
 

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
         clock_gettime(CLOCK_MONOTONIC, &start);
         gpt2_forward(&model, x, y, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward(&model);
+        gpt2_backward(&model, x);
         clock_gettime(CLOCK_MONOTONIC, &end);
         double time_elapsed_s = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
 

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -39,6 +39,7 @@ This reads & runs in fp32, B=4, T=64, LR=1e-4, val/sample never (200),
 #include <stdarg.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <functional>
 #include <unordered_map>
 // GPU / CUDA related


### PR DESCRIPTION
This is a complete rewrite of the encoder backward pass, splitting it into two kernels (wte and wpe) which are both fully deterministic as they do not use atomics (assuming the seed for stochastic rounding is also deterministic, ofc).

The performance of the wte kernel and the associated CPU overhead are quite input-dependent, it might be quite slow for pathological cases (e.g. all tokens are the same). I tried updating /dev/cuda/ and there were a few problems. Most importantly, the performance on the random inputs was bad on the CPU side, and there was no way to hide the significant CPU overhead unlike in the real training loop.

Interestingly, profile_gpt2.cu is also broken when profiling the *current* encoder_backward: it is unrealistically fast (or more likely the train_gpt2.cu one is abnormally slow and needed fixing but not worth debugging it now...) - so in profile_gpt2.cu, this new kernel looks like it is much slower, but...

Performance actually improves by nearly ~1% on my RTX 4090 with a batch size of 24:

> Current: 106213 tokens/s
> New: 107216 tokens/s (+0.94%)

Unfortunately, while this made training *nearly* deterministic a week ago with only layernorm_backward still using atomics which didn't seem to noticeably impact training loss, the addition of gradient clipping seems to cause a lot of non-determinism, so we will also need to make that kernel deterministic to be identical bit-for-bit between runs (and make sure we save/restore the seed if we pause/restart a training run).