### PR TITLE
add http status check for download_file

### DIFF
--- a/dev/download_starter_pack.sh
+++ b/dev/download_starter_pack.sh
@@ -37,8 +37,12 @@ download_file() {
     fi
 
     # Download the file
-    curl -s -L -o "$FILE_PATH" "$FILE_URL"
-    echo "Downloaded $FILE_NAME to $FILE_PATH"
+    status=$(curl -s -w "%{http_code}\n" -L -o "$FILE_PATH" "$FILE_URL")
+    if [ "$status" -ne 200 ]; then
+        echo "Error: HTTP status is $status"
+    else
+	echo "Downloaded $FILE_NAME to $FILE_PATH"
+    fi
 }
 
 # Export the function so it's available in subshells


### PR DESCRIPTION
This pr add http status check for download_file and reports error if it fails to download file. 
I met a issue that curl does not report error when it failed to pull model from huggingface through proxy and get http error 503 .
But the output still is that 
`Downloaded gpt2_124M_bf16.bin to /home/bily/llm.c-fork/dev/../gpt2_124M_bf16.bin`
despite that it does not downloads the file successfully.