### PR TITLE
Add missing MULTI_GPU compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ else
       $(info ✗ Multi-GPU on CUDA on Darwin is not supported, skipping NCCL support)
     else ifeq ($(shell dpkg -l | grep -q nccl && echo "exists"), exists)
       $(info ✓ NCCL found, OK to train with multiple GPUs)
+      NVCC_FLAGS += -DMULTI_GPU
       NVCC_LDLIBS += -lnccl
     else
       $(info ✗ NCCL is not found, disabling multi-GPU support)


### PR DESCRIPTION
To run the file sharing NO_USE_MPI build.