### PR TITLE
Dataloader - introducing randomness

### DIFF
--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -92,7 +92,7 @@ int64_t dataloader_load_shard_(DataLoader *loader, int shard_index) {
         exit(EXIT_FAILURE);
     }
     // -1 uint16_t due to us taking B*T+1 tokens but moving by B*T tokens
-    loader->shard_num_samples = (loader->file_size_bytes - sizeof(uint16_t)) / loader->total_batch_size_bytes;
+    loader->shard_num_samples = (ntok * sizeof(uint16_t) - sizeof(uint16_t)) / loader->total_batch_size_bytes;
     return ntok;
 }
 

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -110,7 +110,7 @@ void prepare_intra_shard_indices_(DataLoader *loader) {
         free(loader->intra_shard_indices);
     }
     loader->intra_shard_indices = (int*)malloc(loader->shard_num_samples * sizeof(int));
-    random_permutation_with_init(loader->intra_shard_indices, loader->shard_num_samples, &loader->shuffle_rng);
+    random_permutation_with_init(loader->intra_shard_indices, loader->shard_num_samples, &loader->shuffle_rng, 1);
 }
 
 void dataloader_reset(DataLoader *loader) {
@@ -118,7 +118,7 @@ void dataloader_reset(DataLoader *loader) {
     loader->current_sample_idx = 0;
 
     if (loader->should_shuffle) {  // shuffle the shards
-        random_permutation_with_init(loader->shard_indices, loader->glob_result.gl_pathc, &loader->shuffle_rng);
+        random_permutation_with_init(loader->shard_indices, loader->glob_result.gl_pathc, &loader->shuffle_rng, 0);
     }
 
     dataloader_load_shard_(loader, loader->current_shard_idx);
@@ -130,7 +130,7 @@ void dataloader_reset(DataLoader *loader) {
 
 void dataloader_advance_(DataLoader *loader) {
     if (loader->current_shard_idx == loader->glob_result.gl_pathc - 1) {
-        // if we are at the last shard, we reset the loader
+        // if we are at the last shard, we reset the loader and start a new epoch
         dataloader_reset(loader);
         return;
     }
@@ -181,7 +181,7 @@ void dataloader_init(DataLoader *loader,
         for (int i = 0; i < loader->glob_result.gl_pathc; i++) {
             loader->shard_indices[i] = i;  // start with identity permutation
         }
-        loader->intra_shard_indices = NULL;  // dynamically allocated
+        loader->intra_shard_indices = NULL;  // dynamically allocated allowing different shard sizes
     }
 
     // inspect and validate all shards so we don't get any runtime errors later

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -88,7 +88,7 @@ void dataloader_resume(DataLoader *loader, int current_shard, int64_t current_po
     dataloader_load_shard_(loader, loader->current_shard);
 }
 
-void dataloader_reset(DataLoader *loader, unsigned long long *state = NULL) {
+void dataloader_reset(DataLoader *loader, unsigned long long *state) {
     // fully resets the DataLoader object to init configuration
     // each process starts at a different offset in the file
     int64_t header_bytes = HEADER_SIZE * sizeof(int);
@@ -129,7 +129,7 @@ void dataloader_init(DataLoader *loader,
                      size_t T,
                      int process_rank,
                      int num_processes,
-                     unsigned long long *state = NULL) {
+                     unsigned long long *state) {
     loader->process_rank = process_rank;
     loader->num_processes = num_processes;
     loader->B = B;

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -88,7 +88,7 @@ void dataloader_resume(DataLoader *loader, int current_shard, int64_t current_po
     dataloader_load_shard_(loader, loader->current_shard);
 }
 
-void dataloader_reset(DataLoader *loader, unsigned long long *state) {
+void dataloader_reset(DataLoader *loader, unsigned long long *state = NULL) {
     // fully resets the DataLoader object to init configuration
     // each process starts at a different offset in the file
     int64_t header_bytes = HEADER_SIZE * sizeof(int);

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -15,8 +15,6 @@ Implements:
 // defines: fopenCheck, freadCheck, fcloseCheck, fseekCheck
 // defines: mallocCheck
 #include "utils.h"
-// defines: random_u32
-#include "sampler.h"
 #include "rand.h"
 
 // ----------------------------------------------------------------------------
@@ -118,8 +116,7 @@ void dataloader_reset(DataLoader *loader) {
     if (loader->should_shuffle) {
         // shuffle the examples inside the shards
         if (loader->intra_shard_indices != NULL) {
-            // these might change from shard to shard, but we always have the same number of shards
-            // so we don't have to dynamically allocate them on every reset
+            // in case shards have different number of samples / sizes
             free(loader->intra_shard_indices);
         }
         loader->intra_shard_indices = (int*)malloc(loader->shard_num_samples * sizeof(int));

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -51,8 +51,8 @@ typedef struct {
     // random shuffle related variables
     mt19937_state shuffle_rng;
     bool should_shuffle;
-    size_t* shard_indices;
-    size_t* intra_shard_indices;
+    int* shard_indices;
+    int* intra_shard_indices;
     // sizes in bytes
     size_t total_batch_size_bytes;  // total across all processes
     size_t local_batch_offset_bytes;  // inner-sample offset for this process
@@ -122,7 +122,7 @@ void dataloader_reset(DataLoader *loader) {
             // so we don't have to dynamically allocate them on every reset
             free(loader->intra_shard_indices);
         }
-        loader->intra_shard_indices = (size_t*)malloc(loader->shard_num_samples * sizeof(size_t));
+        loader->intra_shard_indices = (int*)malloc(loader->shard_num_samples * sizeof(int));
         random_permutation_with_init(loader->intra_shard_indices, loader->shard_num_samples, &loader->shuffle_rng);
     }
 }
@@ -170,9 +170,9 @@ void dataloader_init(DataLoader *loader,
 
     if (should_shuffle) {
         mt19937_state shuffle_rng;
-        manual_seed(&shuffle_rng, process_rank);
+        manual_seed(&shuffle_rng, 42 + process_rank);
         loader->shuffle_rng = shuffle_rng;
-        loader->shard_indices = (size_t*)malloc(loader->glob_result.gl_pathc * sizeof(size_t));
+        loader->shard_indices = (int*)malloc(loader->glob_result.gl_pathc * sizeof(int));
         for (int i = 0; i < loader->glob_result.gl_pathc; i++) {
             loader->shard_indices[i] = i;  // start with identity permutation
         }

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,13 +220,13 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
-void random_permutation_with_init(int* data, int numel, mt19937_state* state, int should_init) {
-    if (should_init) {
-        for (int i = 0; i < numel; i++) {
-            data[i] = i;
-        }
+void init_identity_permutation(int *data, int numel) {
+    for (int i = 0; i < numel; i++) {
+        data[i] = i;
     }
+}
 
+void random_permutation(int* data, int numel, mt19937_state* state) {
     for (int i = numel - 1; i > 0; i--) {
         // pick an index j in [0, i] with equal probability
         int j = randint32(state) % (i + 1);

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,14 +220,14 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
-void random_permutation_with_init(size_t* data, unsigned int numel, mt19937_state* state) {
-    for (unsigned int i = 0; i < numel; i++) {
+void random_permutation_with_init(int* data, unsigned int numel, mt19937_state* state) {
+    for (int i = 0; i < numel; i++) {
         data[i] = i;
     }
-    for (unsigned int i = numel - 1; i > 0; i--) {
-        unsigned int j = randint32(state) % (i + 1);
+    for (int i = numel - 1; i > 0; i--) {
+        int j = randint32(state) % (i + 1);
         // swap
-        unsigned int tmp = data[i];
+        int tmp = data[i];
         data[i] = data[j];
         data[j] = tmp;
     }

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,13 +220,14 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
-void random_permutation_with_init(int* data, unsigned int numel, mt19937_state* state) {
+void random_permutation_with_init(int* data, int numel, mt19937_state* state) {
     for (int i = 0; i < numel; i++) {
         data[i] = i;
     }
     for (int i = numel - 1; i > 0; i--) {
+        // pick an index j in [0, i] with equal probability
         int j = randint32(state) % (i + 1);
-        // swap
+        // swap i <-> j
         int tmp = data[i];
         data[i] = data[j];
         data[j] = tmp;

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,7 +220,7 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
-void random_permutation(unsigned int* data, unsigned int numel, mt19937_state* state) {
+void random_permutation_with_init(size_t* data, unsigned int numel, mt19937_state* state) {
     for (unsigned int i = 0; i < numel; i++) {
         data[i] = i;
     }

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,4 +220,17 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
+void random_permutation(unsigned int* data, unsigned int numel, mt19937_state* state) {
+    for (unsigned int i = 0; i < numel; i++) {
+        data[i] = i;
+    }
+    for (unsigned int i = numel - 1; i > 0; i--) {
+        unsigned int j = randint32(state) % (i + 1);
+        // swap
+        unsigned int tmp = data[i];
+        data[i] = data[j];
+        data[j] = tmp;
+    }
+}
+
 #endif

--- a/llmc/rand.h
+++ b/llmc/rand.h
@@ -220,10 +220,13 @@ void normal_(float* data, unsigned int numel, float mean, float std, mt19937_sta
     }
 }
 
-void random_permutation_with_init(int* data, int numel, mt19937_state* state) {
-    for (int i = 0; i < numel; i++) {
-        data[i] = i;
+void random_permutation_with_init(int* data, int numel, mt19937_state* state, int should_init) {
+    if (should_init) {
+        for (int i = 0; i < numel; i++) {
+            data[i] = i;
+        }
     }
+
     for (int i = numel - 1; i > 0; i--) {
         // pick an index j in [0, i] with equal probability
         int j = randint32(state) % (i + 1);

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -1083,8 +1083,8 @@ int main() {
     int B = 4; // batch size 4 (i.e. 4 independent token sequences will be trained on)
     int T = 64; // sequence length 64 (i.e. each sequence is 64 tokens long). must be <= maxT, which is 1024 for GPT-2
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_tokens, B, T, 0, 1, NULL);
-    dataloader_init(&val_loader, val_tokens, B, T, 0, 1, NULL);
+    dataloader_init(&train_loader, train_tokens, B, T, 0, 1, 1);
+    dataloader_init(&val_loader, val_tokens, B, T, 0, 1, 0);
     printf("train dataset num_batches: %zu\n", train_loader.num_tokens / (B*T));
     printf("val dataset num_batches: %zu\n", val_loader.num_tokens / (B*T));
     int val_num_batches = 5;
@@ -1105,7 +1105,7 @@ int main() {
         // once in a while estimate the validation loss
         if (step % 10 == 0) {
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader, NULL);
+            dataloader_reset(&val_loader);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -1083,8 +1083,8 @@ int main() {
     int B = 4; // batch size 4 (i.e. 4 independent token sequences will be trained on)
     int T = 64; // sequence length 64 (i.e. each sequence is 64 tokens long). must be <= maxT, which is 1024 for GPT-2
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_tokens, B, T, 0, 1);
-    dataloader_init(&val_loader, val_tokens, B, T, 0, 1);
+    dataloader_init(&train_loader, train_tokens, B, T, 0, 1, NULL);
+    dataloader_init(&val_loader, val_tokens, B, T, 0, 1, NULL);
     printf("train dataset num_batches: %zu\n", train_loader.num_tokens / (B*T));
     printf("val dataset num_batches: %zu\n", val_loader.num_tokens / (B*T));
     int val_num_batches = 5;
@@ -1105,7 +1105,7 @@ int main() {
         // once in a while estimate the validation loss
         if (step % 10 == 0) {
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader);
+            dataloader_reset(&val_loader, NULL);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -359,7 +359,7 @@ void gpt2_init_common(GPT2 *model) {
     model->v_memory = NULL;
     model->master_weights = NULL;
     // other default settings
-    model->rng_state = 13371337; // used in stochastic rounding
+    model->rng_state = 13371337 + multi_gpu_config.process_rank; // used in stochastic rounding
     model->use_master_weights = 1; // safe default: do keep master weights in fp32
     model->recompute = 1; // good default: recompute gelu but not layernorm
 }
@@ -1445,7 +1445,7 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes);
+    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, &model.rng_state);
     dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes);
     // figure out the number of training steps we will run for
     int train_num_batches = max_steps; // passed in from command line

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1446,7 +1446,7 @@ int main(int argc, char *argv[]) {
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
     dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, &model.rng_state);
-    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes);
+    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, NULL);
     // figure out the number of training steps we will run for
     int train_num_batches = max_steps; // passed in from command line
     if (train_num_batches == -1) {
@@ -1534,7 +1534,7 @@ int main(int argc, char *argv[]) {
         if (step % val_loss_every == 0 || last_step) {
             NvtxRange validation_range("validation");
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader);
+            dataloader_reset(&val_loader, NULL);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1219,7 +1219,7 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     assert(state_header[1] == 1); // version number
     assert(state_header[2] == multi_gpu_config.num_processes); // number of processes
     assert(state_header[3] == multi_gpu_config.process_rank); // rank of this process
-    bool should_shuffle = state_header[4]; // shuffle state of the dataloader
+    int should_shuffle = state_header[4]; // shuffle state of the dataloader
     *step = state_header[10]; // step of the optimization
     model->rng_state = *((unsigned long long*)&state_header[20]); // random number generator state
     size_t current_shard_idx = *((size_t*)&state_header[30]); // shard index
@@ -1250,7 +1250,7 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     free(cpu_buffer);
 
     if (should_shuffle) {
-        loader->should_shuffle = true;
+        loader->should_shuffle = 1;
 
         size_t glob_result_gl_pathc;
         freadCheck(&glob_result_gl_pathc, sizeof(size_t), 1, state_file);
@@ -1477,8 +1477,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, true);
-    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, false);
+    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 1);
+    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 0);
     // figure out the number of training steps we will run for
     int train_num_batches = max_steps; // passed in from command line
     if (train_num_batches == -1) {

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1321,8 +1321,8 @@ int main(int argc, char *argv[]) {
     multi_gpu_config = multi_gpu_config_init(&argc, &argv);
 
     // read in the (optional) command line arguments
-    const char* train_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_train_*.bin";
-    const char* val_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_val_*.bin";
+    const char* train_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_train.bin";
+    const char* val_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_val.bin";
     const char* load_filename = "gpt2_124M_bf16.bin"; // bf16 weights of the model
     const char* output_log_dir = NULL;
     int checkpoint_every = 0; // write optimization checkpoints every how many steps?

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1182,12 +1182,13 @@ void save_state(const char* filename, int step, GPT2* model, DataLoader* loader)
     state_header[5] = loader->should_shuffle; // shuffle state of the dataloader
     // int main state, start at 10 to leave some padding
     state_header[10] = step; // step of the optimization
-    // model state, state, start at 20 to leave some padding
+    // model rng state, start at 20 to leave some padding
     *((unsigned long long*)&state_header[20]) = model->rng_state; // random number generator state
     // dataloader state, start at 30 to leave some padding
-    state_header[30] = loader->current_shard_idx; // shard of the dataset
-    *((size_t*)&state_header[31]) = loader->current_sample_idx; // position in shard
+    *((size_t*)&state_header[30]) = loader->current_shard_idx; // shard of the dataset
+    *((size_t*)&state_header[32]) = loader->current_sample_idx; // position in shard
     fwrite(state_header, sizeof(int), 256, state_file);
+
     // write AdamW m, v, and master_weights here (they are all float)
     size_t shard_num_parameters = multi_gpu_config.shard_num_parameters;
     float* cpu_buffer = (float*)mallocCheck(shard_num_parameters * sizeof(float));
@@ -1199,14 +1200,14 @@ void save_state(const char* filename, int step, GPT2* model, DataLoader* loader)
         cudaCheck(cudaMemcpy(cpu_buffer, model->master_weights, shard_num_parameters * sizeof(float), cudaMemcpyDeviceToHost));
         fwrite(cpu_buffer, sizeof(float), shard_num_parameters, state_file);
     }
+    free(cpu_buffer);
     if (loader->should_shuffle) {
-        fwrite(&loader->glob_result.gl_pathc, sizeof(size_t), 1, state_file);
-        fwrite(loader->shard_indices, sizeof(size_t), loader->glob_result.gl_pathc, state_file);
+        fwrite(&loader->glob_result.gl_pathc, sizeof(size_t), 1, state_file);  // number of shards
+        fwrite(loader->shard_indices, sizeof(int), loader->glob_result.gl_pathc, state_file);
         fwrite(&loader->shard_num_samples, sizeof(size_t), 1, state_file);
-        fwrite(loader->intra_shard_indices, sizeof(size_t), loader->shard_num_samples, state_file);
+        fwrite(loader->intra_shard_indices, sizeof(int), loader->shard_num_samples, state_file);
         fwrite(&loader->shuffle_rng, sizeof(mt19937_state), 1, state_file);
     }
-    free(cpu_buffer);
     fclose(state_file);
 }
 
@@ -1218,11 +1219,12 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     assert(state_header[1] == 1); // version number
     assert(state_header[2] == multi_gpu_config.num_processes); // number of processes
     assert(state_header[3] == multi_gpu_config.process_rank); // rank of this process
+    bool should_shuffle = state_header[4]; // shuffle state of the dataloader
     *step = state_header[10]; // step of the optimization
     model->rng_state = *((unsigned long long*)&state_header[20]); // random number generator state
-    bool should_shuffle = state_header[4]; // shuffle state of the dataloader
-    size_t current_shard_idx = state_header[30]; // shard of the dataset
-    size_t current_sample_idx = *((size_t*)&state_header[31]); // position in shard
+    size_t current_shard_idx = *((size_t*)&state_header[30]); // shard index
+    size_t current_sample_idx = *((size_t*)&state_header[32]); // position in shard
+
     // read AdamW m, v (they are all float)
     // also allocate the m, v memory in the model, if it does not yet exist
     size_t shard_num_parameters = multi_gpu_config.shard_num_parameters;
@@ -1254,15 +1256,15 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
         freadCheck(&glob_result_gl_pathc, sizeof(size_t), 1, state_file);
         assert(glob_result_gl_pathc == loader->glob_result.gl_pathc);
 
-        loader->shard_indices = (size_t*)mallocCheck(loader->glob_result.gl_pathc * sizeof(size_t));
-        freadCheck(loader->shard_indices, sizeof(size_t), loader->glob_result.gl_pathc, state_file);
+        loader->shard_indices = (int*)mallocCheck(loader->glob_result.gl_pathc * sizeof(int));
+        freadCheck(loader->shard_indices, sizeof(int), loader->glob_result.gl_pathc, state_file);
 
         size_t shard_num_samples;
         freadCheck(&shard_num_samples, sizeof(size_t), 1, state_file);
         assert(shard_num_samples == loader->shard_num_samples);
 
-        loader->intra_shard_indices = (size_t*)mallocCheck(loader->shard_num_samples * sizeof(size_t));
-        freadCheck(loader->intra_shard_indices, sizeof(size_t), loader->shard_num_samples, state_file);
+        loader->intra_shard_indices = (int*)mallocCheck(loader->shard_num_samples * sizeof(int));
+        freadCheck(loader->intra_shard_indices, sizeof(int), loader->shard_num_samples, state_file);
 
         freadCheck(&loader->shuffle_rng, sizeof(mt19937_state), 1, state_file);
     }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1480,8 +1480,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 1);
-    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 0);
+    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, true);
+    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, false);
     // figure out the number of training steps we will run for
     int train_num_batches = max_steps; // passed in from command line
     if (train_num_batches == -1) {

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1184,7 +1184,7 @@ void save_state(const char* filename, int step, GPT2* model, DataLoader* loader)
     // model state, state, start at 20 to leave some padding
     *((unsigned long long*)&state_header[20]) = model->rng_state; // random number generator state
     // dataloader state, start at 30 to leave some padding
-    state_header[30] = loader->current_shard; // shard of the dataset
+    state_header[30] = loader->current_shard_idx; // shard of the dataset
     *((int64_t*)&state_header[31]) = loader->current_position; // position in shard
     fwrite(state_header, sizeof(int), 256, state_file);
     // write AdamW m, v, and master_weights here (they are all float)
@@ -1212,9 +1212,9 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     assert(state_header[3] == multi_gpu_config.process_rank); // rank of this process
     *step = state_header[10]; // step of the optimization
     model->rng_state = *((unsigned long long*)&state_header[20]); // random number generator state
-    int current_shard = state_header[30]; // shard of the dataset
+    int current_shard_idx = state_header[30]; // shard of the dataset
     int64_t current_position = *((int64_t*)&state_header[31]); // position in shard
-    dataloader_resume(loader, current_shard, current_position);
+    dataloader_resume(loader, current_shard_idx, current_position);
     // read AdamW m, v (they are all float)
     // also allocate the m, v memory in the model, if it does not yet exist
     size_t shard_num_parameters = multi_gpu_config.shard_num_parameters;
@@ -1289,8 +1289,8 @@ int main(int argc, char *argv[]) {
     multi_gpu_config = multi_gpu_config_init(&argc, &argv);
 
     // read in the (optional) command line arguments
-    const char* train_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_train.bin";
-    const char* val_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_val.bin";
+    const char* train_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_train_*.bin";
+    const char* val_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_val_*.bin";
     const char* load_filename = "gpt2_124M_bf16.bin"; // bf16 weights of the model
     const char* output_log_dir = NULL;
     int checkpoint_every = 0; // write optimization checkpoints every how many steps?
@@ -1445,8 +1445,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, &model.rng_state);
-    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, NULL);
+    dataloader_init(&train_loader, train_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 1);
+    dataloader_init(&val_loader, val_data_pattern, B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 0);
     // figure out the number of training steps we will run for
     int train_num_batches = max_steps; // passed in from command line
     if (train_num_batches == -1) {
@@ -1534,7 +1534,7 @@ int main(int argc, char *argv[]) {
         if (step % val_loss_every == 0 || last_step) {
             NvtxRange validation_range("validation");
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader, NULL);
+            dataloader_reset(&val_loader);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);

--- a/train_gpt2_fp32.cu
+++ b/train_gpt2_fp32.cu
@@ -1634,8 +1634,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1);
-    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1);
+    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1, 1);
+    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1, 0);
     int train_num_batches = train_loader.num_tokens / (B*T); // let's do 1 epoch by default for now
     int val_num_batches = val_loader.num_tokens / (B*T);
     if (val_num_batches > val_max_steps) { val_num_batches = val_max_steps; }

--- a/train_gpt2_fp32.cu
+++ b/train_gpt2_fp32.cu
@@ -1634,8 +1634,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1);
-    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1);
+    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1, NULL);
+    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1, NULL);
     int train_num_batches = train_loader.num_tokens / (B*T); // let's do 1 epoch by default for now
     int val_num_batches = val_loader.num_tokens / (B*T);
     if (val_num_batches > val_max_steps) { val_num_batches = val_max_steps; }
@@ -1668,7 +1668,7 @@ int main(int argc, char *argv[]) {
         // once in a while estimate the validation loss
         if (step % val_loss_every == 0 || last_step) {
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader);
+            dataloader_reset(&val_loader, NULL);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);

--- a/train_gpt2_fp32.cu
+++ b/train_gpt2_fp32.cu
@@ -1634,8 +1634,8 @@ int main(int argc, char *argv[]) {
 
     // build DataLoaders for both train and val
     DataLoader train_loader, val_loader;
-    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1, NULL);
-    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1, NULL);
+    dataloader_init(&train_loader, train_data_pattern, B, T, 0, 1);
+    dataloader_init(&val_loader, val_data_pattern, B, T, 0, 1);
     int train_num_batches = train_loader.num_tokens / (B*T); // let's do 1 epoch by default for now
     int val_num_batches = val_loader.num_tokens / (B*T);
     if (val_num_batches > val_max_steps) { val_num_batches = val_max_steps; }
@@ -1668,7 +1668,7 @@ int main(int argc, char *argv[]) {
         // once in a while estimate the validation loss
         if (step % val_loss_every == 0 || last_step) {
             float val_loss = 0.0f;
-            dataloader_reset(&val_loader, NULL);
+            dataloader_reset(&val_loader);
             for (int i = 0; i < val_num_batches; i++) {
                 dataloader_next_batch(&val_loader);
                 gpt2_forward(&model, val_loader.inputs, val_loader.targets, B, T);


### PR DESCRIPTION
On the way to fully random train data shuffling...

This PR does the following:
1) Each process has a different unique random seed
2) Each process train data loader independently chooses its starting shard and starting example within that shard
3) This should not impact save/load state since we store the `rng_state` inside of the header and later load it

For handling multiple epochs:
1) We can explicitly call `dataloader_reset` on each epoch boundary inside the training loop -> that would enable us new random shard/position for each process.
2) We could alternatively delegate this responsibility to the data loader, which might be a bit nicer - we can keep the start shard index (and start position) and when we hit the starting position again we call `dataloader_reset` automatically.

Regarding "page" shuffling:
1) We could create a permutation of shard indices and iterative over it. That would be a partial solution.
2) In order to do intra-shard shuffling we'd need to extract the `eos` guarded tokens (i.e. unique docs) and randomly permute them and store them to the file system (and then override on each epoch so we upper bound mem footprint with 2x the original size) or for smaller datasets maybe keep the permutation in RAM.

Just some quick thoughts.

Looking into how we can integrate this over multiple PRs as opposed to all in a single go.

Let me know what you think!