### PR TITLE
New softmax forward kernel in `dev/cuda`

### DIFF
--- a/dev/cuda/softmax_forward.cu
+++ b/dev/cuda/softmax_forward.cu
@@ -29,6 +29,9 @@ version 7 is softmax optimized for very large C.
 version 8 is a cooperative groups free implementation (compares to version 6) of online softmax.
 Which has close performance to version 6 but better code readability.
 ./softmax_forward 8
+
+version 9 is online softmax that similar to version 8, plus using float4 to acclerate memory accessing.
+./softmax_forward 9
 */
 
 #include <stdio.h>


### PR DESCRIPTION
Did tiny modifications to made codes cleaner and performance better.

OS: Ubuntu 22.04
Device: NVIDIA GeForce RTX 3070 Laptop GPU

### Performance
#### `softmax_forward6` (online softmax with cooperative groups)
```
block_size   32 | time 14.3109 ms | per token 1.75 µs
block_size   64 | time 13.4489 ms | per token 1.64 µs
block_size  128 | time 16.3121 ms | per token 1.99 µs
block_size  256 | time 17.4961 ms | per token 2.14 µs
block_size  512 | time 22.0295 ms | per token 2.69 µs
block_size 1024 | time 22.6308 ms | per token 2.76 µs
```
#### `softmax_forward8` (online softmax without cgs)
```
block_size   32 | time 14.2730 ms | per token 1.74 µs
block_size   64 | time 13.2274 ms | per token 1.61 µs
block_size  128 | time 14.4429 ms | per token 1.76 µs
block_size  256 | time 17.3742 ms | per token 2.12 µs
block_size  512 | time 18.2752 ms | per token 2.23 µs
block_size 1024 | time 20.2799 ms | per token 2.48 µs
```