### PR TITLE
`softmax_autoregressive_backward_kernel` does not use share memory in the kernel

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1875,7 +1875,7 @@ void attention_backward(floatX* dinp, floatX* dqkvr, floatX* dpreatt, floatX* da
     // backward into preatt
     int hs = C / NH; // head size
     float scale = 1.0f / sqrtf(hs);
-    softmax_autoregressive_backward_kernel<<<dim3(T / 4, B * NH), 256, 256>>>(dpreatt, datt, att, B, T, C, scale);
+    softmax_autoregressive_backward_kernel<<<dim3(T / 4, B * NH), 256>>>(dpreatt, datt, att, B, T, C, scale);
     // backward into q
     cublasCheck(cublasGemmStridedBatchedEx(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, HS, T, T, &alpha,
                                            k, CUBLAS_LOWP, HS, T * HS, dpreatt, CUBLAS_LOWP, T, T * T, &beta,


### PR DESCRIPTION
`softmax_autoregressive_backward_kernel` does not use share memory in the kernel.

we do not need to launch the kernel with 256 bytes share memory, so remove it