### PR TITLE
Adds dev container to speed up project onboarding 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "nvidia-cuda",
+    "image": "nvidia/cuda:12.5.0-devel-ubuntu22.04",
+    "runArgs": [
+      "--gpus",
+      "all"
+    ],
+    "features": {
+      "ghcr.io/devcontainers/features/python:1": {},
+      "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "extensions": [
+      "ms-vscode.cpptools"
+    ],
+    "containerEnv": {
+      "NVIDIA_VISIBLE_DEVICES": "all"
+    },
+    "postCreateCommand": "apt-get update && apt-get install -y sudo && sudo apt-get install -y openmpi-bin openmpi-doc libopenmpi-dev && pip install -r requirements.txt"
+  }


### PR DESCRIPTION
As someone new to CUDA development, I encountered challenges in setting up the necessary environment and dependencies. To simplify the process and ensure a consistent setup for both myself and others, I have created a devcontainer.json file that sets up a standardized development environment. Now you can jump straight into the first example. 

Please review and provide feedback. Thank you for considering this pull request!