### PR TITLE
Changes toward `layernorm_forward` in `dev/cuda`

### DIFF
--- a/dev/cuda/layernorm_forward.cu
+++ b/dev/cuda/layernorm_forward.cu
@@ -179,10 +179,9 @@ __global__ void normalization_kernel(float* out, const float* inp, float* mean, 
     out[idx] = o;
 }
 
-__global__ void layernorm_forward_kernel3(
-    float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
-    const float* __restrict__ inp, const float* __restrict__ weight,
-    const float* __restrict__ bias, int N, int C) {
+__global__ void layernorm_forward_kernel3(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
+                                    const float*  __restrict__ inp, const float*  __restrict__ weight,
+                                    const float* __restrict__ bias, int N, int C) {
     int warpsPerBlock = blockDim.x / warpSize;
     int warpId = threadIdx.x / warpSize;
     int laneId = threadIdx.x % warpSize;
@@ -230,10 +229,9 @@ __global__ void layernorm_forward_kernel3(
 }
 
 // same as kernel 3 but uses var(x) == mean(x**2) - mean(x)**2
-__global__ void layernorm_forward_kernel4(
-    float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
-    const float* __restrict__ inp, const float* __restrict__ weight,
-    const float* __restrict__ bias, int N, int C) {
+__global__ void layernorm_forward_kernel4(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
+                                    const float*  __restrict__ inp, const float*  __restrict__ weight,
+                                    const float* __restrict__ bias, int N, int C) {
     int warpsPerBlock = blockDim.x / warpSize;
     int warpId = threadIdx.x / warpSize;
     int laneId = threadIdx.x % warpSize;
@@ -336,11 +334,9 @@ __global__ void layernorm_forward_kernel5(float* __restrict__ out, float* __rest
 // similar to kernel4, plus using smem to temporaily store input data
 // due to the smem limit, this kernel cannot handle block size > 512 (with fixed C 768 and warp size 32)
 // not so much modification, but decently improve bandwidth
-__global__ void __launch_bounds__(512) layernorm_forward_kernel6(float* __restrict__ out, float* __restrict__ mean,
-                              float* __restrict__ rstd,
-                              const float* __restrict__ inp,
-                              const float* __restrict__ weight,
-                              const float* __restrict__ bias, int N, int C) {
+__global__ void __launch_bounds__(512) layernorm_forward_kernel6(float* __restrict__ out, float* __restrict__ mean, float* __restrict__ rstd,
+                                    const float*  __restrict__ inp, const float*  __restrict__ weight,
+                                    const float* __restrict__ bias, int N, int C) {
     float eps = 1e-5f;
     extern __shared__ float xShared[];
     int warpsPerBlock = blockDim.x / warpSize;


### PR DESCRIPTION
## Remove cooperative groups
Following the instructions in #292, remove cooperative groups codes in existing layernorm forward kernels.

### benchmark

Performance before and after changes:

|             | Block Size | `layernorm_forward3`     | `layernorm_forward4`     | `layernorm_forward5`     |
| ----------- | ---------- | ------------------------ | ------------------------ | ------------------------ |
| With cgs    | 32         | `0.1373 ms, 366.49 GB/s` | `0.1381 ms, 364.35 GB/s` | `0.1732 ms, 290.67 GB/s` |
|             | 64         | `0.1473 ms, 341.73 GB/s` | `0.1421 ms, 354.32 GB/s` | `0.1348 ms, 373.39 GB/s` |
|             | 128        | `0.1776 ms, 283.32 GB/s` | `0.1519 ms, 331.27 GB/s` | `0.1293 ms, 389.28 GB/s` |
|             | 256        | `0.1678 ms, 300.02 GB/s` | `0.1493 ms, 337.01 GB/s` | `0.1459 ms, 344.90 GB/s` |
|             | 512        | `0.1704 ms, 295.34 GB/s` | `0.1498 ms, 336.09 GB/s` | `0.2136 ms, 235.61 GB/s` |
|             | 1024       | `0.1475 ms, 341.28 GB/s` | `0.1441 ms, 349.33 GB/s` | `0.4137 ms, 121.65 GB/s` |
| Without cgs | 32         | `0.1382 ms, 364.23 GB/s` | `0.1366 ms, 368.52 GB/s` | `0.1715 ms, 293.44 GB/s` |
|             | 64         | `0.1466 ms, 343.30 GB/s` | `0.1397 ms, 360.29 GB/s` | `0.1356 ms, 371.27 GB/s` |
|             | 128        | `0.1759 ms, 286.09 GB/s` | `0.1502 ms, 335.11 GB/s` | `0.1326 ms, 379.48 GB/s` |
|             | 256        | `0.1675 ms, 300.56 GB/s` | `0.1484 ms, 339.12 GB/s` | `0.1411 ms, 356.80 GB/s` |
|             | 512        | `0.1674 ms, 300.70 GB/s` | `0.1487 ms, 338.50 GB/s` | `0.2315 ms, 217.41 GB/s` |
|             | 1024       | `0.1437 ms, 350.18 GB/s` | `0.1445 ms, 348.27 GB/s` | `0.4223 ms, 119.18 GB/s` |


## New implementation: `layernorm_forward6`

Similar to kernel4, plus using shared memory to acclerate data accessing.
Due to the smem limit in my gpu, the kernel cannot handle block size > 512 (with fixed C 768 and warp size 32).

### Benchmark
OS: Ubuntu 22.04
Device: NVIDIA GeForce RTX 3070 Laptop GPU 

Format: (time, bandwidth)
| Block size| `layernorm_forward4()` | `layernorm_forward_5()` | `layernorm_forward6()` |
| ---------- | ------------------------- | -------------------------- | ------------------------- |
| 32            |  `0.1376 ms, 365.86 GB/s` | `0.1735 ms, 290.03 GB/s` | `0.1268 ms, 396.90 GB/s` |
| 64 | `0.1418 ms, 355.04 GB/s` |  `0.1349 ms, 373.13 GB/s` |  `0.1271 ms, 395.86 GB/s` |
| 128 |  `0.1515 ms, 332.21 GB/s` |  `0.1304 ms, 385.93 GB/s` |  `0.1268 ms, 396.88 GB/s` |
| 256 | `0.1479 ms, 340.38 GB/s` |  `0.1386 ms, 363.08 GB/s` |  `0.1267 ms, 397.23 GB/s` |
| 512 | `0.1493 ms, 337.06 GB/s` | `0.2123 ms, 237.10 GB/s` |  `0.1283 ms, 392.31 GB/s` |
| 1024 |  `0.1435 ms, 350.81 GB/s` |  `0.4182 ms, 120.35 GB/s` |  `0.1290 ms, 390.16 GB/s` (still 512 here) |

