### PR TITLE
Add master weights to resume state

### DIFF
--- a/llmc/global_norm.cuh
+++ b/llmc/global_norm.cuh
@@ -13,13 +13,7 @@ Global norm, used in gradient clipping
 
 template<class T>
 __device__ float global_norm_squared_for_range(const T* data, size_t count) {
-    // we want as few atomics as possible, so each block tries to do
-    // the maximum amount of work (so no fixed chunk, but instead iterating
-    // until we run out of data), and then we reduce inside the block
-    // and finally have just one atomic per block.
-    // out will be updated atomically from all thread blocks. It is a float, so the
-    // atomic op is unproblematic
-    size_t index = threadIdx.x + blockDim.x * blockIdx.x;
+    size_t index = blockIdx.x * blockDim.x + threadIdx.x;
     size_t grid_width = blockDim.x * gridDim.x;
     float accumulator = 0.f;
     for(size_t i = index; i < count; i += grid_width) {
@@ -32,8 +26,22 @@ __device__ float global_norm_squared_for_range(const T* data, size_t count) {
 template<class T>
 __global__ void global_norm_squared_kernel(float* out, const T* data, size_t count, ptrdiff_t stride) {
     float block_sum = global_norm_squared_for_range(data + blockIdx.y * stride, count);
+    // each block accumulates its partial sum to out[out_index]
+    // we want to avoid using atomic add here so we combine this kernel with another kernel call
+    // that sums up the partial block sums
     if(threadIdx.x == 0) {
-        atomicAdd(out, block_sum);
+        size_t out_index = blockIdx.y * gridDim.x + blockIdx.x;
+        *(out + out_index) = *(out + out_index) + block_sum;
+    }
+}
+
+__global__ void global_norm_aggregate_kernel(float* out, size_t grid_size) {
+    size_t index = threadIdx.x;
+    // grab block sums from the previous kernel, use 0. as the neutral sum element
+    float block_sum = (index < grid_size) ? out[index] : 0.f;
+    float sum = blockReduce<warpReduceSum>(block_sum);
+    if(threadIdx.x == 0) {
+        *out = sum;  // out[0] ends up with the final norm squared
     }
 }
 
@@ -50,9 +58,10 @@ void global_norm_squared(float* out, const T* values, size_t count, ptrdiff_t st
     // on all gpus, so the division really is going to be exact.
     const int grid_size = deviceProp.maxThreadsPerMultiProcessor * deviceProp.multiProcessorCount / block_size;
     assert(grid_size > 0);      // gives a better error than letting the call below fail
+    assert(grid_size < 1024);  // we want to later accumulate the block sums in a single block
     // initialize out with zero
     if(reset) {
-        cudaCheck(cudaMemsetAsync(out, 0, sizeof(float), stream));
+        cudaCheck(cudaMemsetAsync(out, 0, grid_size * sizeof(float), stream));
     }
     const int gx = CEIL_DIV(grid_size, num_slices);
     const int gy = num_slices;
@@ -60,3 +69,12 @@ void global_norm_squared(float* out, const T* values, size_t count, ptrdiff_t st
     cudaCheck(cudaGetLastError());
 }
 
+void global_norm_squared_aggregate(float* out, cudaStream_t stream) {
+    const int block_size = 512;
+    const int grid_size = deviceProp.maxThreadsPerMultiProcessor * deviceProp.multiProcessorCount / block_size;
+    assert(grid_size > 0);
+    assert(grid_size < 1024);
+
+    global_norm_aggregate_kernel<<<1, grid_size, 0, stream>>>(out, grid_size);
+    cudaCheck(cudaGetLastError());
+}

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1188,6 +1188,8 @@ void save_state(const char* filename, int step, GPT2* model, DataLoader* loader)
     fwrite(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
     cudaCheck(cudaMemcpy(cpu_buffer, model->v_memory, shard_num_parameters * sizeof(float), cudaMemcpyDeviceToHost));
     fwrite(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
+    cudaCheck(cudaMemcpy(cpu_buffer, model->master_weights, shard_num_parameters * sizeof(float), cudaMemcpyDeviceToHost));
+    fwrite(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
     free(cpu_buffer);
     fclose(state_file);
 }
@@ -1219,6 +1221,8 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     cudaCheck(cudaMemcpy(model->m_memory, cpu_buffer, shard_num_parameters * sizeof(float), cudaMemcpyHostToDevice));
     freadCheck(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
     cudaCheck(cudaMemcpy(model->v_memory, cpu_buffer, shard_num_parameters * sizeof(float), cudaMemcpyHostToDevice));
+    freadCheck(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
+    cudaCheck(cudaMemcpy(model->master_weights, cpu_buffer, shard_num_parameters * sizeof(float), cudaMemcpyHostToDevice));
     free(cpu_buffer);
     fclose(state_file);
 }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -974,13 +974,12 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
         // because of the ncclReduceScatter() in backward,
         // grads_memory only contains the averaged gradients at the local shards,
         // so we only calculate the grad norm at the grads_memory belonging to the local shards
-        cudaCheck(cudaMemsetAsync(grad_norm_squared, 0, sizeof(float), main_stream));
         for (int i = 0; i < NUM_PARAMETER_TENSORS; i++) {
             if((i < 2 || i > 13)) {
                 ShardInfo tensor = gpt2_get_tensor_at_layer(model, 0, i);
                 ShardInfo shard = multi_gpu_get_shard_offset(tensor.size, multi_gpu_config, 1);
                 ptrdiff_t offset = tensor.offset + shard.offset;
-                global_norm_squared(grad_norm_squared, grads_memory + offset, shard.size, 0, 1, false, main_stream);
+                global_norm_squared(grad_norm_squared, grads_memory + offset, shard.size, 0, 1, i == 0, main_stream);
             } else {
                 ShardInfo tensor = gpt2_get_tensor_at_layer(model, 0, i);
                 ShardInfo shard = multi_gpu_get_shard_offset(tensor.size, multi_gpu_config, 1);
@@ -989,6 +988,7 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
                                     false, main_stream);
             }
         }
+        global_norm_squared_aggregate(grad_norm_squared, main_stream);
         cudaCheck(cudaMemcpy(&grad_norm_squared_cpu, grad_norm_squared, sizeof(float), cudaMemcpyDeviceToHost));
         // further sum the (partial) squared norm across all GPUs (see comment ^1 above)
         grad_norm_squared_cpu = multi_gpu_cpu_float_sum(grad_norm_squared_cpu);
@@ -996,6 +996,7 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
         // in regular DDP, backward has averaged the gradients across all GPUs
         // so each GPU can compute the squared norm over the whole grad vector, with no added comms needed
         global_norm_squared(grad_norm_squared, grads_memory, model->num_parameters, 0, 1, true, main_stream);
+        global_norm_squared_aggregate(grad_norm_squared, main_stream);
         cudaCheck(cudaMemcpy(&grad_norm_squared_cpu, grad_norm_squared, sizeof(float), cudaMemcpyDeviceToHost));
     }
 


### PR DESCRIPTION
We're currently not saving master weights as part of the state -> we lose some precision because otherwise when we resume we'll have to reconstruct the master weights by upcasting from lower precision params.