### PR TITLE
Fix "Mismatch of dweight at layernorm_backward.cu #428"

### DIFF
--- a/dev/cuda/layernorm_backward.cu
+++ b/dev/cuda/layernorm_backward.cu
@@ -1278,6 +1278,8 @@ void layernorm_backward2(Tdinp* dinp, Tparams* dweight, Tparams* dbias,
     cudaMemset(dbias_tmp, 0, C * sizeof(float));
     layernorm_backward_kernel2<<<grid_size, block_size, shared_mem_size>>>(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T, C, dweight_tmp, dbias_tmp);
     copy_to_dweight_dbias<<<1, 512>>>(C, dweight, dbias, dweight_tmp, dbias_tmp);
+    cudaCheck(cudaFree(dweight_tmp));
+    cudaCheck(cudaFree(dbias_tmp));
 }
 
 template <typename Tdinp, typename Tparams, typename Tdout, typename Trest>


### PR DESCRIPTION
1. Fix #428, the root cause: we are doing accumulation using the bfloat precision directly in atomicaddX, which results in a final error that is large.  The fix is to do accumulation in `float` (temp array allocated on device) and write the final accumulated result as `bfloat`.
2. spell the uint to `unsigned int` since uint isn't an actual type in C or C++ (comments from @ngc92 ).


After fix, kernel 2 passed.
```
Using kernel 2
Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=32.

Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=64.

Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=128.

Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=256.

Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=512.

Checking correctness...
dinp:
-0.559983 -0.562500
0.620476 0.621094
0.028621 0.028564
0.765740 0.765625
0.062205 0.062256
dweight:
-23.181511 -23.125000
-85.985672 -86.000000
-16.258125 -16.250000
-3.262060 -3.156250
59.474670 59.250000
dbias:
-30.434944 -30.500000
-93.241646 -93.500000
-41.022255 -41.000000
-13.087867 -13.125000
-56.647667 -56.500000
All results match for block_size=1024.

block_size   32 time 1.3195 ms
block_size   64 time 0.7869 ms
block_size  128 time 0.5699 ms
block_size  256 time 0.4764 ms
block_size  512 time 0.4901 ms
block_size 1024 time 0.5541 ms
```
