### PR TITLE
Fix copy and casting from spawning excessive threads

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1037,7 +1037,7 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
         float* master_ptr = NULL;
         if (model->master_weights != NULL) { master_ptr = model->master_weights + opt_state_offset; }
         if(init_master_weights) {
-            size_t grid_size = CEIL_DIV(shard_num_parameters, 512);
+            size_t grid_size = CEIL_DIV(shard.size, 512);
             copy_and_cast_kernel<<<dim3(grid_size, num_layers), 512, 0, main_stream>>>(master_ptr, param_ptr, shard.size,
                                                                      shard.size, tensor.size);
             cudaCheck(cudaGetLastError());


### PR DESCRIPTION
Due to Amdahl's law this optimization won't really matter (we only call this on the first call to `gpt2_update`), but for reference:

for a 124M model:
* `shard_num_parameters` (in zero stage 0, and single GPU setups) is 124M
* `shard.size` can be as small as 764 (layernorm shards)

So we're spawning 124M threads more than we need. :')