### PR TITLE
made implicit includes of standard headers explicit

### DIFF
--- a/llmc/cublas_common.h
+++ b/llmc/cublas_common.h
@@ -4,6 +4,9 @@ cuBLAS related utils
 #ifndef CUBLAS_COMMON_H
 #define CUBLAS_COMMON_H
 
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include <cublas_v2.h>
 #include <cublasLt.h>
 

--- a/llmc/cuda_common.h
+++ b/llmc/cuda_common.h
@@ -4,12 +4,15 @@ Common utilities for CUDA code.
 #ifndef CUDA_COMMON_H
 #define CUDA_COMMON_H
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <math.h>
 #include <string>
 #include <cuda_runtime.h>
 #include <nvtx3/nvToolsExt.h>
 #include <cuda_profiler_api.h>
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 
 // ----------------------------------------------------------------------------
 // Global defines and settings

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -4,9 +4,10 @@ In the forward pass, both encodings are added together
 In the backward pass, the gradients flow to both, handled by different kernels
 */
 #include <assert.h>
+#include <stdint.h>
+#include <utility>              // std::pair
 #include <vector>
 #include <algorithm>
-#include <functional>
 #include <unordered_map>
 // llmc internal imports
 #include "cuda_common.h"

--- a/llmc/logger.h
+++ b/llmc/logger.h
@@ -6,6 +6,7 @@ The Logger object is stateless and uses append mode to write to log files.
 #define LOGGER_H
 
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 // defines: fopenCheck, freadCheck, fcloseCheck, fseekCheck, mallocCheck
 #include "utils.h"

--- a/llmc/matmul.cuh
+++ b/llmc/matmul.cuh
@@ -2,6 +2,7 @@
 Matrix Multiplication, with help from cuBLASLt
 */
 #include <assert.h>
+#include <type_traits>      // std::bool_constant
 // llmc internal imports
 #include "cuda_common.h"
 #include "cuda_utils.cuh"

--- a/llmc/tokenizer.h
+++ b/llmc/tokenizer.h
@@ -90,7 +90,7 @@ const char *tokenizer_decode(Tokenizer *tokenizer, uint32_t token_id) {
     if (token_id < tokenizer->vocab_size) {
         return tokenizer->token_table[token_id];
     } else {
-        printf("invalid token id %d!\n", token_id);
+        printf("invalid token id %u!\n", token_id);
         return NULL;
     }
 }

--- a/llmc/utils.h
+++ b/llmc/utils.h
@@ -7,6 +7,7 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>


### PR DESCRIPTION
we are using some standard library facilities that are available because  some other header includes them, but we should be explicit about this so code doesn't break on compiler/lib upgrades that, e.g., reorganize some internal includes.