### PR TITLE
Fix issue 555, support c++11 and fix compiler warnings

### DIFF
--- a/dev/cuda/matmul_backward_bias.cu
+++ b/dev/cuda/matmul_backward_bias.cu
@@ -116,7 +116,7 @@ __global__ void matmul_backward_bias_kernel2(floatX* dbias, const floatX* dout, 
     sum = cg::reduce(warp, sum, cg::plus<float>{});
     // write the result to output (global memory)
     if(warp.thread_rank() == 0) {
-        dbias[idx] += sum;
+        dbias[idx] = (float)dbias[idx] + sum;
     }
 }
 
@@ -148,7 +148,7 @@ __global__ void matmul_backward_bias_kernel3(floatX* dbias, const floatX* dout, 
     float block_sum = cg::reduce(warp, warp_sum, cg::plus<float>{}); // sum(x)
     // write the result to output (global memory)
     if(threadIdx.x == 0) {
-        dbias[idx] += block_sum;
+        dbias[idx] = (float)dbias[idx] + block_sum;
     }
 }
 
@@ -188,7 +188,7 @@ __global__ void matmul_backward_bias_kernel4(floatX* dbias, const floatX* dout, 
         for (int j = 0; j < vstep; j++) {
             dout_sum += smem[lane_id + j * warpSize];
         }
-        dbias[tl + lane_id] += dout_sum;
+        dbias[tl + lane_id] = (float)dbias[tl + lane_id] + dout_sum;
     }
 }
 


### PR DESCRIPTION
Fix #555. 

- fix compiler error (compiler dependent) of following type: 
```
matmul_backward_bias.cu(151): error: no operator "+=" matches these operands
            operand types are: floatX += float
          dbias[idx] += block_sum;
```

- support c++11, replace the c++17 only features with c++11 equivalence 
          - fix `error: namespace "std" has no member "bool_constant"`, 
          - replace `std::is_same_v`
          - handle  `constexpr if statements` with function overload since `constexpr if statements are a C++17 feature`. No runtime speed impact since the branch is still determined at the compile time. But it is a bit verbose without  `if constexpr`.

Tested with `nvcc -O3 -lcublas -lcublasLt -std=c++11 matmul_backward_bias.cu -lineinfo -o matmul_backward_bias`
and executes kernels with changes (all passed).