### PR TITLE
[Python code]: fix leak of validation examples into training loop

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -746,9 +746,9 @@ if __name__ == "__main__":
             with torch.no_grad():
                 val_loss = 0.0
                 for _ in range(args.val_max_steps):
-                    x, y = val_loader.next_batch()
-                    x, y = x.to(device), y.to(device)
-                    _, loss = model(x, y, return_logits=False)
+                    x_val, y_val = val_loader.next_batch()
+                    x_val, y_val = x_val.to(device), y_val.to(device)
+                    _, loss = model(x_val, y_val, return_logits=False)
                     val_loss += loss.item()
                 val_loss /= args.val_max_steps
             # log to console and to file
@@ -768,13 +768,13 @@ if __name__ == "__main__":
                 # before we end, let's also do one round of inference
                 # we'll kick off the generation with "<|endoftext|>", which designates the start of a new sequence
                 start_ids = [enc.eot_token]
-                x = (torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...])
+                x_sample = (torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...])
                 max_new_tokens = 32
                 temperature = 1.0
                 top_k = 40
-                y = raw_model.generate(x, max_new_tokens, temperature=temperature, top_k=top_k)
+                y_sample = raw_model.generate(x_sample, max_new_tokens, temperature=temperature, top_k=top_k)
                 print0('---------------')
-                print0(enc.decode(y[0].tolist()))
+                print0(enc.decode(y_sample[0].tolist()))
                 print0('---------------')
 
         # bit confusing: we want to make sure to eval and sample on 0th iteration


### PR DESCRIPTION
I was running this code with validation enabled every 128 steps when I noticed a strange pattern in the loss:

<img width="604" alt="Screenshot 2024-05-30 at 10 41 34 AM" src="https://github.com/karpathy/llm.c/assets/18433116/f246db3f-5e97-4305-940b-657aca664812">

This is caused by the fact that the validation batches share a scope and name with the training batches. So, the network ends up training on the last batch of validation examples once after every run of validation.

This can be fixed by giving the valid batches a different name. I also gave the batches used for sampling a different name.

Thanks