### PR TITLE
Trigger CI on new branch creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build and test
 
 on:
+  create:
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
With this small CI change, it will enable the developer to trigger local CI workflows in VS Code and GitHub manually.

When you create a new branch in your fork (or repo) this will kick off a CI build. This first CI build causes GitHub to create a newly accessible CI trigger which allows you to subsequently trigger CI manually in VS Code using the GitHub actions extension OR in GitHub under the Actions menu.

This allows the developer to trigger CI and eventually pass CI while working in their branch before initiating a PR.