### PR TITLE
Inplace gelu backward

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2885,8 +2885,8 @@ void gpt2_free(GPT2 *model) {
     cudaCheck(cudaFree(model->grads_acts_memory));
     cudaCheck(cudaFree(model->inputs));
     cudaCheck(cudaFree(model->targets));
-    cudaFreeHost(model->cpu_losses);
-    cudaFreeHost(model->cpu_losses_fp32);
+    cudaCheck(cudaFreeHost(model->cpu_losses));
+    cudaCheck(cudaFreeHost(model->cpu_losses_fp32));
     free(model->workload_indices);
     free(model->bucket_info);
 }


### PR DESCRIPTION
make it obvious to the reader that the gelu backward operation is performed in-place, so we don't get any accidental "optimizations" in the future (like applying __restrict__ wrongly)