### PR TITLE
Add explicit HuggingFace cache dir

### DIFF
--- a/dev/data/fineweb.py
+++ b/dev/data/fineweb.py
@@ -44,10 +44,13 @@ elif args.version == "100B":
 
 # create the cache the local directory if it doesn't exist yet
 DATA_CACHE_DIR = os.path.join(os.path.dirname(__file__), local_dir)
+# change the cache directory to a custom location if needed
+HUGGINGFACE_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache/huggingface/datasets")
 os.makedirs(DATA_CACHE_DIR, exist_ok=True)
+os.makedirs(HUGGINGFACE_CACHE_DIR, exist_ok=True)
 
 # download the dataset
-fw = load_dataset("HuggingFaceFW/fineweb", name=remote_name, split="train")
+fw = load_dataset("HuggingFaceFW/fineweb", name=remote_name, split="train", cache_dir=HUGGINGFACE_CACHE_DIR)
 
 # init the tokenizer
 enc = tiktoken.get_encoding("gpt2")


### PR DESCRIPTION
Some of these datasets can be fairly large and I don't like the fact it's hard to figure out where HuggingFace is storing all of it.

I've set it to the default location in the code, but at least it's now explicit.

e.g. I have 2 partitions and HF ends up saving on the one that has only few GBs as opposed to few TBs.