### PR TITLE
Improve kernel in layerNorm forward: adapt variance estimation method from kernel 4 for use in kernel 6

### DIFF
--- a/dev/cuda/layernorm_forward.cu
+++ b/dev/cuda/layernorm_forward.cu
@@ -370,26 +370,23 @@ __global__ void layernorm_forward_kernel6(float* __restrict__ out, float* __rest
 
     const float eps = 1e-5f;
     float sum = 0.0f;
+    float sum2 = 0.0f;
     for(int c = threadIdx.x * x128::size; c < C; c += WARP_SIZE * x128::size) {
         const x128 in_data = load128cs(inp + c);
         for(int k = 0; k < x128::size; ++k) {
-            sum += (float)in_data[k];
+            float xi = (float)in_data[k];
+            sum += xi;
+            sum2 += xi * xi;
         }
         s_in[c / x128::size] = in_data;
     }
 
     sum = warpReduceSum(sum);
-    float m = sum / C;
-    float v = 0.f;
-
-    for(int c = threadIdx.x * x128::size; c < C; c += WARP_SIZE * x128::size) {
-        const x128 in_data = s_in[c / x128::size];
-        for(int k = 0; k < x128::size; ++k) {
-            v += ((float)in_data[k] - m) * ((float)in_data[k] - m);
-        }
-    }
-
-    v = warpReduceSum(v) / C;
+    sum2 = warpReduceSum(sum2);
+    sum /= C;
+    sum2 /= C;
+    float m = sum;
+    float v = sum2 - sum * sum;
     float s = rsqrtf(v + eps);
 
     for(int c = threadIdx.x * x128::size; c < C; c += WARP_SIZE * x128::size) {


### PR DESCRIPTION
@gordicaleksa @karpathy Hi, since kernel 4  already used a more clever way to estimate variance, `var(x) = mean(x**2) - mean(x)**2`,

I am wondering if kernel 6, which is used in the main `train_gpt2.cu`, can adapt the same technique?

I conducted tests on the A100 80G (from Modal) with the following results:

**Before the change:**
```
block_size   32 | time 0.0466 ms | bandwidth 1079.39 GB/s
block_size   64 | time 0.0437 ms | bandwidth 1152.29 GB/s
block_size  128 | time 0.0434 ms | bandwidth 1160.60 GB/s
block_size  256 | time 0.0425 ms | bandwidth 1183.23 GB/s
block_size  512 | time 0.0433 ms | bandwidth 1162.06 GB/s
block_size 1024 | time 0.0437 ms | bandwidth 1151.32 GB/s
```
**After the change:**
```
block_size   32 | time 0.0449 ms | bandwidth 1120.00 GB/s
block_size   64 | time 0.0412 ms | bandwidth 1220.50 GB/s
block_size  128 | time 0.0407 ms | bandwidth 1237.67 GB/s
block_size  256 | time 0.0397 ms | bandwidth 1268.84 GB/s
block_size  512 | time 0.0405 ms | bandwidth 1243.80 GB/s
block_size 1024 | time 0.0412 ms | bandwidth 1221.16 GB/s
```
It seems work for every blocksize!