### PR TITLE
Fix zero stage 1 norm computation

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2764,17 +2764,17 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
     // repurposing this buffer (which isn't needed now) to write grad norm into it
     float* grad_norm_squared = (float*)model->acts.output;
     if (multi_gpu_config->zero_stage == 1) {
-        // we only have a local shard of the gradients, so we need to compute the norm of the local shard
-        global_norm_squared(grad_norm_squared, (floatX*)model->grads_memory + shard_offset, shard_num_parameters);
+        // only the local grad shard has correct values -> compute the squared norm of the local grad shard
+        global_norm_squared(grad_norm_squared, grads_memory + shard_offset, shard_num_parameters);
     } else {
-        // we have all the gradients, so we can compute the norm of all the gradients
-        global_norm_squared(grad_norm_squared, (floatX*)model->grads_memory, model->num_parameters);
+        // all grad shards have correct values -> compute the squared norm of the whole grad vector
+        global_norm_squared(grad_norm_squared, grads_memory, model->num_parameters);
     }
     // transfer the gradient norm to CPU
     float grad_norm_squared_cpu = 0.0f;
     cudaCheck(cudaMemcpy(&grad_norm_squared_cpu, grad_norm_squared, sizeof(float), cudaMemcpyDeviceToHost));
     if (multi_gpu_config->zero_stage == 1) {
-        // we have to sum the gradient norm across all GPUs as they're only partial
+        // sum the squared norm across all GPUs as they're only partial (computed per shard)
         grad_norm_squared_cpu = multi_gpu_cpu_float_sum(grad_norm_squared_cpu)
     }
 

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2775,7 +2775,7 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
     cudaCheck(cudaMemcpy(&grad_norm_squared_cpu, grad_norm_squared, sizeof(float), cudaMemcpyDeviceToHost));
     if (multi_gpu_config->zero_stage == 1) {
         // sum the squared norm across all GPUs as they're only partial (computed per shard)
-        grad_norm_squared_cpu = multi_gpu_cpu_float_sum(grad_norm_squared_cpu)
+        grad_norm_squared_cpu = multi_gpu_cpu_float_sum(grad_norm_squared_cpu);
     }
 
     if(!isfinite(grad_norm_squared_cpu)) {


### PR DESCRIPTION
As per our Discord discussion:
Right now, in ZeRO stage 1, each GPU will compute a grad norm across all of its shards - but only a single shard has the correct numbers (after NCCL's reduce-scatter).

So what we should do instead is compute norm squared per shard that the device owns and then reduce (sum) them up across devices, take a sqrt and only then call AdamW kernel to update the params.