### PR TITLE
Add learning rate schedulers

### DIFF
--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -1,0 +1,43 @@
+
+
+// Cosine learning rate scheduler
+
+#ifndef SCHEDULERS_H
+
+#define SCHEDULERS_H
+
+#include <assert.h>
+#include <math.h>
+
+typedef struct {
+    float learning_rate;
+    int warmup_iterations;
+    int train_num_batches;
+    float final_learning_rate_frac;
+} CosineLearningRateScheduler;
+
+
+// learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
+float get_learning_rate(CosineLearningRateScheduler *scheduler, int step) {
+    float step_learning_rate = scheduler->learning_rate;
+    if (step < scheduler->warmup_iterations) {
+        step_learning_rate = scheduler->learning_rate * ((float)(step + 1)) / scheduler->warmup_iterations;
+    } else {
+        float decay_ratio = ((float)(step - scheduler->warmup_iterations)) / (scheduler->train_num_batches - scheduler->warmup_iterations);
+        assert(0.0f <= decay_ratio && decay_ratio <= 1.0f);
+        float coeff = 0.5f * (1.0f + cosf(M_PI * decay_ratio)); // coeff starts at 1 and goes to 0
+        assert(0.0f <= coeff && coeff <= 1.0f);
+        float min_lr = scheduler->learning_rate * scheduler->final_learning_rate_frac;
+        step_learning_rate = min_lr + coeff * (scheduler->learning_rate - min_lr);
+    }
+    return step_learning_rate;
+}
+
+void lr_scheduler_init(CosineLearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
+    scheduler->learning_rate = learning_rate;
+    scheduler->warmup_iterations = warmup_iterations;
+    scheduler->train_num_batches = train_num_batches;
+    scheduler->final_learning_rate_frac = final_learning_rate_frac;
+}
+
+#endif // SCHEDULERS_H

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -7,6 +7,7 @@ Implements various learning rate schedulers.
 
 #include <assert.h>
 #include <math.h>
+#include <cstring>
 
 typedef enum {
     LR_SCHEDULER_COSINE,
@@ -62,24 +63,6 @@ void lr_scheduler_init(LearningRateScheduler *scheduler, float learning_rate, in
 // Learning rate scheduler functions
 //
 
-// switch to the appropriate learning rate scheduler
-float get_learning_rate(LRSchedulerType lr_scheduler_type, LearningRateScheduler *scheduler, int step) {
-    float step_learning_rate;
-    if (lr_scheduler_type == LR_SCHEDULER_COSINE) {
-        step_learning_rate = get_learning_rate_cosine(scheduler, step);
-    } else if (lr_scheduler_type == LR_SCHEDULER_LINEAR) {
-        step_learning_rate = get_learning_rate_linear(scheduler, step);
-    } else if (lr_scheduler_type == LR_SCHEDULER_TRIANGULAR) {
-        step_learning_rate = get_learning_rate_triangular(scheduler, step);
-    } else if (lr_scheduler_type == LR_SCHEDULER_CONSTANT) {
-        step_learning_rate = get_learning_rate_constant(scheduler, step);
-    } else {
-        printf("Unknown learning rate scheduler type\n");
-        exit(EXIT_FAILURE);
-    }
-    return step_learning_rate;
-}
-
 // cosine learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
 float get_learning_rate_cosine(LearningRateScheduler *scheduler, int step) {
     float lr = scheduler->learning_rate;
@@ -113,6 +96,7 @@ float get_learning_rate_linear(LearningRateScheduler *scheduler, int step) {
 // cyclic triangular learning rate schedule: linearly increase LR from min LR to max LR, then linearly decrease LR to min LR (repeat)
 // currently hardcoded to support only a single cycle
 float get_learning_rate_triangular(LearningRateScheduler *scheduler, int step) {
+    // warmup_iterations <- not used.
     int step_size = scheduler->train_num_batches / 2;  // number of steps in half a cycle
     float min_lr = scheduler->learning_rate * scheduler->final_learning_rate_frac;
     float max_lr = scheduler->learning_rate;
@@ -125,7 +109,29 @@ float get_learning_rate_triangular(LearningRateScheduler *scheduler, int step) {
 
 // constant learning rate schedule
 float get_learning_rate_constant(LearningRateScheduler *scheduler, int step) {
+    // warmup_iterations <- not used.
+    // train_num_batches <- not used.
+    // final_learning_rate_frac <- not used.
     return scheduler->learning_rate;
 }
+
+// switch to the appropriate learning rate scheduler
+float get_learning_rate(LRSchedulerType lr_scheduler_type, LearningRateScheduler *scheduler, int step) {
+    float step_learning_rate;
+    if (lr_scheduler_type == LR_SCHEDULER_COSINE) {
+        step_learning_rate = get_learning_rate_cosine(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_LINEAR) {
+        step_learning_rate = get_learning_rate_linear(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_TRIANGULAR) {
+        step_learning_rate = get_learning_rate_triangular(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_CONSTANT) {
+        step_learning_rate = get_learning_rate_constant(scheduler, step);
+    } else {
+        printf("Unknown learning rate scheduler type\n");
+        exit(EXIT_FAILURE);
+    }
+    return step_learning_rate;
+}
+
 
 #endif // SCHEDULERS_H

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -8,6 +8,38 @@ Implements various learning rate schedulers.
 #include <assert.h>
 #include <math.h>
 
+typedef enum {
+    LR_SCHEDULER_COSINE,
+    LR_SCHEDULER_LINEAR,
+    LR_SCHEDULER_TRIANGULAR,
+    LR_SCHEDULER_CONSTANT,
+    NUM_LR_SCHEDULERS   // To keep track of the number of schedulers
+} LRSchedulerType;
+
+const char* lr_scheduler_names[] = {
+    "cosine",
+    "linear",
+    "triangular",
+    "constant",
+};
+
+const char* get_lr_scheduler_name(LRSchedulerType type) {
+    if (type < 0 || type >= NUM_LR_SCHEDULERS) {
+        exit(EXIT_FAILURE);
+    }
+    return lr_scheduler_names[type];
+}
+
+LRSchedulerType get_lr_scheduler_type_from_name(const char* name) {
+    for (int i = 0; i < NUM_LR_SCHEDULERS; ++i) {
+        if (strcmp(name, lr_scheduler_names[i]) == 0) {
+            return (LRSchedulerType)i;
+        }
+    }
+    printf("Warning: Unknown learning rate scheduler name: %s\n. Using cosine as default.", name);
+    return LR_SCHEDULER_COSINE;  // Default to cosine if not found
+}
+
 //
 // Learning rate scheduler structs
 //

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -7,7 +7,7 @@ Implements various learning rate schedulers.
 
 #include <assert.h>
 #include <math.h>
-#include <cstring>
+#include <string.h>
 
 typedef enum {
     LR_SCHEDULER_COSINE,

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -41,7 +41,7 @@ LRSchedulerType get_lr_scheduler_type_from_name(const char* name) {
 }
 
 //
-// Learning rate scheduler structs
+// Learning rate scheduler structs and init
 //
 
 typedef struct {
@@ -49,33 +49,39 @@ typedef struct {
     int warmup_iterations;
     int train_num_batches;
     float final_learning_rate_frac;
-} CosineLearningRateScheduler;
+} LearningRateScheduler;
 
-// Linear with warmup learning rate scheduler
-typedef struct {
-    float learning_rate;
-    int warmup_iterations;
-    int train_num_batches;
-    float final_learning_rate_frac;
-} LinearLearningRateScheduler;
-
-typedef struct {
-    float min_lr;
-    float max_lr;
-    int step_size;
-} CyclicTriangularLearningRateScheduler;
-
-// Constant learning rate scheduler
-typedef struct {
-    float learning_rate;
-} ConstantLearningRateScheduler;
+void lr_scheduler_init(LearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
+    scheduler->learning_rate = learning_rate;
+    scheduler->warmup_iterations = warmup_iterations;
+    scheduler->train_num_batches = train_num_batches;
+    scheduler->final_learning_rate_frac = final_learning_rate_frac;
+}
 
 //
 // Learning rate scheduler functions
 //
 
+// switch to the appropriate learning rate scheduler
+float get_learning_rate(LRSchedulerType lr_scheduler_type, LearningRateScheduler *scheduler, int step) {
+    float step_learning_rate;
+    if (lr_scheduler_type == LR_SCHEDULER_COSINE) {
+        step_learning_rate = get_learning_rate_cosine(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_LINEAR) {
+        step_learning_rate = get_learning_rate_linear(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_TRIANGULAR) {
+        step_learning_rate = get_learning_rate_triangular(scheduler, step);
+    } else if (lr_scheduler_type == LR_SCHEDULER_CONSTANT) {
+        step_learning_rate = get_learning_rate_constant(scheduler, step);
+    } else {
+        printf("Unknown learning rate scheduler type\n");
+        exit(EXIT_FAILURE);
+    }
+    return step_learning_rate;
+}
+
 // cosine learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
-float get_learning_rate_cosine(CosineLearningRateScheduler *scheduler, int step) {
+float get_learning_rate_cosine(LearningRateScheduler *scheduler, int step) {
     float lr = scheduler->learning_rate;
     if (step < scheduler->warmup_iterations) {
         lr = scheduler->learning_rate * ((float)(step + 1)) / scheduler->warmup_iterations;
@@ -91,7 +97,7 @@ float get_learning_rate_cosine(CosineLearningRateScheduler *scheduler, int step)
 }
 
 // linear warmup learning rate schedule: warmup linearly to max LR, then decay linearly to LR * final_learning_rate_frac
-float get_learning_rate_linear(LinearLearningRateScheduler *scheduler, int step) {
+float get_learning_rate_linear(LearningRateScheduler *scheduler, int step) {
     float lr = scheduler->learning_rate;
     if (step < scheduler->warmup_iterations) {
         lr = scheduler->learning_rate * ((float)(step + 1)) / scheduler->warmup_iterations;
@@ -105,44 +111,21 @@ float get_learning_rate_linear(LinearLearningRateScheduler *scheduler, int step)
 }
 
 // cyclic triangular learning rate schedule: linearly increase LR from min LR to max LR, then linearly decrease LR to min LR (repeat)
-float get_learning_rate_triangular(CyclicTriangularLearningRateScheduler *scheduler, int step) {
-    int cycle_index = 1 + step / (2 * scheduler->step_size);  // tells us which cycle we are in, starting at 1
-    float x = fabsf((float)step / scheduler->step_size - 2 * cycle_index + 1);  // goes from 0 to 1 to 0
-    float lr = scheduler->min_lr + (scheduler->max_lr - scheduler->min_lr) * fmaxf(0, (1 - x));
+// currently hardcoded to support only a single cycle
+float get_learning_rate_triangular(LearningRateScheduler *scheduler, int step) {
+    int step_size = scheduler->train_num_batches / 2;  // number of steps in half a cycle
+    float min_lr = scheduler->learning_rate * scheduler->final_learning_rate_frac;
+    float max_lr = scheduler->learning_rate;
+
+    int cycle_index = 1 + step / (2 * step_size);  // tells us which cycle we are in, starting at 1
+    float x = fabsf((float)step / step_size - 2 * cycle_index + 1);  // goes from 0 to 1 to 0
+    float lr = min_lr + (max_lr - min_lr) * fmaxf(0, (1 - x));
     return lr;
 }
 
 // constant learning rate schedule
-float get_learning_rate_constant(ConstantLearningRateScheduler *scheduler, int step) {
+float get_learning_rate_constant(LearningRateScheduler *scheduler, int step) {
     return scheduler->learning_rate;
-}
-
-//
-// Init functions
-//
-
-void lr_scheduler_init_cosine(CosineLearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
-    scheduler->learning_rate = learning_rate;
-    scheduler->warmup_iterations = warmup_iterations;
-    scheduler->train_num_batches = train_num_batches;
-    scheduler->final_learning_rate_frac = final_learning_rate_frac;
-}
-
-void lr_scheduler_init_linear(LinearLearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
-    scheduler->learning_rate = learning_rate;
-    scheduler->warmup_iterations = warmup_iterations;
-    scheduler->train_num_batches = train_num_batches;
-    scheduler->final_learning_rate_frac = final_learning_rate_frac;
-}
-
-void lr_scheduler_init_triangular(CyclicTriangularLearningRateScheduler *scheduler, float min_lr, float max_lr, int step_size) {
-    scheduler->min_lr = min_lr;
-    scheduler->max_lr = max_lr;
-    scheduler->step_size = step_size;
-}
-
-void lr_scheduler_init_constant(ConstantLearningRateScheduler *scheduler, float learning_rate) {
-    scheduler->learning_rate = learning_rate;
 }
 
 #endif // SCHEDULERS_H

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -8,6 +8,10 @@ Implements various learning rate schedulers.
 #include <assert.h>
 #include <math.h>
 
+//
+// Learning rate scheduler structs
+//
+
 typedef struct {
     float learning_rate;
     int warmup_iterations;
@@ -15,27 +19,55 @@ typedef struct {
     float final_learning_rate_frac;
 } CosineLearningRateScheduler;
 
-// learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
-float get_learning_rate(CosineLearningRateScheduler *scheduler, int step) {
-    float step_learning_rate = scheduler->learning_rate;
+typedef struct {
+    float min_lr;
+    float max_lr;
+    int step_size;
+} CyclicTriangularLearningRateScheduler;
+
+//
+// Learning rate scheduler functions
+//
+
+// cosine learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
+float get_learning_rate_cosine(CosineLearningRateScheduler *scheduler, int step) {
+    float lr = scheduler->learning_rate;
     if (step < scheduler->warmup_iterations) {
-        step_learning_rate = scheduler->learning_rate * ((float)(step + 1)) / scheduler->warmup_iterations;
+        lr = scheduler->learning_rate * ((float)(step + 1)) / scheduler->warmup_iterations;
     } else {
         float decay_ratio = ((float)(step - scheduler->warmup_iterations)) / (scheduler->train_num_batches - scheduler->warmup_iterations);
         assert(0.0f <= decay_ratio && decay_ratio <= 1.0f);
         float coeff = 0.5f * (1.0f + cosf(M_PI * decay_ratio)); // coeff starts at 1 and goes to 0
         assert(0.0f <= coeff && coeff <= 1.0f);
         float min_lr = scheduler->learning_rate * scheduler->final_learning_rate_frac;
-        step_learning_rate = min_lr + coeff * (scheduler->learning_rate - min_lr);
+        lr = min_lr + coeff * (scheduler->learning_rate - min_lr);
     }
-    return step_learning_rate;
+    return lr;
 }
 
-void lr_scheduler_init(CosineLearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
+// cyclic triangular learning rate schedule: linearly increase LR from min LR to max LR, then linearly decrease LR to min LR (repeat)
+float get_learning_rate_triangular(CyclicTriangularLearningRateScheduler *scheduler, int step) {
+    int cycle = 1 + step / (2 * scheduler->step_size);
+    float x = fabsf((float)step / scheduler->step_size - 2 * cycle + 1);
+    float lr = scheduler->min_lr + (scheduler->max_lr - scheduler->min_lr) * fmaxf(0, (1 - x));
+    return lr;
+}
+
+//
+// Init functions
+//
+
+void lr_scheduler_init_cosine(CosineLearningRateScheduler *scheduler, float learning_rate, int warmup_iterations, int train_num_batches, float final_learning_rate_frac) {
     scheduler->learning_rate = learning_rate;
     scheduler->warmup_iterations = warmup_iterations;
     scheduler->train_num_batches = train_num_batches;
     scheduler->final_learning_rate_frac = final_learning_rate_frac;
+}
+
+void lr_scheduler_init_triangular(CyclicTriangularLearningRateScheduler *scheduler, float min_lr, float max_lr, int step_size) {
+    scheduler->min_lr = min_lr;
+    scheduler->max_lr = max_lr;
+    scheduler->step_size = step_size;
 }
 
 #endif // SCHEDULERS_H

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -25,6 +25,11 @@ typedef struct {
     int step_size;
 } CyclicTriangularLearningRateScheduler;
 
+// Constant learning rate scheduler
+typedef struct {
+    float learning_rate;
+} ConstantLearningRateScheduler;
+
 //
 // Learning rate scheduler functions
 //
@@ -47,10 +52,15 @@ float get_learning_rate_cosine(CosineLearningRateScheduler *scheduler, int step)
 
 // cyclic triangular learning rate schedule: linearly increase LR from min LR to max LR, then linearly decrease LR to min LR (repeat)
 float get_learning_rate_triangular(CyclicTriangularLearningRateScheduler *scheduler, int step) {
-    int cycle = 1 + step / (2 * scheduler->step_size);
-    float x = fabsf((float)step / scheduler->step_size - 2 * cycle + 1);
+    int cycle_index = 1 + step / (2 * scheduler->step_size);  // tells us which cycle we are in, starting at 1
+    float x = fabsf((float)step / scheduler->step_size - 2 * cycle_index + 1);  // goes from 0 to 1 to 0
     float lr = scheduler->min_lr + (scheduler->max_lr - scheduler->min_lr) * fmaxf(0, (1 - x));
     return lr;
+}
+
+// constant learning rate schedule
+float get_learning_rate_constant(ConstantLearningRateScheduler *scheduler, int step) {
+    return scheduler->learning_rate;
 }
 
 //
@@ -68,6 +78,10 @@ void lr_scheduler_init_triangular(CyclicTriangularLearningRateScheduler *schedul
     scheduler->min_lr = min_lr;
     scheduler->max_lr = max_lr;
     scheduler->step_size = step_size;
+}
+
+void lr_scheduler_init_constant(ConstantLearningRateScheduler *scheduler, float learning_rate) {
+    scheduler->learning_rate = learning_rate;
 }
 
 #endif // SCHEDULERS_H

--- a/llmc/schedulers.h
+++ b/llmc/schedulers.h
@@ -1,7 +1,6 @@
-
-
-// Cosine learning rate scheduler
-
+/*
+Implements various learning rate schedulers.
+*/
 #ifndef SCHEDULERS_H
 
 #define SCHEDULERS_H
@@ -15,7 +14,6 @@ typedef struct {
     int train_num_batches;
     float final_learning_rate_frac;
 } CosineLearningRateScheduler;
-
 
 // learning rate schedule: warmup linearly to max LR, then cosine decay to LR * final_learning_rate_frac
 float get_learning_rate(CosineLearningRateScheduler *scheduler, int step) {

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1550,7 +1550,7 @@ int main(int argc, char *argv[]) {
 
     // set up learning rate scheduler
     CosineLearningRateScheduler lr_scheduler;
-    lr_scheduler_init(&lr_scheduler, learning_rate, warmup_iterations, train_num_batches, final_learning_rate_frac);
+    lr_scheduler_init_cosine(&lr_scheduler, learning_rate, warmup_iterations, train_num_batches, final_learning_rate_frac);
 
     // some memory for generating samples from the model
     int* gen_tokens = (int*)mallocCheck(B * T * sizeof(int));
@@ -1711,7 +1711,7 @@ int main(int argc, char *argv[]) {
         // average the loss and the gradients between all processes
         gpt2_multi_gpu_loss_reduce(&model, &multi_gpu_config);
         // fetch the next learning rate
-        float step_learning_rate = get_learning_rate(&lr_scheduler, step);
+        float step_learning_rate = get_learning_rate_cosine(&lr_scheduler, step);
         // update the model parameters
         float grad_norm = gpt2_update(&model, step_learning_rate, 0.9f, 0.95f, 1e-8f, weight_decay, 1.0f, step+1, &multi_gpu_config);
         // zero out the gradients for the next iteration

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1303,6 +1303,7 @@ void error_usage() {
     // workload (number of steps)
     fprintf(stderr, "  -x <int>    max_steps of optimization to run (-1 (default) = disable, run 1 epoch)\n");
     // optimization
+    fprintf(stderr, "  -k <string> learning rate scheduler (default = cosine)\n");
     fprintf(stderr, "  -l <float>  learning rate (default = 3e-4f)\n");
     fprintf(stderr, "  -u <int>    learning rate warmup iterations (default = 0, no warmup)\n");
     fprintf(stderr, "  -q <float>  learning rate decay: final fraction, at end of training (default = 1.0 (no decay))\n");
@@ -1333,6 +1334,7 @@ int main(int argc, char *argv[]) {
     const char* train_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_train.bin";
     const char* val_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_val.bin";
     const char* load_filename = "gpt2_124M_bf16.bin"; // bf16 weights of the model
+    LRSchedulerType lr_scheduler_type = LR_SCHEDULER_COSINE;
     const char* output_log_dir = NULL;
     int checkpoint_every = 0; // write optimization checkpoints every how many steps?
     int resume = 0; // resume the optimization, if one is found inside output_log_dir?
@@ -1383,6 +1385,7 @@ int main(int argc, char *argv[]) {
         else if (argv[i][1] == 'z') { zero_stage = atoi(argv[i+1]); }
         else if (argv[i][1] == 'r') { recompute = atoi(argv[i+1]); }
         else if (argv[i][1] == 'h') { hellaswag_eval = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'k') { lr_scheduler_type = get_lr_scheduler_type_from_name(argv[i + 1]); }
         else { error_usage(); }
     }
     // should do a bit more error checking here
@@ -1416,6 +1419,7 @@ int main(int argc, char *argv[]) {
     printf0("| micro batch size B    | %-50d |\n", B);
     printf0("| sequence length T     | %-50d |\n", T);
     printf0("| total batch size      | %-50d |\n", total_batch_size);
+    printf0("| LR scheduler          | %-50s |\n", get_lr_scheduler_name(lr_scheduler_type));
     printf0("| learning rate (LR)    | %-50e |\n", learning_rate);
     printf0("| warmup iterations     | %-50d |\n", warmup_iterations);
     printf0("| final LR fraction     | %-50e |\n", final_learning_rate_frac);
@@ -1549,8 +1553,26 @@ int main(int argc, char *argv[]) {
     tokenizer_init(&tokenizer, "gpt2_tokenizer.bin");
 
     // set up learning rate scheduler
-    CosineLearningRateScheduler lr_scheduler;
-    lr_scheduler_init_cosine(&lr_scheduler, learning_rate, warmup_iterations, train_num_batches, final_learning_rate_frac);
+    CosineLearningRateScheduler lr_scheduler_cosine;
+    LinearLearningRateScheduler lr_scheduler_linear;
+    CyclicTriangularLearningRateScheduler lr_scheduler_triangular;
+    ConstantLearningRateScheduler lr_scheduler_constant;
+    if (lr_scheduler_type == LR_SCHEDULER_COSINE) {
+        lr_scheduler_init_cosine(&lr_scheduler_cosine, learning_rate, warmup_iterations, train_num_batches, final_learning_rate_frac);
+    } else if (lr_scheduler_type == LR_SCHEDULER_LINEAR) {
+        lr_scheduler_init_linear(&lr_scheduler_linear, learning_rate, warmup_iterations, train_num_batches, final_learning_rate_frac);
+    } else if (lr_scheduler_type == LR_SCHEDULER_TRIANGULAR) {
+        // Hardcode some reasonable defaults for now
+        float min_lr = learning_rate / 10.0f;
+        float max_lr = learning_rate;
+        int step_size = train_num_batches / 4;
+        lr_scheduler_init_triangular(&lr_scheduler_triangular, min_lr, max_lr, step_size);
+    } else if (lr_scheduler_type == LR_SCHEDULER_CONSTANT) {
+        lr_scheduler_init_constant(&lr_scheduler_constant, learning_rate);
+    } else {
+        printf("Unknown learning rate scheduler type\n");
+        exit(EXIT_FAILURE);
+    }
 
     // some memory for generating samples from the model
     int* gen_tokens = (int*)mallocCheck(B * T * sizeof(int));
@@ -1711,7 +1733,19 @@ int main(int argc, char *argv[]) {
         // average the loss and the gradients between all processes
         gpt2_multi_gpu_loss_reduce(&model, &multi_gpu_config);
         // fetch the next learning rate
-        float step_learning_rate = get_learning_rate_cosine(&lr_scheduler, step);
+        float step_learning_rate;
+        if (lr_scheduler_type == LR_SCHEDULER_COSINE) {
+            step_learning_rate = get_learning_rate_cosine(&lr_scheduler_cosine, step);
+        } else if (lr_scheduler_type == LR_SCHEDULER_LINEAR) {
+            step_learning_rate = get_learning_rate_linear(&lr_scheduler_linear, step);
+        } else if (lr_scheduler_type == LR_SCHEDULER_TRIANGULAR) {
+            step_learning_rate = get_learning_rate_triangular(&lr_scheduler_triangular, step);
+        } else if (lr_scheduler_type == LR_SCHEDULER_CONSTANT) {
+            step_learning_rate = get_learning_rate_constant(&lr_scheduler_constant, step);
+        } else {
+            printf("Unknown learning rate scheduler type\n");
+            exit(EXIT_FAILURE);
+        }
         // update the model parameters
         float grad_norm = gpt2_update(&model, step_learning_rate, 0.9f, 0.95f, 1e-8f, weight_decay, 1.0f, step+1, &multi_gpu_config);
         // zero out the gradients for the next iteration


### PR DESCRIPTION
Refactored the learning rate schedulers code - we'll keep all definitions inside "schedulers.h" as per our offline discussion.

Supported LR schedulers:
* Cosine with warmup
* Cyclic triangular (https://arxiv.org/abs/1506.01186)
* Constant
* Linear with warmup