### PR TITLE
Optionally specify root location of CUDNN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,13 @@ ifeq ($(USE_CUDNN), 1)
     NVCC_INCLUDES += -I$(CUDNN_FRONTEND_PATH)
     NVCC_LDFLAGS += -lcudnn
     NVCC_FLAGS += -DENABLE_CUDNN
-    NVCC_CUDNN = $(BUILD_DIR)/cudnn_att.o
+    NVCC_CUDNN = $(BUILD_DIR)/cudnn_att.o 
+
+    ifdef CUDNN_PATH
+    	NVCC_INCLUDES += -I$(CUDNN_PATH)/include
+    	NVCC_LDFLAGS += -L$(CUDNN_PATH)/lib -L$(CUDNN_PATH)/lib64
+		endif
+
   else
     ifneq ($(OS), Windows_NT)
       $(info → cuDNN is not supported on MAC OS right now)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ sudo apt-get update
 sudo apt-get -y install libcudnn9-dev-cuda-12
 ```
 
+If the cuDNN package is not installed under a default location, you can explicitly specify the location of cuDNN by setting the `CUDNN_PATH` to the `make` command line. 
+
 On top of this you need the [cuDNN frontend](https://github.com/NVIDIA/cudnn-frontend/tree/main), but this is just header files. Simply clone the repo to your disk. The Makefile currently looks for it in either your home directory or the current directory. If you have put it elsewhere, add `CUDNN_FRONTEND_PATH=/path/to/your/cudnn-frontend/include` to the `make` command-line.
 
 **multi-GPU training using MPI and NCCL**. Make sure you install MPI and NCCL, e.g. on Linux:


### PR DESCRIPTION
Defines the location of CUDNN to the makefile. This is the second part of the original #628 as requested by @rosslwheeler