### PR TITLE
Fix zero grads bug

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -699,6 +699,7 @@ if __name__ == "__main__":
         train_loader.reset()
         # clear the grads here explicitly because otherwise we'd have a duplicate grad accumulation
         # since in the training loop we do a backward() and then zero_grad() at the end of the loop
+        # this would cause an incorrect first training step
         model.zero_grad()
 
     # -------------------------------------------------------------------------

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -697,9 +697,9 @@ if __name__ == "__main__":
         write_state(model, x, y, logits, loss, f"gpt2_{model_size_str}_debug_state.bin")
         # reset the train_loader for the optimization below
         train_loader.reset()
-        # clear the grads
-        for name, param in model.named_parameters():
-            param.grad = 0.0 * param.grad
+        # clear the grads here explicitly because otherwise we'd have a duplicate grad accumulation
+        # since in the training loop we do a backward() and then zero_grad() at the end of the loop
+        model.zero_grad()
 
     # -------------------------------------------------------------------------
     # main training loop

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -697,6 +697,9 @@ if __name__ == "__main__":
         write_state(model, x, y, logits, loss, f"gpt2_{model_size_str}_debug_state.bin")
         # reset the train_loader for the optimization below
         train_loader.reset()
+        # clear the grads
+        for name, param in model.named_parameters():
+            param.grad = 0.0 * param.grad
 
     # -------------------------------------------------------------------------
     # main training loop


### PR DESCRIPTION
We have to zero the grads here because in the training loop we first do backward and only later we do zero grad.

This causes a duplicate "deposit" of gradients in the first training step which explains the divergence we had between PyTorch & C code.