### PR TITLE
Fix stochastic rounding

### DIFF
--- a/llmc/adamw.cuh
+++ b/llmc/adamw.cuh
@@ -40,9 +40,7 @@ __device__ void adamw_update(Tp* params_memory, float* master_params_memory, Tg*
     float param = old_param - (learning_rate * (m / (sqrtf(v) + eps) + weight_decay * old_param));
     // update our low precision version of the parameters using stochastic rounding
     // this will be used in the next forward pass
-    // TODO: simply doing `params_memory[i] = (floatX)param;` breaks everything (why?)
-    unsigned int random = Get2dNoiseUint(threadIdx.x, blockIdx.x + blockDim.y * gridDim.y, seed);
-    stochastic_rounding(param, &params_memory[idx], random);
+    stochastic_rounding(param, &params_memory[idx], seed);
     // write the full, float version of the param into our master copy, if we maintain one
     // this will be used in the next update
     if (master_params_memory != NULL) { master_params_memory[idx] = param; }

--- a/llmc/cuda_utils.cuh
+++ b/llmc/cuda_utils.cuh
@@ -190,7 +190,8 @@ __device__ __host__ constexpr unsigned int Get2dNoiseUint(int indexX, int indexY
 // stochastic rounding built on top of Squirel Noise above (with seed updated per step via xorshift)
 __device__ __forceinline__ void stochastic_rounding(float in, __nv_bfloat16 *out, unsigned int seed) {
     // todo - is this stochastic rounding *too good*? can we cut any corners?
-    unsigned int random = Get2dNoiseUint(threadIdx.x, blockIdx.x, seed);
+    // makes sure each thread gets a different random number
+    unsigned int random = Get2dNoiseUint(threadIdx.x, blockIdx.x * blockDim.x + blockIdx.y, seed);
     unsigned int threshold = random & 0xFFFF;
     unsigned int float_bits = __float_as_uint(in);
     unsigned int rounded_bits = float_bits & 0x0000FFFF;

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1009,10 +1009,12 @@ float gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, fl
     float grad_scale = (grad_norm_cpu > grad_clip) ? grad_clip / grad_norm_cpu : 1.0f;
 
     // AdamW update
-    unsigned int seed = random_u32(&model->rng_state);
 
     // handle adamw for all the transformer blocks
     for (int i = 0; i < NUM_PARAMETER_TENSORS; i++) {
+        // generate a unique seed for each tensor
+        unsigned int seed = random_u32(&model->rng_state);
+
         int num_layers = model->config.num_layers;
         if((i < 2 || i > 13)) {
             num_layers = 1;


### PR DESCRIPTION
Previously our stochastic rounding logic didn't have a unique seed for each of the parameters we're rounding. This PR fixes that.

In more detail, previously:
* we were passing the same seed for all `NUM_PARAMETER_TENSORS` (16) sections of the param buffer.
* the above combined with this logic (extracted to demonstrate the gist of the logic):
```
unsigned int seed1 = Get2dNoiseUint(threadIdx.x, blockIdx.x + blockDim.y * gridDim.y, seed);
unsigned int seed2 = Get2dNoiseUint(threadIdx.x, blockIdx.x, seed1);
```
and given that `blockDim.y * gridDim.y` is constant and equal to either `1*1` or `1*12` (depending on whether we deal with one of the 4 layers like wte, wpe, lnfw, lnfb or with transformer layers respectively) - meant that many params were getting the same `seed2`!

In particular for the 4 layers (wte, wpe, lnfw, lnfb) we'd be doing:
```
unsigned int seed1 = Get2dNoiseUint(threadIdx.x, blockIdx.x + 1, seed);
unsigned int seed2 = Get2dNoiseUint(threadIdx.x, blockIdx.x, seed1);
```
which means that all params handled by a thread (blockIdx.x, threadIdx.x) are receiving the same seed.

Similarly for the 12 transformer layers - the offset would just be 12. But additionally all 12 shards would be reusing the same seed so the situation is even worse as `blockIdx.y` is not used in the generation of the seed.

The new logic makes sure that every single param has a unique seed.
