### PR TITLE
Check determinism in CI

### DIFF
--- a/llmc/cuda_common.h
+++ b/llmc/cuda_common.h
@@ -42,13 +42,25 @@ extern cudaDeviceProp deviceProp;
 // Error checking
 
 // CUDA error checking
-void inline cudaCheck(cudaError_t error, const char *file, int line) {
+inline void cudaCheck(cudaError_t error, const char *file, int line) {
   if (error != cudaSuccess) {
     printf("[CUDA ERROR] at file %s:%d:\n%s\n", file, line, cudaGetErrorString(error));
     exit(EXIT_FAILURE);
   }
 };
 #define cudaCheck(err) (cudaCheck(err, __FILE__, __LINE__))
+
+// like cudaFree, but checks for errors _and_ resets the pointer.
+template<class T>
+inline void cudaFreeCheck(T** ptr, const char *file, int line) {
+    cudaError_t error = cudaFree(*ptr);
+    if (error != cudaSuccess) {
+        printf("[CUDA ERROR] at file %s:%d:\n%s\n", file, line, cudaGetErrorString(error));
+        exit(EXIT_FAILURE);
+    }
+    *ptr = nullptr;
+}
+#define cudaFreeCheck(ptr) (cudaFreeCheck(ptr, __FILE__, __LINE__))
 
 // ----------------------------------------------------------------------------
 // CUDA Precision settings and defines

--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -96,13 +96,6 @@ int64_t dataloader_load_shard_(DataLoader *loader, int shard_index) {
     return ntok;
 }
 
-void dataloader_resume(DataLoader *loader, size_t current_shard_idx, size_t current_sample_idx) {
-    // used during model resumption (-y 1) flag
-    loader->current_shard_idx = current_shard_idx;
-    loader->current_sample_idx = current_sample_idx;
-    dataloader_load_shard_(loader, loader->current_shard_idx);
-}
-
 void prepare_intra_shard_indices_(DataLoader *loader) {
     // shuffle the examples inside the shards
     if (loader->intra_shard_indices != NULL) {
@@ -206,12 +199,13 @@ void dataloader_init(DataLoader *loader,
 
     // reset the loader, to initialize it
     dataloader_reset(loader);
+    // we haven't drawn a current sample yet
+    loader->current_sample_idx = -1;
 }
 
-void dataloader_next_batch(DataLoader *loader) {
+void dataloader_load_batch(DataLoader* loader) {
     assert(!loader->should_shuffle || (loader->should_shuffle && loader->intra_shard_indices != NULL));
     assert(loader->current_sample_idx < loader->shard_num_samples);
-
     size_t idx = loader->should_shuffle ? loader->intra_shard_indices[loader->current_sample_idx] : loader->current_sample_idx;
     size_t global_batch_offset_bytes = idx * loader->total_batch_size_bytes;
     int64_t current_offset = loader->header_bytes + global_batch_offset_bytes + loader->local_batch_offset_bytes;
@@ -226,12 +220,24 @@ void dataloader_next_batch(DataLoader *loader) {
         loader->inputs[i] = (int)loader->buffer[i];
         loader->targets[i] = (int)loader->buffer[i+1];
     }
+}
 
+void dataloader_next_batch(DataLoader *loader) {
     loader->current_sample_idx += 1;
     // if the next batch would go past the end of the file, advance the loader
     if (loader->current_sample_idx >= loader->shard_num_samples) {
         dataloader_advance_(loader);
     }
+    dataloader_load_batch(loader);
+}
+
+
+void dataloader_resume(DataLoader *loader, size_t current_shard_idx, size_t current_sample_idx) {
+    // used during model resumption (-y 1) flag
+    loader->current_shard_idx = current_shard_idx;
+    loader->current_sample_idx = current_sample_idx;
+    dataloader_load_shard_(loader, loader->current_shard_idx);
+    dataloader_load_batch(loader);
 }
 
 void dataloader_free(DataLoader *loader) {

--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -33,6 +33,7 @@ int main(int argc, char *argv[]) {
 
     // build the GPT-2 model from a checkpoint
     GPT2 model;
+    gpt2_init_common(&model);
     gpt2_build_from_checkpoint(&model, "gpt2_124M_bf16.bin");
 
     int B = 24; // if program OOMs decrease this number, e.g. all the way down to 4 or etc

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -315,39 +315,54 @@ int main(int argc, char *argv[]) {
 
     // Finally, let's check determinism
     gpt2_write_to_checkpoint(&model, "test_gpt2cu_model.ckpt");
-    save_state("test_gpt2cu_state.ckpt", 10, &model, nullptr);
-    for (int step = 10; step < 20; step++) {
-        gpt2_forward(&model, x, y, B, T);
+
+    DataLoader loader;
+    dataloader_init(&loader, "dev/data/tinyshakespeare/tiny_shakespeare_val.bin", B, T, multi_gpu_config.process_rank, multi_gpu_config.num_processes, 1);
+    dataloader_next_batch(&loader);
+    save_state("test_gpt2cu_state.ckpt", 10, &model, &loader);
+    int tokens[10];
+    for (int step = 0; step < 10; step++) {
+        gpt2_forward(&model, loader.inputs, loader.targets, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward(&model, x, true);
-        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+1, &multi_gpu_config);
-        losses[step - 10] = model.mean_loss;
+        gpt2_backward(&model, loader.inputs, true);
+        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+11, &multi_gpu_config);
+        losses[step] = model.mean_loss;
+        tokens[step] = loader.inputs[0];
+        dataloader_next_batch(&loader);
     }
 
     // reload
     gpt2_free(&model);
     gpt2_build_from_checkpoint(&model, "test_gpt2cu_model.ckpt");
     int ld_step;
-    load_state(&ld_step, &model, nullptr, "test_gpt2cu_state.ckpt");
-    for (int step = 10; step < 20; step++) {
-        gpt2_forward(&model, x, y, B, T);
+    load_state(&ld_step, &model, &loader, "test_gpt2cu_state.ckpt");
+    for (int step = 0; step < 10; step++) {
+        gpt2_forward(&model, loader.inputs, loader.targets, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward(&model, x, true);
-        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+1, &multi_gpu_config);
+        gpt2_backward(&model, loader.inputs, true);
+        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+11, &multi_gpu_config);
 
-        if(losses[step-10] != model.mean_loss) {
-            printf("Nondeterminism! Loss mismatch at step %d: %.15f vs %.15f\n", step, losses[step-10], model.mean_loss);
+        if(loader.inputs[0] != tokens[step]) {
+            printf("Nondeterminism! Token mismatch at step %d: %d vs %d\n", step, tokens[step], loader.inputs[0]);
+            allok = false;
+            break;
+        }
+
+        if(losses[step] != model.mean_loss) {
+            printf("Nondeterminism! Loss mismatch at step %d: %.15f vs %.15f\n", step, losses[step], model.mean_loss);
             allok = false;
             break;
         } else {
-            printf("loss ok at step %d: %f %f\n", step, losses[step-10], model.mean_loss);
+            printf("loss ok at step %d: %f %f\n", step, losses[step], model.mean_loss);
         }
+        dataloader_next_batch(&loader);
     }
 
     // final approval
     printf("overall okay: %d\n", allok);
 
     // free everything
+    dataloader_free(&loader);
     gpt2_free(&model);
     common_free(model);
     free(x);

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -101,6 +101,7 @@ int main(int argc, char *argv[]) {
 
     // build the GPT-2 model from a checkpoint
     GPT2 model;
+    gpt2_init_common(&model);
 
     gpt2_build_from_checkpoint(&model, load_filename);
     size_t V = model.config.vocab_size;
@@ -309,6 +310,37 @@ int main(int argc, char *argv[]) {
             allok = 0;
         } else {
             printf("loss ok at step %d: %f %f\n", i+1, losses[i], expected_losses[i]);
+        }
+    }
+
+    // Finally, let's check determinism
+    gpt2_write_to_checkpoint(&model, "test_gpt2cu_model.ckpt");
+    save_state("test_gpt2cu_state.ckpt", 10, &model, nullptr);
+    for (int step = 10; step < 20; step++) {
+        gpt2_forward(&model, x, y, B, T);
+        gpt2_zero_grad(&model);
+        gpt2_backward(&model, x, true);
+        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+1, &multi_gpu_config);
+        losses[step - 10] = model.mean_loss;
+    }
+
+    // reload
+    gpt2_free(&model);
+    gpt2_build_from_checkpoint(&model, "test_gpt2cu_model.ckpt");
+    int ld_step;
+    load_state(&ld_step, &model, nullptr, "test_gpt2cu_state.ckpt");
+    for (int step = 10; step < 20; step++) {
+        gpt2_forward(&model, x, y, B, T);
+        gpt2_zero_grad(&model);
+        gpt2_backward(&model, x, true);
+        gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+1, &multi_gpu_config);
+
+        if(losses[step-10] != model.mean_loss) {
+            printf("Nondeterminism! Loss mismatch at step %d: %.15f vs %.15f\n", step, losses[step-10], model.mean_loss);
+            allok = false;
+            break;
+        } else {
+            printf("loss ok at step %d: %f %f\n", step, losses[step-10], model.mean_loss);
         }
     }
 

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
             }
 
             // move the (mixed precision) grads from GPU to CPU
-            cudaMemcpy(grads_memory_cpu, model.grads_memory, model.num_parameters_bytes, cudaMemcpyDeviceToHost);
+            cudaCheck(cudaMemcpy(grads_memory_cpu, model.grads_memory, model.num_parameters_bytes, cudaMemcpyDeviceToHost));
 
             // convert all gradients to float on the CPU
             char* src_iterator = (char*)grads_memory_cpu; // can be lower precision, so we use char*


### PR DESCRIPTION
Extends the test script to validate determinism.
Some thoughts:
* With C memory management, it is quite easy to introduce memory leaks, e.g., loading from checkpoint twice without freeing in the middle causes a leak. To be somewhat defensive against this, I added a check that  validates that the pointer is null before allocating; which doesn't actually work, because the pointer value will be whatever random garbage was at that memory location before. In the end, I ended up requiring a separate gpt2_init call in front of either checkpoint loading or random generation.
* As the test script currently doesn't use the data loader, there are now some ugly ifdefs inside state saving/reading.

I did test cherry-picking this commit into an earlier version of the code, before the recent fixes, where it produces
>  Nondeterminism! Loss mismatch at step 11: 0.047421135008335 vs 0.049596484750509