### PR TITLE
Added new cuda kernel for encoder forwards using three dimensional kernels

### DIFF
--- a/dev/cuda/encoder_forward.cu
+++ b/dev/cuda/encoder_forward.cu
@@ -115,6 +115,31 @@ __global__ void encoder_forward_kernel3(floatX* out,
     }
 }
 
+__global__ void encoder_forward_kernel4(floatX* out,
+                                        const int* inp, const floatX* wte, const floatX* wpe,
+                                        int C) {
+    int c = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
+    int t = blockIdx.y;
+    int b = blockIdx.z;
+
+    if (c < C) {
+        int ix = inp[b * gridDim.y + t];
+
+        floatX* out_btc = out + b * gridDim.y * C + t * C + c;
+        const floatX* wte_ix = wte + ix * C + c;
+        const floatX* wpe_tc = wpe + t * C + c;
+
+        x128 packed_out;
+        x128 wte128 = load128cs(wte_ix);
+        x128 wpe128 = load128cs(wpe_tc);
+        #pragma unroll
+        for (int k = 0; k < x128::size; k++) {
+            packed_out[k] = (floatX)((float)wte128[k] + (float)wpe128[k]);
+        }
+        store128(out_btc, packed_out);
+    }
+}
+
 // ----------------------------------------------------------------------------
 // kernel launcher
 
@@ -148,6 +173,16 @@ void encoder_forward3(floatX* out,
     cudaCheck(cudaGetLastError());
 }
 
+void encoder_forward4(floatX* out,
+                      const int* inp, const floatX* wte, const floatX* wpe,
+                      int B, int T, int C,
+                      const int block_size) {
+    const int num_c_blocks = ceil_div(C, x128::size * block_size);
+    dim3 grid_size(num_c_blocks, T, B);
+    encoder_forward_kernel4<<<grid_size, block_size>>>(out, inp, wte, wpe, C);
+    cudaCheck(cudaGetLastError());
+}
+
 // kernel version dispatch
 void encoder_forward(int kernel_num,
                      floatX* out,
@@ -163,6 +198,9 @@ void encoder_forward(int kernel_num,
             break;
         case 3:
             encoder_forward3(out, inp, wte, wpe, B, T, C, block_size);
+            break;
+        case 4:
+            encoder_forward4(out, inp, wte, wpe, B, T, C, block_size);
             break;
         default:
             printf("Invalid kernel number\n");


### PR DESCRIPTION
Spent the afternoon trying to understand how the multi dimensional cuda kernel instantiation works and came up with an example for the encoder forwards but I'm having the issue that for large block sizes its slower. Would love for someone with more understanding of how this works to take a look.

Kernel 3:
block_size   32 | time 0.0309 ms | bandwidth 3257.16 GB/s
block_size   64 | time 0.0293 ms | bandwidth 3436.13 GB/s
block_size  128 | time 0.0291 ms | bandwidth 3463.98 GB/s
block_size  256 | time 0.0294 ms | bandwidth 3428.10 GB/s
block_size  512 | time 0.0293 ms | bandwidth 3436.86 GB/s
block_size 1024 | time 0.0300 ms | bandwidth 3351.67 GB/s


Kernel 4:
block_size   32 | time 0.0306 ms | bandwidth 3286.23 GB/s
block_size   64 | time 0.0295 ms | bandwidth 3416.79 GB/s
block_size  128 | time 0.0292 ms | bandwidth 3444.44 GB/s
block_size  256 | time 0.0295 ms | bandwidth 3413.71 GB/s
block_size  512 | time 0.0315 ms | bandwidth 3194.80 GB/s
block_size 1024 | time 0.0518 ms | bandwidth 1942.42 GB/s

I'm having a hard time intuitively understanding why it could be slower since its removes all of the modulo, and division operations