### PR TITLE
Bugfix eval dataloader out of bound file read and crash

### DIFF
--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -204,8 +204,9 @@ Copy pasting the section on the eval datafile format, from data_common.py:
 
 // for now, could relax later
 #define ASSUMED_NUM_COMPLETIONS 4
-// helper macro for ceildiv
+// helper macro for ceildiv and floordiv
 #define CEIL_DIV(M, N) (((M) + (N)-1) / (N))
+#define FLOOR_DIV(M, N) ((M) / (N))
 
 typedef struct {
     // variables related to distributed training
@@ -236,16 +237,17 @@ void evalloader_reset(EvalLoader *loader) {
     // For example if there are N examples in the file and 4 processes,
     // then process 0 should start at 0, process 1 at N/4, process 2 at N/2, etc.
     // determine how much work there is for all processes
-    int examples_per_process = CEIL_DIV(loader->num_examples, loader->num_processes);
-    int can_fit_examples = loader->B / ASSUMED_NUM_COMPLETIONS;
-    loader->num_batches = CEIL_DIV(examples_per_process, can_fit_examples);
+    int examples_per_process = FLOOR_DIV(loader->num_examples, loader->num_processes);
     // determine the start and end example indices for this process
     loader->start_example_index = examples_per_process * loader->process_rank;
     loader->end_example_index = examples_per_process * (loader->process_rank + 1);
-    // crop the end example index to the total number of examples
-    if (loader->end_example_index > loader->num_examples) {
+    // extend the end example index to the total number of examples
+    if (loader->process_rank == loader->num_processes - 1) {
         loader->end_example_index = loader->num_examples;
+        examples_per_process = loader->end_example_index - loader->start_example_index;
     }
+    int can_fit_examples = loader->B / ASSUMED_NUM_COMPLETIONS;
+    loader->num_batches = CEIL_DIV(examples_per_process, can_fit_examples);
     // now seek through the file to the start of that example
     // utilize <EXAMPLE_BYTES> for efficiency
     int64_t header_bytes = HEADER_SIZE * sizeof(int);


### PR DESCRIPTION
When number of process is higher eval dataloader goes out of bound when processing 10042 hellswag samples.
Recreated the issue with debug printfs using 200 process.
Samples per proc become 51 (ceil_div(10042/200))
process 196-199 start with error start idx.
```
Process 195: start_example_index = 9945, end_example_index before = 9996, end_example_index after = 9996
Process 196: start_example_index = 9996, end_example_index before = 10047, end_example_index after = 10042
Process 197: start_example_index = 10047, end_example_index before = 10098, end_example_index after = 10042
Process 198: start_example_index = 10098, end_example_index before = 10149, end_example_index after = 10042
Process 199: start_example_index = 10149, end_example_index before = 10200, end_example_index after = 10042
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
Error: Unexpected end of file at llmc/dataloader.h:258
Error details:
  File: llmc/dataloader.h
  Line: 258
  Expected elements: 3
  Read elements: 0
```

Fixed by introducing floor_div and indexing looks like this.
```
Process 195: start_example_index = 9750, end_example_index before = 9800, end_example_index after = 9800
Process 196: start_example_index = 9800, end_example_index before = 9850, end_example_index after = 9850
Process 197: start_example_index = 9850, end_example_index before = 9900, end_example_index after = 9900
Process 198: start_example_index = 9900, end_example_index before = 9950, end_example_index after = 9950
Process 199: start_example_index = 9950, end_example_index before = 10000, end_example_index after = 10042
```