### PR TITLE
Modal benchmarking script updated to replace deprecated calls

### DIFF
--- a/dev/cuda/benchmark_on_modal.py
+++ b/dev/cuda/benchmark_on_modal.py
@@ -27,7 +27,7 @@ GPU_NAME_TO_MODAL_CLASS_MAP = {
 N_GPUS = int(os.environ.get("N_GPUS", 1))
 GPU_MEM = int(os.environ.get("GPU_MEM", 40))
 GPU_NAME = os.environ.get("GPU_NAME", "A100")
-GPU_CONFIG = GPU_NAME_TO_MODAL_CLASS_MAP[GPU_NAME](count=N_GPUS, memory=GPU_MEM)
+GPU_CONFIG = GPU_NAME_TO_MODAL_CLASS_MAP[GPU_NAME](count=N_GPUS, size=str(GPU_MEM)+'GB')
 
 APP_NAME = "llm.c benchmark run"
 
@@ -51,7 +51,7 @@ axolotl_image = (
     )
 )
 
-stub = Stub(APP_NAME)
+stub = modal.App(APP_NAME)
 
 
 def execute_command(command: str):


### PR DESCRIPTION
The old script was not working due to deprecated API calls, it gave the following errors as shown in the picture below:

<img width="1320" alt="Screenshot 2024-05-29 at 8 03 48 PM" src="https://github.com/karpathy/llm.c/assets/93402393/b393c762-d4d5-4060-b3ee-cc970d7e92ff">

So I just updated those.