### PR TITLE
Removing B in encoder and replacing with calculated N in kernel

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -521,9 +521,8 @@ E.g., the layernorms are connected to the residuals so we += in layernorm backwa
 
 __global__ void encoder_forward_kernel3(floatX* out,
                                const int* inp, const floatX* wte, const floatX* wpe,
-                               int B, int T, int C) {
+                               int N, int T, int C) {
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
-    int N = B * T * C;
     if (idx >= N) { return; }
 
     int bt = idx / C;
@@ -1494,7 +1493,7 @@ void encoder_forward(floatX* out,
     const int block_size = 256;
     const int N = B * T * C;
     const int grid_size = CEIL_DIV(N, (int)(block_size * x128::size));
-    encoder_forward_kernel3<<<grid_size, block_size>>>(out, inp, wte, wpe, B, T, C);
+    encoder_forward_kernel3<<<grid_size, block_size>>>(out, inp, wte, wpe, N, T, C);
     cudaCheck(cudaGetLastError());
 }
 


### PR DESCRIPTION
Simple change that removes multiple calculations and passes the total number of parameters into the kernel. There are a few places where this occurs in the codebase and ideally all of them can be changed to this format to reduce the number of calculations in the kernels