### PR TITLE
fix compilation with older nvcc

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -228,10 +228,10 @@ struct alignas(16) Packed128 {
         return result;
     }
     __device__ static Packed128 zeros() {
-        return constant(0);
+        return constant(0.f);
     }
     __device__ static Packed128 ones() {
-        return constant(1);
+        return constant(1.f);
     }
 
     __device__ ElementType& operator[](int index) {


### PR DESCRIPTION
`bfloat16(0)` leads to an ambiguous conversion for older `nvcc`s, because it could either be int->float->bfloat or int->double->bfloat. Both would actually lead to the same result, but  the compiler doesn't know that, so we help it along by explicitly putting a float literal there.