### PR TITLE
Fused Forward GELU (again)

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -703,8 +703,7 @@ void gpt2_forward(GPT2 *model, const int* inputs, const int* targets, size_t B, 
 
         matmul_forward_cublaslt(l_attproj, l_atty, l_attprojw, l_attprojb, B, T, C, C, main_stream);
         fused_residual_forward5(l_residual2, l_ln2, l_ln2_mean, l_ln2_rstd, residual, l_attproj, l_ln2w, l_ln2b, B*T, C, main_stream);
-        matmul_forward_cublaslt(l_fch, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream);
-        gelu_forward(l_fch_gelu, l_fch, B*T*4*C, main_stream);
+        matmul_forward_cublaslt(l_fch, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream, l_fch_gelu); // with GELU
         matmul_forward_cublaslt(l_fcproj, l_fch_gelu, l_fcprojw, l_fcprojb, B, T, 4*C, C, main_stream);
 
         // OK, fusion across blocks.


### PR DESCRIPTION
This turns out to be properly fused (and therefore faster) on H100 with CUDA 12.5 - it was definitely *not* fused and actually noticeably slower on RTX 4090 with CUDA 12.4, I suspect that is more about H100 vs AD102 code paths in cuBLAS than about the CUDA version, but I am not sure. Seems to be about ~144K/s to ~145K/s for the default settings of train_gpt2cu.

Not sure what the best approach is here, we could potentially detect >= SM_90 and only use the fused path in that case *sigh*