### PR TITLE
[attension.cuh] Move assert outside of attn kernel to launcher

### DIFF
--- a/llmc/attention.cuh
+++ b/llmc/attention.cuh
@@ -87,7 +87,7 @@ __global__ void softmax_forward_kernel5(floatX* out, float inv_temperature, cons
     // fuses the multiplication by scale inside attention
     // directly autoregressive, so we only compute the lower triangular part
     // uses the online softmax algorithm
-    assert(T % 4  == 0);
+
     int lane_id = threadIdx.x % WARP_SIZE;
     int warp_id = threadIdx.x / WARP_SIZE;
     int num_warps = blockDim.x / WARP_SIZE;
@@ -223,6 +223,7 @@ void attention_forward(floatX* out, floatX* qkvr, floatX* att,
     // multiply all elements of preatt elementwise by scale
     float scale = 1.0 / sqrtf(HS);
     int grid_size = CEIL_DIV(B * NH * T * WARP_SIZE, block_size);
+    assert(T % 4  == 0);
     softmax_forward_kernel5<<<grid_size, block_size>>>(att, scale, preatt, B * NH, T);
 
     // new approach: first cuBLAS another batched matmul


### PR DESCRIPTION
Move assert outside of kernels into launchers. Early catch the assert failure instead of fail during actual kernel computations.