### PR TITLE
Makefile: Respect the NO_MULTI_GPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,6 @@ else ifeq ($(shell [ -d /usr/lib/x86_64-linux-gnu/openmpi/lib/ ] && [ -d /usr/li
   NVCC_LDFLAGS += -L/usr/lib/x86_64-linux-gnu/openmpi/lib/
   NVCC_LDLIBS += -lmpi
   NVCC_FLAGS += -DUSE_MPI
-  NVCC_FLAGS += -DMULTI_GPU
 else
   $(info ✗ MPI not found)
 endif


### PR DESCRIPTION
I am experimenting with cross-compiling the program to an nvidia device and bumped into the need for this change.
During the openMPI check, the MULTI_GPU define slinks in. 