### PR TITLE
pytorch parity v1

### DIFF
--- a/pyrun124M.sh
+++ b/pyrun124M.sh
@@ -1,9 +1,17 @@
 
-# the same as run124M.sh but in PyTorch
+# the same as run124M.sh but with PyTorch
+# current restrictions:
+# - does not write checkpoint, only logs of the train/val losses
+# - does not evaluate hellaswag accuracy
+# - cannot "resume training" (i.e. the `-y 1` flag)
+
 # if you wish to train on just a single GPU, simply skip the torchrun part, i.e.
 # python train_gpt2.py ... (all the other arguments the same)
 torchrun --standalone --nproc_per_node=4 train_gpt2.py \
     --input_bin "dev/data/fineweb10B/fineweb_train_*.bin" \
+    --input_val_bin "dev/data/fineweb10B/fineweb_val_*.bin" \
+    --val_loss_every 250 \
+    --sample_every 0 \
     --output_dir pylog124M \
     --write_tensors 0 \
     --model d12 \

--- a/pyrun124M.sh
+++ b/pyrun124M.sh
@@ -1,0 +1,22 @@
+
+# the same as run124M.sh but in PyTorch
+# if you wish to train on just a single GPU, simply skip the torchrun part, i.e.
+# python train_gpt2.py ... (all the other arguments the same)
+torchrun --standalone --nproc_per_node=4 train_gpt2.py \
+    --input_bin dev/data/fineweb10B/fineweb_train_000001.bin \
+    --write_tensors 0 \
+    --model d12 \
+    --batch_size 32 \
+    --sequence_length 1024 \
+    --total_batch_size 524288 \
+    --dtype bfloat16 \
+    --compile 1 \
+    --tensorcores 1 \
+    --flash 1 \
+    --num_iterations 18865 \
+    --weight_decay 0.1 \
+    --zero_stage 1 \
+    --learning_rate 0.0006 \
+    --warmup_iters 700 \
+    --learning_rate_decay_frac 0.0 \
+    --overfit_single_batch 0

--- a/pyrun124M.sh
+++ b/pyrun124M.sh
@@ -4,6 +4,7 @@
 # python train_gpt2.py ... (all the other arguments the same)
 torchrun --standalone --nproc_per_node=4 train_gpt2.py \
     --input_bin dev/data/fineweb10B/fineweb_train_000001.bin \
+    --output_dir pylog124M \
     --write_tensors 0 \
     --model d12 \
     --batch_size 32 \

--- a/pyrun124M.sh
+++ b/pyrun124M.sh
@@ -3,7 +3,7 @@
 # if you wish to train on just a single GPU, simply skip the torchrun part, i.e.
 # python train_gpt2.py ... (all the other arguments the same)
 torchrun --standalone --nproc_per_node=4 train_gpt2.py \
-    --input_bin dev/data/fineweb10B/fineweb_train_000001.bin \
+    --input_bin "dev/data/fineweb10B/fineweb_train_*.bin" \
     --output_dir pylog124M \
     --write_tensors 0 \
     --model d12 \

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -365,11 +365,11 @@ class DistributedDataLoader:
         buf = torch.tensor(buf.astype(np.int32), dtype=torch.long)
         x = (buf[:-1]).view(B, T) # inputs
         y = (buf[1:]).view(B, T) # targets
-        # advance current position and load next shard if necessary
+        # advance the start pointer in current shard
+        self.current_position += B * T * self.num_processes
+        # if loading the next batch would be out of bounds advance the shard
         if self.current_position + (B * T * self.num_processes + 1) > len(self.tokens):
             self.advance()
-        else:
-            self.current_position += B * T * self.num_processes
         return x, y
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I believe we're getting the same results as `./run124M.sh` with this as of this PR:

```bash
# the same as run124M.sh but in PyTorch
# if you wish to train on just a single GPU, simply skip the torchrun part, i.e.
# python train_gpt2.py ... (all the other arguments the same)
torchrun --standalone --nproc_per_node=8 train_gpt2.py \
    --input_bin dev/data/fineweb10B/fineweb_train_000001.bin \
    --write_tensors 0 \
    --model d12 \
    --batch_size 32 \
    --sequence_length 1024 \
    --total_batch_size 524288 \
    --dtype bfloat16 \
    --compile 1 \
    --tensorcores 1 \
    --flash 1 \
    --num_iterations 18865 \
    --weight_decay 0.1 \
    --zero_stage 1 \
    --learning_rate 0.0006 \
    --warmup_iters 700 \
    --learning_rate_decay_frac 0.0 \
    --overfit_single_batch 0
```

but only for 1 data shard. the dataloader is still not set up to do multiple shards.