### PR TITLE
MPI/TCP/FS for NCCL-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,14 +207,14 @@ else
   endif
 endif
 
-ifeq ($(USE_MPI), 1)
+ifeq ($(NO_USE_MPI), 1)
+  $(info → MPI is manually disabled)
+else
   $(info → MPI is manually enabled)
   NVCC_INCLUDES += -I/usr/lib/x86_64-linux-gnu/openmpi/include
   NVCC_LDFLAGS += -L/usr/lib/x86_64-linux-gnu/openmpi/lib/
   NVCC_FLAGS += -DUSE_MPI
   NVCC_LDLIBS += -lmpi
-else
-  $(info → MPI is manually disabled)
 endif
 
 # Precision settings, default to bf16 but ability to override

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ else
   LDFLAGS :=
   LDLIBS :=
   INCLUDES :=
-  NVCC_FLAGS += -I"dev" -lWs2_32
+  NVCC_FLAGS += -I"dev"
   ifeq ($(WIN_CI_BUILD),1)
     $(info Windows CI build)
     OUTPUT_FILE = /link /OUT:$@

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,6 @@ else
     else ifeq ($(shell dpkg -l | grep -q nccl && echo "exists"), exists)
       $(info ✓ NCCL found, OK to train with multiple GPUs)
       NVCC_LDLIBS += -lnccl
-      NVCC_FLAGS += -DMULTI_GPU
     else
       $(info ✗ NCCL is not found, disabling multi-GPU support)
       $(info ---> On Linux you can try install NCCL with `sudo apt install libnccl2 libnccl-dev`)
@@ -209,12 +208,15 @@ endif
 
 ifeq ($(NO_USE_MPI), 1)
   $(info → MPI is manually disabled)
-else
+else ifeq ($(shell [ -d /usr/lib/x86_64-linux-gnu/openmpi/lib/ ] && [ -d /usr/lib/x86_64-linux-gnu/openmpi/include/ ] && echo "exists"), exists)
   $(info ✓ MPI enabled)
   NVCC_INCLUDES += -I/usr/lib/x86_64-linux-gnu/openmpi/include
   NVCC_LDFLAGS += -L/usr/lib/x86_64-linux-gnu/openmpi/lib/
-  NVCC_FLAGS += -DUSE_MPI
   NVCC_LDLIBS += -lmpi
+  NVCC_FLAGS += -DUSE_MPI
+  NVCC_FLAGS += -DMULTI_GPU
+else
+  $(info ✗ MPI not found)
 endif
 
 # Precision settings, default to bf16 but ability to override

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ else
   LDFLAGS :=
   LDLIBS :=
   INCLUDES :=
-  NVCC_FLAGS += -I"dev"
+  NVCC_FLAGS += -I"dev" -lWs2_32
   ifeq ($(WIN_CI_BUILD),1)
     $(info Windows CI build)
     OUTPUT_FILE = /link /OUT:$@

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ endif
 ifeq ($(NO_USE_MPI), 1)
   $(info → MPI is manually disabled)
 else
-  $(info → MPI is manually enabled)
+  $(info ✓ MPI enabled)
   NVCC_INCLUDES += -I/usr/lib/x86_64-linux-gnu/openmpi/include
   NVCC_LDFLAGS += -L/usr/lib/x86_64-linux-gnu/openmpi/lib/
   NVCC_FLAGS += -DUSE_MPI

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ sudo apt-get -y install libcudnn9-dev-cuda-12
 
 On top of this you need the [cuDNN frontend](https://github.com/NVIDIA/cudnn-frontend/tree/main), but this is just header files. Simply clone the repo to your disk. The Makefile currently looks for it in either your home directory or the current directory. If you have put it elsewhere, add `CUDNN_FRONTEND_PATH=/path/to/your/cudnn-frontend/include` to the `make` command-line.
 
-**multi-GPU training using MPI and NCCL**. Make sure you install MPI and NCCL, e.g. on Linux:
+## multi-GPU training
+
+Make sure you install MPI and NCCL, e.g. on Linux:
 
 ```bash
 sudo apt install openmpi-bin openmpi-doc libopenmpi-dev
@@ -148,6 +150,23 @@ and then:
 make train_gpt2cu
 mpirun -np <number of GPUs> ./train_gpt2cu
 ```
+
+or simply run one of our scripts under `./scripts/`.
+
+## multi-node training
+
+Make sure you've installed `NCCL` following instructions from [multi-GPU](#multi-gpu-training) section.
+
+There are 3 ways we currently support that allow you to run multi-node training:
+1) Use OpenMPI to exchange nccl id and initialize NCCL. See e.g. `./scripts/multi_node/run_gpt2_124M_mpi.sh` script for details.
+2) Use shared file system to init NCCL. See `./scripts/multi_node/run_gpt2_124M_fs.sbatch` script for details.
+3) Use TCP sockets to init NCCL. See `./scripts/multi_node/run_gpt2_124M_tcp.sbatch` script for details.
+
+Note:
+* If you're running in a slurm environment and your slurm doesn't support PMIx (which we assume will be a common situation given that `slurm-wlm` dropped PMIx support) you will have to use FS (2) or TCP (3) approach. To test whether your slurm supports PMIx run: `srun --mpi=list` and see whether you get `pmix` in the output.
+* If you don't have slurm set up, you can kick off a multi-node run using `mpirun` - MPI (1).
+
+None of these 3 methods is superior, we just offer you options so that you can run in your specific environment.
 
 ## experiments / sweeps
 

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -14,10 +14,9 @@ Utilities for ZeRO sharding
 
 #ifdef MULTI_GPU
 #include <nccl.h>
-#endif
-
 #ifdef USE_MPI
 #include <mpi.h>
+#endif
 #endif
 
 // ----------------------------------------------------------------------------

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -16,6 +16,10 @@ Utilities for ZeRO sharding
 #include <nccl.h>
 #endif
 
+#ifdef USE_MPI
+#include <mpi.h>
+#endif
+
 // ----------------------------------------------------------------------------
 // Multi-GPU related
 #ifdef MULTI_GPU
@@ -35,6 +39,19 @@ void nccl_check(ncclResult_t status, const char *file, int line) {
     }
 }
 #define ncclCheck(err) (nccl_check(err, __FILE__, __LINE__))
+
+#ifdef USE_MPI
+void mpi_check(int status, const char *file, int line) {
+    if (status != MPI_SUCCESS) {
+        char mpi_error[4096];
+        int mpi_error_len = 0;
+        assert(MPI_Error_string(status, &mpi_error[0], &mpi_error_len) == MPI_SUCCESS);
+        printf("[MPI ERROR] at file %s:%d:\n%.*s\n", file, line, mpi_error_len, mpi_error);
+        exit(EXIT_FAILURE);
+    }
+}
+#define mpiCheck(err) (mpi_check(err, __FILE__, __LINE__))
+#endif
 
 #endif // MULTI_GPU
 
@@ -70,23 +87,15 @@ void send_nccl_id_to_clients(ncclUniqueId *nccl_id, int client_sockets[], int nu
         close(client_sockets[i]);
     }
 }
-#endif
 
-MultiGpuConfig multi_gpu_config_init(int num_processes, int process_rank) {
-#ifdef MULTI_GPU
-    MultiGpuConfig result;
-    result.process_rank = process_rank;
-    result.num_processes = num_processes;
-    result.local_device_idx = process_rank % 8;
-    cudaCheck(cudaSetDevice(result.local_device_idx));
+ncclUniqueId get_nccl_id_via_tcp(MultiGpuConfig* result, const char* server_ip) {
     ncclUniqueId nccl_id;
-
+    // hardcode an arbitrary port number between 1024 and 49151 (registered ports)
     int SERVER_PORT = 12345;
-    const char* SERVER_IP = "10.0.1.220";
-    if (result.process_rank == 0) {
+    if (result->process_rank == 0) {
         ncclCheck(ncclGetUniqueId(&nccl_id));
 
-        int MAX_CLIENTS = num_processes - 1;
+        int MAX_CLIENTS = result->num_processes - 1;
         int client_sockets[MAX_CLIENTS];
         int num_clients = 0;
         int server_socket, new_socket;
@@ -110,7 +119,7 @@ MultiGpuConfig multi_gpu_config_init(int num_processes, int process_rank) {
         }
 
         address.sin_family = AF_INET;  // IPv4
-        address.sin_addr.s_addr = inet_addr(SERVER_IP); // alternatively use INADDR_ANY to bind to all interfaces, currently we only allow ethernet
+        address.sin_addr.s_addr = inet_addr(server_ip); // alternatively use INADDR_ANY to bind to all interfaces, currently we only allow ethernet
         address.sin_port = htons(SERVER_PORT);
 
         // Bind the socket to the address and port
@@ -155,14 +164,14 @@ MultiGpuConfig multi_gpu_config_init(int num_processes, int process_rank) {
         // Set the server address and port
         serv_addr.sin_family = AF_INET;
         serv_addr.sin_port = htons(SERVER_PORT);
-        if (inet_pton(AF_INET, SERVER_IP, &serv_addr.sin_addr) <= 0) {
+        if (inet_pton(AF_INET, server_ip, &serv_addr.sin_addr) <= 0) {
             printf("Invalid address or address not supported");
             exit(EXIT_FAILURE);
         }
 
         // Try to connect to the server - retry if connection fails
         while (connect(client_socket, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-            printf("%d Connection failed, retrying in %d seconds\n", process_rank, time_to_sleep);
+            printf("%d Connection failed, retrying in %d seconds\n", result->process_rank, time_to_sleep);
             if (--num_attempts == 0) {
                 printf("Failed to connect to the server\n");
                 exit(EXIT_FAILURE);
@@ -178,6 +187,112 @@ MultiGpuConfig multi_gpu_config_init(int num_processes, int process_rank) {
         printf("Received NCCL ID\n");
         close(client_socket);
     }
+
+    return nccl_id;
+}
+
+ncclUniqueId get_nccl_id_via_fs(MultiGpuConfig* result, char* fs_path) {
+    // Works assuming that the filesystem is shared among all processes
+    ncclUniqueId nccl_id;
+    FILE* idFile;
+    static char filename[1024];
+    snprintf(filename, sizeof(filename), "%s/ncclUniqueId.sync", fs_path);
+
+    if (result->process_rank == 0) {
+        ncclCheck(ncclGetUniqueId(&nccl_id));
+        idFile = fopen(filename, "wb");
+        assert(idFile != NULL);
+        fwrite(&nccl_id, sizeof(nccl_id), 1, idFile);
+        fclose(idFile);
+    } else {
+        // Other ranks wait until the file is available and read the unique ID
+        do {
+            usleep(1000000);  // 1 second
+            idFile = fopen(filename, "rb");
+            if (idFile != NULL) break;
+        } while (idFile == NULL);
+        freadCheck(&nccl_id, sizeof(nccl_id), 1, idFile);
+        fclose(idFile);
+    }
+
+    return nccl_id;
+}
+
+#ifdef USE_MPI
+// Determine which GPU this process should use.
+// Processes on the same machines use different GPU indicies. Processes on other machines don't.
+// Copied from NCCL examples: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html#example-2-one-device-per-process-or-thread
+int multi_gpu_get_local_device_idx(int process_rank, int num_processes) {
+    char hostname[1024];
+    hostname[1023] = '\0';
+    // All processes on the same machine will share the same hostname.
+    gethostname(hostname, 1023);
+    for (int i=0; i < 1024; i++) {
+        if (hostname[i] == '.') {
+            hostname[i] = '\0';
+            break;
+        }
+    }
+    uint64_t hostname_hash = 5381u;
+    for (int c = 0; hostname[c] != '\0'; c++){ hostname_hash = ((hostname_hash << 5u) + hostname_hash) ^ hostname[c]; }
+
+    // Distribute all hostname hashes to all processes.
+    uint64_t* all_hostsname_hashes = (uint64_t*)malloc(num_processes * sizeof(uint64_t));
+    all_hostsname_hashes[process_rank] = hostname_hash;
+    mpiCheck(MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, all_hostsname_hashes, sizeof(uint64_t), MPI_BYTE, MPI_COMM_WORLD));
+
+    // Identify which GPU we need to use.
+    int local_device_idx = 0;
+    for (int current_process = 0; current_process < num_processes; ++current_process) {
+        if (current_process == process_rank) {
+        // Found my gpu, local_device_idx now has my target GPU index.
+        break;
+        }
+        if (all_hostsname_hashes[current_process] == all_hostsname_hashes[process_rank]) {
+        // This process ID runs on the same machine, but it's not me, skip this GPU
+        local_device_idx++;
+        }
+    }
+
+    free(all_hostsname_hashes);
+    return local_device_idx;
+}
+#endif
+
+#endif
+
+MultiGpuConfig multi_gpu_config_init(int num_processes, int process_rank, char* server_ip, char* fs_path, char* init_method) {
+#ifdef MULTI_GPU
+    MultiGpuConfig result;
+    ncclUniqueId nccl_id;
+    if (strcmp(init_method, "mpi") != 0) {
+        result.process_rank = process_rank;
+        result.num_processes = num_processes;
+        result.local_device_idx = process_rank % 8;
+        if (strcmp(init_method, "tcp") == 0) {
+            nccl_id = get_nccl_id_via_tcp(&result, server_ip);
+        } else if (strcmp(init_method, "fs") == 0) {
+            nccl_id = get_nccl_id_via_fs(&result, fs_path);
+        } else {
+            printf("Invalid init method\n");
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        #ifdef USE_MPI
+        mpiCheck(MPI_Init(NULL, NULL));
+        mpiCheck(MPI_Comm_rank(MPI_COMM_WORLD, &result.process_rank));
+        mpiCheck(MPI_Comm_size(MPI_COMM_WORLD, &result.num_processes));
+        result.local_device_idx = multi_gpu_get_local_device_idx(result.process_rank, result.num_processes);
+        if (result.process_rank == 0) {
+            ncclCheck(ncclGetUniqueId(&nccl_id));
+        }
+        mpiCheck(MPI_Bcast(&nccl_id, sizeof(nccl_id), MPI_BYTE, 0, MPI_COMM_WORLD));
+        #else
+        printf("MPI support is disabled. Please enable MPI support to use MPI init method.\n");
+        exit(EXIT_FAILURE);
+        #endif
+    }
+    cudaCheck(cudaSetDevice(result.local_device_idx));
     ncclCheck(ncclCommInitRank(&result.nccl_comm, result.num_processes, nccl_id, result.process_rank));
     cudaCheck(cudaStreamCreate(&result.nccl_stream));
     // event without timing for maximum performance
@@ -203,6 +318,9 @@ void multi_gpu_config_free(MultiGpuConfig* multi_gpu_config) {
     cudaCheck(cudaStreamDestroy(multi_gpu_config->nccl_stream));
     cudaCheck(cudaEventDestroy(multi_gpu_config->compute_nccl_sync));
     cudaCheck(cudaFree(multi_gpu_config->unified_buffer));
+    #ifdef USE_MPI
+    mpiCheck(MPI_Finalize());
+    #endif
 #endif
 }
 

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -157,8 +157,7 @@ void multi_gpu_config_free(MultiGpuConfig* multi_gpu_config) {
 void multi_gpu_barrier(const MultiGpuConfig* multi_gpu_config) {
 #ifdef MULTI_GPU
     if (multi_gpu_config->num_processes > 1) {
-        float* unified_buffer = multi_gpu_config->unified_buffer;
-        ncclCheck(ncclAllReduce(unified_buffer, unified_buffer, sizeof(float), ncclFloat, ncclSum, multi_gpu_config->nccl_comm, multi_gpu_config->nccl_stream));
+        ncclCheck(ncclAllReduce(multi_gpu_config->unified_buffer, multi_gpu_config->unified_buffer, sizeof(float), ncclFloat, ncclSum, multi_gpu_config->nccl_comm, multi_gpu_config->nccl_stream));
     }
     cudaCheck(cudaDeviceSynchronize());
 #endif

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -150,6 +150,7 @@ void multi_gpu_config_free(MultiGpuConfig* multi_gpu_config) {
     ncclCheck(ncclCommDestroy(multi_gpu_config->nccl_comm));
     cudaCheck(cudaStreamDestroy(multi_gpu_config->nccl_stream));
     cudaCheck(cudaEventDestroy(multi_gpu_config->compute_nccl_sync));
+    cudaCheck(cudaFree(multi_gpu_config->unified_buffer));
     mpiCheck(MPI_Finalize());
 #endif
 }

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -7,7 +7,6 @@ Utilities for ZeRO sharding
 
 #ifdef _WIN32
 #include <winsock2.h>
-#include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -28,7 +28,13 @@ the profile.ncu-rep from a cloud box to local to pretty view.
 #include "train_gpt2.cu"
 
 int main(int argc, char *argv[]) {
-    multi_gpu_config = multi_gpu_config_init(&argc, &argv);
+    char nccl_init_method[256] = "mpi";  // "tcp" or "fs" or "mpi"
+    int num_processes = -1;  // doesn't matter when using MPI
+    int process_rank = -1;  // doesn't matter when using MPI
+    int gpus_per_node = -1;  // doesn't matter when using MPI
+    char server_ip[256] = "";  // doesn't matter when using MPI
+    char fs_path[256] = "";  // doesn't matter when using MPI
+    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, nccl_init_method, server_ip, fs_path);
     common_start(true, true);
 
     // build the GPT-2 model from a checkpoint

--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     int gpus_per_node = -1;  // doesn't matter when using MPI
     char server_ip[256] = "";  // doesn't matter when using MPI
     char fs_path[256] = "";  // doesn't matter when using MPI
-    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, nccl_init_method, server_ip, fs_path);
+    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, server_ip, fs_path, nccl_init_method);
     common_start(true, true);
 
     // build the GPT-2 model from a checkpoint

--- a/scripts/multi_node/run_gpt2_124M_fs.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_fs.sbatch
@@ -77,6 +77,7 @@ srun -l -u bash -c "
     -e d12 \
     -pn \$SLURM_NTASKS \
     -pr \$SLURM_PROCID \
+    -pg \$SLURM_NTASKS_PER_NODE \
     -pf $sync_fs_path \
     -pi "fs" \
 "

--- a/scripts/multi_node/run_gpt2_124M_fs.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_fs.sbatch
@@ -1,0 +1,84 @@
+#!/bin/bash
+#SBATCH --job-name=llmc-multinode                                     # job name
+#SBATCH --output=/home/ubuntu/llm.c/scripts/multi_node/%x_%j_%t.log   # output file
+#SBATCH --error=/home/ubuntu/llm.c/scripts/multi_node/%x_%j_%t.err    # error file
+#SBATCH --partition=llmc                                              # Specify the GPU partition
+#SBATCH --ntasks=16                                                   # total number of processes to launch on all nodes
+#SBATCH --nodes=2                                                     # total number of nodes
+#SBATCH --ntasks-per-node=8                                           # assuming each node has 8 gpus
+#SBATCH --gres=gpu:8                                                  # request 8 gpus from each node
+
+# NOTE: change the above slurm arguments to match your system!
+# Run with `sbatch <path_to_this_script.sh>`
+
+make train_gpt2cu USE_CUDNN=1 USE_MPI=0
+
+# NOTE: change the following to match your system
+binary_path="/home/ubuntu/llm.c/train_gpt2cu"
+out_dir="/ephemeral/data/fineweb/log_gpt2_124M_multi"
+train_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_train_*.bin'
+val_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_val_*.bin'
+sync_fs_path=$out_dir  # needs to be a shared filesystem path that all nodes can access
+
+# In case the file system is shared this is a no-op.
+# Otherwise, we need to copy the binary to all nodes.
+current_user=$USER
+hosts=$(scontrol show hostnames $SLURM_JOB_NODELIST)  # get the hostnames of the allocated nodes
+current_host=$(hostname)
+for host in $hosts; do
+    if [ $host == $current_host ]; then
+        continue
+    fi
+    echo "copying $binary_path to $current_user@$host"
+    scp -r $binary_path $current_user@$host:$binary_path
+done
+
+# Use this for NCCL debugging if you run into issues
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=ALL
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+# Optimization flags
+export NCCL_NET_GDR_LEVEL=2  # use GPUDirect RDMA - allows for direct memory access between GPUs across different nodes by bypassing the CPU
+export NCCL_IB_DISABLE=0  # use InfiniBand if available
+
+# NOTE: change the following environment variables to match your system - or comment them out if you don't need them
+export NCCL_SOCKET_IFNAME=ens17
+export OMPI_MCA_btl_tcp_if_include=ens17
+export NCCL_P2P_LEVEL=PXB
+
+if [ -z "$SLURM_JOB_ID" ]; then
+    echo "Make sure you're running in a SLURM environment. Did you forget to run with sbatch? Aborting."
+    exit 1
+else
+    DATESTRING=`date "+%Y-%m-%dT%H:%M:%S"`
+    echo "Running in a SLURM environment (job ID: $SLURM_JOB_ID, user: $current_user)"
+    echo "Running on hosts: $(echo $(scontrol show hostname))"
+    echo "$DATESTRING"
+fi
+
+srun -l -u bash -c "
+    $binary_path \
+    -i '$train_data_path' \
+    -j '$val_data_path' \
+    -o $out_dir \
+    -v 250 -s 20000 -g 144 \
+    -h 1 \
+    -b 64 -t 1024 \
+    -d 2097152 \
+    -r 0 \
+    -z 1 \
+    -c 0.1 \
+    -l 0.0006 \
+    -q 0.0 \
+    -u 700 \
+    -n 5000 \
+    -y 1 \
+    -e d12 \
+    -pn \$SLURM_NTASKS \
+    -pr \$SLURM_PROCID \
+    -pf $sync_fs_path \
+    -pi "fs" \
+"
+
+echo "$DATESTRING"

--- a/scripts/multi_node/run_gpt2_124M_fs.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_fs.sbatch
@@ -11,7 +11,7 @@
 # NOTE: change the above slurm arguments to match your system!
 # Run with `sbatch <path_to_this_script.sh>`
 
-make train_gpt2cu USE_CUDNN=1 USE_MPI=0
+make train_gpt2cu USE_CUDNN=1 NO_USE_MPI=1
 
 # NOTE: change the following to match your system
 binary_path="/home/ubuntu/llm.c/train_gpt2cu"

--- a/scripts/multi_node/run_gpt2_124M_mpi.sh
+++ b/scripts/multi_node/run_gpt2_124M_mpi.sh
@@ -1,5 +1,5 @@
 
-make train_gpt2cu USE_CUDNN=1 USE_MPI=1
+make train_gpt2cu USE_CUDNN=1
 
 # NOTE: change the following to match your system
 binary_path="/home/ubuntu/llm.c/train_gpt2cu"

--- a/scripts/multi_node/run_gpt2_124M_mpi.sh
+++ b/scripts/multi_node/run_gpt2_124M_mpi.sh
@@ -1,0 +1,49 @@
+
+make train_gpt2cu USE_CUDNN=1 USE_MPI=1
+
+# NOTE: change the following to match your system
+binary_path="/home/ubuntu/llm.c/train_gpt2cu"
+out_dir="/ephemeral/data/fineweb/log_gpt2_124M_multi"
+train_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_train_*.bin'
+val_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_val_*.bin'
+# You can find these names either in `/etc/hosts`` file or in the terminal (user@host:~$).
+host1="h100-node-1-0"  # master and worker node
+host2="h100-node-1-1"  # worker node
+
+# In case the file system is shared this is a no-op.
+# Otherwise, we need to copy the binary to all nodes.
+scp -r $binary_path $USER@$host2:$binary_path
+
+# Use this for NCCL debugging if you run into issues
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=ALL
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+# Optimization flags
+export NCCL_NET_GDR_LEVEL=2  # use GPUDirect RDMA - allows for direct memory access between GPUs across different nodes by bypassing the CPU
+export NCCL_IB_DISABLE=0  # use InfiniBand if available
+
+# NOTE: change the following environment variables to match your system - or comment them out if you don't need them
+export NCCL_SOCKET_IFNAME=ens17
+export OMPI_MCA_btl_tcp_if_include=ens17
+export NCCL_P2P_LEVEL=PXB
+
+mpirun -np 16 --host $host1:8,$host2:8 \
+    $binary_path \
+    -i "$train_data_path" \
+    -j "$val_data_path" \
+    -o $out_dir \
+    -v 250 -s 20000 -g 144 \
+    -h 1 \
+    -b 64 -t 1024 \
+    -d 2097152 \
+    -r 0 \
+    -z 1 \
+    -c 0.1 \
+    -l 0.0006 \
+    -q 0.1 \
+    -u 700 \
+    -n 1000 \
+    -y 0 \
+    -e d12 \
+    -pi "mpi" \

--- a/scripts/multi_node/run_gpt2_124M_tcp.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_tcp.sbatch
@@ -78,6 +78,7 @@ srun -l -u bash -c "
     -e d12 \
     -pn \$SLURM_NTASKS \
     -pr \$SLURM_PROCID \
+    -pg \$SLURM_NTASKS_PER_NODE \
     -ps $server_ip \
     -pi "tcp" \
 "

--- a/scripts/multi_node/run_gpt2_124M_tcp.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_tcp.sbatch
@@ -11,7 +11,7 @@
 # NOTE: change the above slurm arguments to match your system!
 # Run with `sbatch <path_to_this_script.sh>`
 
-make train_gpt2cu USE_CUDNN=1 USE_MPI=0
+make train_gpt2cu USE_CUDNN=1 NO_USE_MPI=1
 
 # NOTE: change the following to match your system
 binary_path="/home/ubuntu/llm.c/train_gpt2cu"

--- a/scripts/multi_node/run_gpt2_124M_tcp.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_tcp.sbatch
@@ -1,0 +1,85 @@
+#!/bin/bash
+#SBATCH --job-name=llmc-multinode                                     # job name
+#SBATCH --output=/home/ubuntu/llm.c/scripts/multi_node/%x_%j_%t.log   # output file
+#SBATCH --error=/home/ubuntu/llm.c/scripts/multi_node/%x_%j_%t.err    # error file
+#SBATCH --partition=llmc                                              # Specify the GPU partition
+#SBATCH --ntasks=16                                                   # total number of processes to launch on all nodes
+#SBATCH --nodes=2                                                     # total number of nodes
+#SBATCH --ntasks-per-node=8                                           # assuming each node has 8 gpus
+#SBATCH --gres=gpu:8                                                  # request 8 gpus from each node
+
+# NOTE: change the above slurm arguments to match your system!
+# Run with `sbatch <path_to_this_script.sh>`
+
+make train_gpt2cu USE_CUDNN=1 USE_MPI=0
+
+# NOTE: change the following to match your system
+binary_path="/home/ubuntu/llm.c/train_gpt2cu"
+out_dir="/ephemeral/data/fineweb/log_gpt2_124M_multi"
+train_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_train_*.bin'
+val_data_path='/ephemeral/data/fineweb/bin_10B/fineweb_val_*.bin'
+# NOTE: change the server_ip to the IP address of the machine that is running process zero
+server_ip="10.0.1.220"
+
+# In case the file system is shared this is a no-op.
+# Otherwise, we need to copy the binary to all nodes.
+current_user=$USER
+hosts=$(scontrol show hostnames $SLURM_JOB_NODELIST)  # get the hostnames of the allocated nodes
+current_host=$(hostname)
+for host in $hosts; do
+    if [ $host == $current_host ]; then
+        continue
+    fi
+    echo "copying $binary_path to $current_user@$host"
+    scp -r $binary_path $current_user@$host:$binary_path
+done
+
+# Use this for NCCL debugging if you run into issues
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=ALL
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+# Optimization flags
+export NCCL_NET_GDR_LEVEL=2  # use GPUDirect RDMA - allows for direct memory access between GPUs across different nodes by bypassing the CPU
+export NCCL_IB_DISABLE=0  # use InfiniBand if available
+
+# NOTE: change the following environment variables to match your system - or comment them out if you don't need them
+export NCCL_SOCKET_IFNAME=ens17
+export OMPI_MCA_btl_tcp_if_include=ens17
+export NCCL_P2P_LEVEL=PXB
+
+if [ -z "$SLURM_JOB_ID" ]; then
+    echo "Make sure you're running in a SLURM environment. Did you forget to run with sbatch? Aborting."
+    exit 1
+else
+    DATESTRING=`date "+%Y-%m-%dT%H:%M:%S"`
+    echo "Running in a SLURM environment (job ID: $SLURM_JOB_ID, user: $current_user)"
+    echo "Running on hosts: $(echo $(scontrol show hostname))"
+    echo "$DATESTRING"
+fi
+
+srun -l -u bash -c "
+    $binary_path \
+    -i '$train_data_path' \
+    -j '$val_data_path' \
+    -o $out_dir \
+    -v 250 -s 20000 -g 144 \
+    -h 1 \
+    -b 64 -t 1024 \
+    -d 2097152 \
+    -r 0 \
+    -z 1 \
+    -c 0.1 \
+    -l 0.0006 \
+    -q 0.0 \
+    -u 700 \
+    -n 5000 \
+    -y 1 \
+    -e d12 \
+    -pn \$SLURM_NTASKS \
+    -pr \$SLURM_PROCID \
+    -ps $server_ip \
+    -pi "tcp" \
+"
+
+echo "$DATESTRING"

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -89,7 +89,13 @@ float* float_cpu_malloc_and_point_parameters(FloatParameterTensors* params, size
 }
 
 int main(int argc, char *argv[]) {
-    multi_gpu_config = multi_gpu_config_init(&argc, &argv);
+    char nccl_init_method[256] = "mpi";  // "tcp" or "fs" or "mpi"
+    int num_processes = -1;  // doesn't matter when using MPI
+    int process_rank = -1;  // doesn't matter when using MPI
+    int gpus_per_node = -1;  // doesn't matter when using MPI
+    char server_ip[256] = "";  // doesn't matter when using MPI
+    char fs_path[256] = "";  // doesn't matter when using MPI
+    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, nccl_init_method, server_ip, fs_path);
     common_start(false, true);
 
     // set the right paths

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
     int gpus_per_node = -1;  // doesn't matter when using MPI
     char server_ip[256] = "";  // doesn't matter when using MPI
     char fs_path[256] = "";  // doesn't matter when using MPI
-    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, nccl_init_method, server_ip, fs_path);
+    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, server_ip, fs_path, nccl_init_method);
     common_start(false, true);
 
     // set the right paths

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -2,6 +2,10 @@
 GPT-2 Transformer Neural Net training loop. See README.md for usage.
 */
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1318,6 +1318,12 @@ void error_usage() {
     // memory management
     fprintf(stderr, "  -z <int>    zero_stage, Zero Optimization Stage, 0,1,2,3 (default = 0)\n");
     fprintf(stderr, "  -r <int>    recompute: less memory but less speed. (default = 1), 0|1|2 = none,gelu,gelu+ln\n");
+    // multi-node settings
+    fprintf(stderr, "  -pn <int>    num_processes (default = 1)\n");
+    fprintf(stderr, "  -pr <int>    process_rank (default = 0)\n");
+    fprintf(stderr, "  -pm <string> nccl_init_method: tcp,fs,mpi (default = mpi)\n");
+    fprintf(stderr, "  -ps <string> server_ip - used only when nccl_init_method is tcp (default = -1)\n");
+    fprintf(stderr, "  -pp <string> fs_path - used only when nccl_init_method is fs (default = /tmp)\n");
     exit(EXIT_FAILURE);
 }
 
@@ -1353,7 +1359,7 @@ int main(int argc, char *argv[]) {
     // multi-node settings
     int num_processes = 1;  // this should be set by the slurm environment
     int process_rank = 0;  // this should be set by the slurm environment
-    char nccl_init_method[256] = "tcp";  // "tcp" or "fs" or "mpi"
+    char nccl_init_method[256] = "mpi";  // "tcp" or "fs" or "mpi"
     char server_ip[256] = "-1";  // used if init_method set to "tcp" -> set to your server ip address
     char fs_path[256] = "/tmp";  // used if init_method set to "fs" -> set to a shared filesystem path
     for (int i = 1; i < argc; i+=2) {

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1366,8 +1366,8 @@ int main(int argc, char *argv[]) {
     int process_rank = 0;  // this should be set by the slurm environment
     int gpus_per_node = 8;  // this should be set by the slurm environment
     char nccl_init_method[256] = "mpi";  // "tcp" or "fs" or "mpi"
-    char server_ip[256] = "-1";  // used if init_method set to "tcp" -> set to your server ip address
-    char fs_path[256] = "/tmp";  // used if init_method set to "fs" -> set to a shared filesystem path
+    char server_ip[256] = "";  // used if init_method set to "tcp" -> set to your server ip address
+    char fs_path[256] = "";  // used if init_method set to "fs" -> set to a shared filesystem path
     for (int i = 1; i < argc; i+=2) {
         if (i + 1 >= argc) { error_usage(); } // must have arg after flag
         if (argv[i][0] != '-') { error_usage(); } // must start with dash

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -899,7 +899,7 @@ float multi_gpu_cpu_float_sum(float value, MultiGpuConfig* multi_gpu_config) {
 
     float* unified_buffer = multi_gpu_config->unified_buffer;
     *unified_buffer = value;
-    ncclCheck(ncclAllReduce(unified_buffer, unified_buffer, sizeof(float), ncclFloat, ncclSum, multi_gpu_config->nccl_comm, main_stream));
+    ncclCheck(ncclAllReduce(unified_buffer, unified_buffer, sizeof(float), ncclFloat, ncclSum, multi_gpu_config->nccl_comm, multi_gpu_config->nccl_stream));
     cudaCheck(cudaDeviceSynchronize());
     return *unified_buffer;
 #else

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1321,6 +1321,7 @@ void error_usage() {
     // multi-node settings
     fprintf(stderr, "  -pn <int>    num_processes (default = 1)\n");
     fprintf(stderr, "  -pr <int>    process_rank (default = 0)\n");
+    fprintf(stderr, "  -pg <int>    gpus_per_node (default = 8)\n");
     fprintf(stderr, "  -pm <string> nccl_init_method: tcp,fs,mpi (default = mpi)\n");
     fprintf(stderr, "  -ps <string> server_ip - used only when nccl_init_method is tcp (default = -1)\n");
     fprintf(stderr, "  -pp <string> fs_path - used only when nccl_init_method is fs (default = /tmp)\n");
@@ -1359,6 +1360,7 @@ int main(int argc, char *argv[]) {
     // multi-node settings
     int num_processes = 1;  // this should be set by the slurm environment
     int process_rank = 0;  // this should be set by the slurm environment
+    int gpus_per_node = 8;  // this should be set by the slurm environment
     char nccl_init_method[256] = "mpi";  // "tcp" or "fs" or "mpi"
     char server_ip[256] = "-1";  // used if init_method set to "tcp" -> set to your server ip address
     char fs_path[256] = "/tmp";  // used if init_method set to "fs" -> set to a shared filesystem path
@@ -1397,9 +1399,10 @@ int main(int argc, char *argv[]) {
         else if (argv[i][1] == 'p' && argv[i][2] == 's') { strcpy(server_ip, argv[i+1]); }
         else if (argv[i][1] == 'p' && argv[i][2] == 'n') { num_processes = atoi(argv[i+1]); }
         else if (argv[i][1] == 'p' && argv[i][2] == 'r') { process_rank = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'p' && argv[i][2] == 'g') { gpus_per_node = atoi(argv[i+1]); }
         else { error_usage(); }
     }
-    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, server_ip, fs_path, nccl_init_method);
+    multi_gpu_config = multi_gpu_config_init(num_processes, process_rank, gpus_per_node, server_ip, fs_path, nccl_init_method);
 
     // should do a bit more error checking here
     assert(warmup_iterations >= 0);


### PR DESCRIPTION
Instead of mixing NCCL & Open MPI during training: let's transition to using only NCCL. To the best of my knowledge there are no downsides here, they're equivalent and speedwise i couldn't observe any difference.

By doing this we scope down our MPI dependence to `multi_gpu_config_init`.

Context: why are we trying to reduce dependence on Open MPI?
`slurm-wlm` package - which is the easiest and thus likely the most frequent way folks setup their slurm clusters - dropped PMIx support which means we can't use slurm in a multi node setup together with Open MPI.

Regarding `multi_gpu_config_init` we have a few options as far as i can tell:
* Keep using MPI (but as mentioned slurm users won't be able to run llm.c in multi-node setup)
* Transition to logic where we synchronize on file system (similar to https://github.com/karpathy/llm.c/pull/426)
* TCP sockets (nodes will have to contain IP address of each other to communicate eitherway so we can use that)

So:
* slurm users can toggle a switch, remove OpenMPI code dependence, and run in multi-node setup
* mpirun users can use llm.c as is and it will just work