### PR TITLE
[WIP - Fix] Add assert for layernorm kernel 8

### DIFF
--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -21,7 +21,6 @@ version 2 moves a lot of reduction to shared memory over global memory
 #define ENABLE_BF16
 #include "common.h"
 
-// typedef unsigned int uint;              needed on windows
 // ----------------------------------------------------------------------------
 // CPU code reference
 

--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -744,7 +744,7 @@ __global__ void __launch_bounds__(1024, MAX_1024_THREADS_BLOCKS)
     int warpThreadIdx = threadIdx.x % warpSize; // Thread index within the warp
     int warpsInGrid = gridDim.x * warpsInBlock;
     int C_per_iteration = warpSize * x128::size;
-    int iterations_C = C / C_per_iteration;
+    int iterations_C = ceil_div(C, C_per_iteration);
 
     // the first half of shared memory is bias, second is weight
     float* dbias_shared = shared;
@@ -1325,7 +1325,7 @@ template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
 void layernorm_backward8(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
                         const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
                         int B, int T, int C, int block_size) {
-        assert(C % (32 * x128::size) == 0  && "Channels must be divisible by (32 * x128::size)");
+        // assert(C % (32 * x128::size) == 0  && "Channels must be divisible by (32 * x128::size)");
         const int grid_size = (1024/block_size) * cuda_num_SMs;
         size_t shared_mem_size = (2 * C + 1) * sizeof(float);
 

--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -21,6 +21,7 @@ version 2 moves a lot of reduction to shared memory over global memory
 #define ENABLE_BF16
 #include "common.h"
 
+// typedef unsigned int uint;              needed on windows
 // ----------------------------------------------------------------------------
 // CPU code reference
 
@@ -1325,6 +1326,7 @@ template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>
 void layernorm_backward8(Tdinp* dinp, Tparams* dweight, Tparams* dbias, float* scratch,
                         const Tdout* dout, const Trest* inp, const Tparams* weight, const Trest* mean, const Trest* rstd,
                         int B, int T, int C, int block_size) {
+        assert(C % (32 * x128::size) == 0  && "Channels must be divisible by (32 * x128::size)");
         const int grid_size = (1024/block_size) * cuda_num_SMs;
         size_t shared_mem_size = (2 * C + 1) * sizeof(float);
 


### PR DESCRIPTION
Original without assert
```
Using kernel 8
Checking correctness...
dinp:
-0.559983 -0.559983
0.620476 0.620476
0.028621 0.028621
0.765740 0.765740
0.062205 0.062205
Mismatch of dinp at 1536: CPU_ref: 0.207321 vs GPU: 0.000000
Mismatch of dinp at 1537: CPU_ref: -0.113342 vs GPU: 0.000000
Mismatch of dinp at 1538: CPU_ref: 0.212997 vs GPU: 0.000000
Mismatch of dinp at 1539: CPU_ref: -0.253951 vs GPU: 0.000000
Mismatch of dinp at 1540: CPU_ref: -0.095276 vs GPU: 0.000000
Mismatch of dinp at 1541: CPU_ref: -0.259907 vs GPU: 0.000000
Mismatch of dinp at 1542: CPU_ref: 0.034323 vs GPU: 0.000000
Mismatch of dinp at 1543: CPU_ref: -0.436444 vs GPU: 0.000000
Mismatch of dinp at 1544: CPU_ref: 0.438957 vs GPU: 0.000000
Mismatch of dinp at 1545: CPU_ref: 0.179537 vs GPU: 0.000000
````

Tested on C = 1024 and case passed.