### PR TITLE
test_gpt2.c: detailed timings

### DIFF
--- a/test_gpt2.c
+++ b/test_gpt2.c
@@ -50,18 +50,6 @@ double timespec_difference_ms(struct timespec start, struct timespec end)
 }
 
 int main(int argc, char *argv[]) {
-#if _WIN32
-    SetCurrentDirectory("C:\\git\\oss\\llm.c");
-    char buffer[MAX_PATH];
-    if (GetCurrentDirectory(MAX_PATH, buffer)) {
-        printf("Current working directory: %s\n", buffer);
-    }
-    else {
-        printf("Error getting current directory\n");
-    }
-
-
-#endif
     // build the GPT-2 model from a checkpoint
     GPT2 model;
     gpt2_build_from_checkpoint(&model, "gpt2_124M.bin");

--- a/test_gpt2.c
+++ b/test_gpt2.c
@@ -45,7 +45,7 @@ struct timespec clock_gettime_monotonic()
 
 double timespec_difference_ms(struct timespec start, struct timespec end)
 {
-    double ms = (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_nsec - start.tv_nsec) / 1e6;
+    double ms = (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_nsec - start.tv_nsec) * 0.000001;
     return ms;
 }
 


### PR DESCRIPTION
@karpathy add detailed timings with output like:
```
step 0: loss 5.269890 OK = 1 ( 4516 ms = forward 1328 ms zero_grad  0 ms backward 2625 ms update  563 ms)
step 1: loss 4.059388 OK = 1 ( 4203 ms = forward 1031 ms zero_grad 47 ms backward 2609 ms update  516 ms)
step 2: loss 3.374212 OK = 1 ( 4218 ms = forward 1062 ms zero_grad 31 ms backward 2610 ms update  515 ms)
step 3: loss 2.800128 OK = 1 ( 4204 ms = forward 1094 ms zero_grad 16 ms backward 2578 ms update  516 ms)
```
note timing includes "update" now. (Numbers from 5950X).