### PR TITLE
Bug fixes and warning fixes for test_dataloader.c

### DIFF
--- a/dev/test/test_dataloader.c
+++ b/dev/test/test_dataloader.c
@@ -181,13 +181,8 @@ void test_shuffled(void) {
         checkEquals(num_seen_inputs + start + tokens_fit, num_tokens - tokens_fit, 0);
         // verify the target counts. same thing but offset by 1
         checkEquals(num_seen_targets + start + 1, tokens_fit, num_epochs);
-        if (s == (num_shards - 1)) {
-            // last shard check should have one less target token
-            checkEquals(num_seen_targets + start + 1 + tokens_fit, num_tokens - tokens_fit - 1, 0);
-        }
-        else {
-            checkEquals(num_seen_targets + start + 1 + tokens_fit, num_tokens - tokens_fit, 0);
-        }
+        checkEquals(num_seen_targets + start + 1 + tokens_fit,
+            (s == (num_shards - 1)) ? num_tokens - tokens_fit - 1 : num_tokens - tokens_fit,0);
     }
 
     dataloader_free(&loader);
@@ -258,13 +253,8 @@ void test_multiprocess_shuffled(void) {
         checkEquals(num_seen_inputs + start + tokens_fit, num_tokens - tokens_fit, 0);
         // verify the target counts. same thing but offset by 1
         checkEquals(num_seen_targets + start + 1, tokens_fit, num_epochs);
-        if (s == (num_shards - 1)) {
-            // last shard should have one less target token
-            checkEquals(num_seen_targets + start + 1 + tokens_fit, num_tokens - tokens_fit - 1, 0);
-        }
-        else {
-            checkEquals(num_seen_targets + start + 1 + tokens_fit, num_tokens - tokens_fit, 0);
-        }
+        checkEquals(num_seen_targets + start + 1 + tokens_fit,
+            (s == (num_shards - 1)) ? num_tokens - tokens_fit - 1 : num_tokens - tokens_fit,0);
     }
 
     // cleanup

--- a/dev/unistd.h
+++ b/dev/unistd.h
@@ -26,7 +26,7 @@ static inline int clock_gettime(int ignore_variable, struct timespec* tv)
 
 
 #include <stdlib.h> // for malloc and free
-#include <string.h> // for malloc and free
+#include <string.h>
 #include <direct.h> // for _mkdir and _stat
 #define mkdir(path, mode) _mkdir(path) /* sketchy way to get mkdir to work on windows */
 #define stat _stat

--- a/dev/unistd.h
+++ b/dev/unistd.h
@@ -7,8 +7,11 @@
 
 #include <stdio.h>
 #include <math.h>
-//#define gen_max_length 64 // compile as C++ to skip this VLA issue
 #include <time.h>
+#include <stdlib.h> // for malloc and free
+#include <string.h>
+#include <direct.h> // for _mkdir and _stat
+#include <io.h> // needed for _access below and _findfirst, _findnext, _findclose
 
 #define CLOCK_MONOTONIC 0
 static inline int clock_gettime(int ignore_variable, struct timespec* tv)
@@ -17,17 +20,12 @@ static inline int clock_gettime(int ignore_variable, struct timespec* tv)
 }
 
 #define OMP /* turn it on */
-#include <io.h> /* needed for access below */
 #define F_OK 0
 #define access _access
 
 #define TURN_OFF_FP_FAST __pragma(float_control( precise, on, push )) // Save current setting and turn on /fp:precise
 #define TURN_ON_FP_FAST  __pragma(float_control(pop)) // Restore file's default settings
 
-
-#include <stdlib.h> // for malloc and free
-#include <string.h>
-#include <direct.h> // for _mkdir and _stat
 #define mkdir(path, mode) _mkdir(path) /* sketchy way to get mkdir to work on windows */
 #define stat _stat
 

--- a/dev/unistd.h
+++ b/dev/unistd.h
@@ -24,7 +24,10 @@ static inline int clock_gettime(int ignore_variable, struct timespec* tv)
 #define TURN_OFF_FP_FAST __pragma(float_control( precise, on, push )) // Save current setting and turn on /fp:precise
 #define TURN_ON_FP_FAST  __pragma(float_control(pop)) // Restore file's default settings
 
-#include <direct.h> /* for _mkdir and _stat */
+
+#include <stdlib.h> // for malloc and free
+#include <string.h> // for malloc and free
+#include <direct.h> // for _mkdir and _stat
 #define mkdir(path, mode) _mkdir(path) /* sketchy way to get mkdir to work on windows */
 #define stat _stat
 
@@ -59,7 +62,7 @@ static inline int glob(const char* pattern, int ignored_flags, int (*ignored_err
 
     replace_forward_slashes (pattern_copy); // Replace forward slashes with backslashes
 
-    if (strchr(pattern_copy, '\\') != NULL) {
+    if (strchr(pattern_copy, '\\') != (void*) NULL) {
         strncpy_s(directory_path, sizeof(directory_path) - 1, pattern_copy, strrchr(pattern_copy, '\\') - pattern_copy + 1);
         directory_path[strrchr(pattern_copy, '\\') - pattern_copy + 1] = '\0';
     }


### PR DESCRIPTION
- test_dataloader.c - In moving this over to CI, ran into a couple of issues accessing past the calloc'ed buffers.
- test_dataloader.c - added some const values to quiet warnings
- test_dataloader.c - added unistd.h for windows
- unistd.h - small cleanup - remove warnings for windows

CI passes.

@karpathy @ngc92  - can you please check the changes in test_shuffled and test_multiprocess_shuffled. We were accessing one token past the end of the buffer. Thank you.

Revised with comments below.
