### PR TITLE
Relax grad tensor thresholds in tests

### DIFF
--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
             // Also, different GPUs may use different matrix multiplication algorithms, so the
             // actual errors can be hardware specific.
 
-            float grad_thresholds[NUM_PARAMETER_TENSORS] = {5e-1f, 4e-3f, 1e-1f, 3e-2f, 1.5e-2f, 3e-2f, 5e-2f, 5e-2f, 5e-2f, 1.5e-2f, 5e-4f, 8e-3f, 1e-3f, 2.5e-3f, 1e-1f, 2e-2f};
+            float grad_thresholds[NUM_PARAMETER_TENSORS] = {5e-1f, 4e-3f, 1e-1f, 3.5e-2f, 2e-2f, 3e-2f, 5e-2f, 5e-2f, 5e-2f, 1.5e-2f, 5e-4f, 8e-3f, 1.5e-3f, 2.5e-3f, 1e-1f, 2e-2f};
             #if defined(ENABLE_FP32)
             for (int i = 0; i < NUM_PARAMETER_TENSORS; i++) {
                 grad_thresholds[i] = 1e-6f;  // we can be much more precise in FP32


### PR DESCRIPTION
Our CI is using A4000 GPUs that didn't caught some of the tight grad tensor thresholds I've set in https://github.com/karpathy/llm.c/pull/614 

Relaxing a few of these reported by @rosslwheeler

On a side note: @karpathy would be cool to understand exactly how many GPUs we've got as CI runners, and potentially ask if we can trade a few of these for some different GPUs. :) (one can but hope)