### PR TITLE
Make cuDNN deterministic for Flash Attention backward

### DIFF
--- a/llmc/cudnn_att.cpp
+++ b/llmc/cudnn_att.cpp
@@ -183,6 +183,9 @@ auto lookup_cache_or_build_graph_bwd(int B, int NH, int T, int HS) {
                             .set_uid(Attn_scale_UID)
                             .set_data_type(fe::DataType_t::FLOAT));
     auto sdpa_backward_options = fe::graph::SDPA_backward_attributes().set_name("flash_attention_backward")
+#if CUDNN_FRONTEND_MAJOR_VERSION > 1 || CUDNN_FRONTEND_MINOR_VERSION >= 5
+                            .set_deterministic_algorithm(true) // 1.5+ needs this for determinism
+#endif
                             .set_causal_mask(true)
                             .set_attn_scale(attn_scale);
 


### PR DESCRIPTION
cuDNN Frontend 1.5 released on June 13th added a new setting to make their backward algorithm deterministic which is disabled by default:
- https://github.com/NVIDIA/cudnn-frontend/commit/47d800ccd9449e1bbc255d64d794ae88d99b043d
- https://github.com/NVIDIA/cudnn-frontend/blob/main/docs/operations/Attention.md

Testing on cuDNN Backend 9.2 + cuDNN Frontend 1.4 (where that setting is not available) revealed that cuDNN Backward was *not* deterministic at large batch sizes. As small batch sizes seem to always be deterministic, this would not have been caught by our test_gpt2cu tests.

This is despite NVIDIA documentation implying that it should have been deterministic, as their lists of non-deterministic cases did not include attention backward. There is a remark in the [cuDNN Backward release notes](https://docs.nvidia.com/deeplearning/cudnn/latest/release-notes.html?highlight=deterministic) about non-determinism for attention and RNNs, but it is only for the case where multiple streams call cuBLAS and/or cuDNN which is not the case for us, and setting CUBLAS_WORKSPACE_CONFIG as suggested in those notes did not make the result deterministic.

This PR should be combined with an upgrade to cuDNN Frontend 1.5 (it will compile without it but not fix the issue).