### PR TITLE
Matmul refactor using only cuBLASLt + GELU Fusion

### DIFF
--- a/llmc/cublas_common.h
+++ b/llmc/cublas_common.h
@@ -14,13 +14,10 @@ cuBLAS related utils
 // cuBLAS Precision settings
 
 #if defined(ENABLE_FP32)
-typedef float floatX;
 #define CUBLAS_LOWP CUDA_R_32F
 #elif defined(ENABLE_FP16)
-typedef half floatX;
 #define CUBLAS_LOWP CUDA_R_16F
 #else // default to bfloat16
-typedef __nv_bfloat16 floatX;
 #define CUBLAS_LOWP CUDA_R_16BF
 #endif
 
@@ -32,7 +29,6 @@ const size_t cublaslt_workspace_size = 32 * 1024 * 1024;
 void* cublaslt_workspace = NULL;
 cublasComputeType_t cublas_compute = CUBLAS_COMPUTE_32F;
 cublasLtHandle_t cublaslt_handle;
-cublasHandle_t cublas_handle;
 
 // ----------------------------------------------------------------------------
 // Error checking

--- a/llmc/matmul.cuh
+++ b/llmc/matmul.cuh
@@ -7,6 +7,8 @@ Matrix Multiplication, with help from cuBLASLt
 #include "cuda_common.h"
 #include "cuda_utils.cuh"
 #include "cublas_common.h"
+// GELU forward can be either fused (cublasLt) or non-fused (gelu.h)
+#include "gelu.cuh"
 
 // ----------------------------------------------------------------------------
 // CUDA kernels
@@ -103,82 +105,145 @@ __global__ void reduce_add_sum_kernel(floatX* dst, const float* src, size_t n, s
 // kernel launchers
 
 // https://docs.nvidia.com/cuda/cublas/#cublasltmatmul
-void matmul_forward_cublaslt(floatX* out,
-                     floatX* inp, floatX* weight, floatX* bias,
-                     int B, int T, int C, int OC, cudaStream_t stream) {
+void matmul_cublaslt(floatX* d, const floatX* a, const floatX* b, const floatX* bias,
+                     int m, int n, int k, cudaStream_t stream, bool transA=true, bool transB=false,
+                     int batch_count=0, size_t strideA=0, size_t strideB=0, size_t strideOut=0,
+                     bool accumulate=false, floatX* pre_gelu=NULL, bool backward=false)
+{
     NVTX_RANGE_FN();
-    int has_bias = (bias != NULL);
+    bool has_bias = (bias != NULL);
+    bool has_gelu = (pre_gelu != NULL);
 
-    // check bias alignment
-    if(((uintptr_t)bias % 16) != 0) {
-        printf("Bias pointer is not aligned (cuBLASLt requirement)!\n");
+    // some modes work OK unaligned but it always best to be aligned for performance
+    if(((uintptr_t)a % 16) != 0 || ((uintptr_t)b % 16) != 0 || ((uintptr_t)d % 16) != 0 || ((uintptr_t)bias % 16) != 0) {
+        printf("All cuBLASLt pointers must be aligned!\n");
         exit(EXIT_FAILURE);
     }
 
-    // these need to be in FP16 if and only if alpha/beta are CUBLAS_COMPUTE_16F
-    const float alpha = 1.0f, beta = 0.0f;
+    // create the operation descriptor
+    cublasLtMatmulDesc_t operationDesc;
+    cublasCheck(cublasLtMatmulDescCreate(&operationDesc, cublas_compute, CUDA_R_32F));
 
     int returnedResults = 0;
-    cublasLtMatmulDesc_t operationDesc;
+    cublasLtMatrixLayout_t ALayout;
+    cublasLtMatrixLayout_t BLayout;
+    cublasLtMatrixLayout_t DLayout;
+    cublasLtMatrixLayout_t CLayout;
     cublasLtMatmulPreference_t preference;
-    cublasLtMatrixLayout_t weightLayout;
-    cublasLtMatrixLayout_t inputLayout;
-    cublasLtMatrixLayout_t outputLayout;
-    cublasLtMatrixLayout_t biasLayout;
     cublasLtMatmulHeuristicResult_t heuristic;
 
-    // create the operation descriptor
     cublasOperation_t opNoTranspose = CUBLAS_OP_N;
     cublasOperation_t opTranspose = CUBLAS_OP_T;
-    cublasLtEpilogue_t epilogueBias = has_bias ? CUBLASLT_EPILOGUE_BIAS : CUBLASLT_EPILOGUE_DEFAULT;
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA, (transA)  ? &opTranspose : &opNoTranspose,   sizeof(opTranspose)));
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB, (transB) ? &opTranspose   : &opNoTranspose, sizeof(opNoTranspose)));
 
-    cublasCheck(cublasLtMatmulDescCreate(&operationDesc, cublas_compute, CUDA_R_32F)); // FP16 if CUBLAS_COMPUTE_16F
-    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSA, &opTranspose, sizeof(opTranspose)));
-    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_TRANSB, &opNoTranspose, sizeof(opNoTranspose)));
-    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE, &epilogueBias, sizeof(epilogueBias)));
-    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    // Define matrix layouts
+    if (transA) {
+        cublasCheck(cublasLtMatrixLayoutCreate(&ALayout, CUBLAS_LOWP, k, m, k));
+    } else {
+        cublasCheck(cublasLtMatrixLayoutCreate(&ALayout, CUBLAS_LOWP, m, k, m));
+    }
+    if (transB) {
+        cublasCheck(cublasLtMatrixLayoutCreate(&BLayout, CUBLAS_LOWP, n, k, n));
+    } else {
+        cublasCheck(cublasLtMatrixLayoutCreate(&BLayout, CUBLAS_LOWP, k, n, k));
+    }
+    // cuBLASLt requires C in FP8 mode to be BF16 or FP32...
+    cublasCheck(cublasLtMatrixLayoutCreate(&CLayout, (sizeof(floatX) == 1) ? CUDA_R_16BF : CUBLAS_LOWP, m, n, m));
+    cublasCheck(cublasLtMatrixLayoutCreate(&DLayout, CUBLAS_LOWP, m, n, m));
 
-    // define matrix layouts
-    cublasCheck(cublasLtMatrixLayoutCreate(&weightLayout, CUBLAS_LOWP, C, OC, C));
-    cublasCheck(cublasLtMatrixLayoutCreate(&inputLayout, CUBLAS_LOWP, C, B*T, C));
-    cublasCheck(cublasLtMatrixLayoutCreate(&outputLayout, CUBLAS_LOWP, OC, B*T, OC));
-    cublasCheck(cublasLtMatrixLayoutCreate(&biasLayout, CUBLAS_LOWP, OC, 1, OC));
+    // batched GEMM for non-flash attention
+    if (batch_count) {
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(ALayout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(BLayout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(CLayout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(DLayout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(ALayout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideA, sizeof(strideA)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(BLayout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideB, sizeof(strideB)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(CLayout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideOut, sizeof(strideOut)));
+        cublasCheck(cublasLtMatrixLayoutSetAttribute(DLayout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strideOut, sizeof(strideOut)));
+    }
 
     // create a preference handle with specified max workspace
     cublasCheck(cublasLtMatmulPreferenceCreate(&preference));
-    cublasCheck(cublasLtMatmulPreferenceSetAttribute(preference,
-        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &cublaslt_workspace_size, sizeof(cublaslt_workspace_size)));
+    cublasCheck(cublasLtMatmulPreferenceSetAttribute(preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                                                     &cublaslt_workspace_size, sizeof(cublaslt_workspace_size)));
+
+    cublasLtEpilogue_t epilogue;
+    if (has_gelu) {
+        int64_t gelu_ld = m; // todo - is this affected by anything else?
+        cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE_AUX_LD, &gelu_ld, sizeof(gelu_ld)));
+        cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE_AUX_POINTER, &pre_gelu, sizeof(pre_gelu)));
+        if (backward) {
+            assert(!has_bias); // we shouldn't have any backward matmuls that use both GELU and bias
+            epilogue = CUBLASLT_EPILOGUE_DGELU;
+        } else {
+            epilogue = has_bias ? CUBLASLT_EPILOGUE_GELU_AUX_BIAS : CUBLASLT_EPILOGUE_GELU_AUX;
+        }
+    } else if(has_bias){
+        epilogue = backward ? CUBLASLT_EPILOGUE_BGRADB : CUBLASLT_EPILOGUE_BIAS;
+    } else {
+        epilogue = CUBLASLT_EPILOGUE_DEFAULT;
+    }
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+
+    if (has_bias) {
+        // cuBLASLt requires bias in FP8 mode to be BF16...
+        cublasDataType_t bias_data_type = (sizeof(floatX) == 1) ? CUDA_R_16BF : CUBLAS_LOWP; // force BF16 bias for FP8 mode
+        cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_data_type, sizeof(bias_data_type)));
+        cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    }
+
+    // Set scale type to FP32 (needs to be FP16 if and only if using CUBLAS_COMPUTE_16F)
+    const float alpha = 1.0f, beta = accumulate ? 1.0f : 0.0f;
+    cublasDataType_t scale_type = CUDA_R_32F;
+    cublasCheck(cublasLtMatmulDescSetAttribute(operationDesc, CUBLASLT_MATMUL_DESC_SCALE_TYPE, &scale_type, sizeof(scale_type)));
 
     // find a suitable algorithm
-    cublasCheck(cublasLtMatmulAlgoGetHeuristic(cublaslt_handle, operationDesc,
-        weightLayout, inputLayout, outputLayout, outputLayout,
-        preference, 1, &heuristic, &returnedResults));
+    cublasLtMatmulAlgoGetHeuristic(cublaslt_handle, operationDesc,
+                                   ALayout, BLayout, CLayout, DLayout,
+                                   preference, 1, &heuristic, &returnedResults);
     if (returnedResults == 0) {
-        printf("No cuBLASLt algorithm: B: %d, T: %d, C: %d, OC: %d, bias: %d\n", B, T, C, OC, has_bias);
+        printf("No cuBLASLt algorithm: m: %d, n: %d, k: %d, bias: %d\n", n, m, k, has_bias);
         exit(EXIT_FAILURE);
     }
 
     // call the matmul
     cublasCheck(cublasLtMatmul(cublaslt_handle, operationDesc,
-        &alpha, weight, weightLayout, inp, inputLayout, &beta,
-        out, outputLayout, out, outputLayout, &heuristic.algo,
-        cublaslt_workspace, cublaslt_workspace_size, stream));
+                               &alpha, a, ALayout, b, BLayout, &beta,
+                               d, CLayout, d, DLayout, &heuristic.algo,
+                               cublaslt_workspace, cublaslt_workspace_size, stream));
 
     // cleanups
     cublasCheck(cublasLtMatmulPreferenceDestroy(preference));
     cublasCheck(cublasLtMatmulDescDestroy(operationDesc));
-    cublasCheck(cublasLtMatrixLayoutDestroy(weightLayout));
-    cublasCheck(cublasLtMatrixLayoutDestroy(inputLayout));
-    cublasCheck(cublasLtMatrixLayoutDestroy(outputLayout));
-    cublasCheck(cublasLtMatrixLayoutDestroy(biasLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(ALayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(BLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(CLayout));
+    cublasCheck(cublasLtMatrixLayoutDestroy(DLayout));
+}
+
+// this is a small wrapper for the forward pass specifically
+void matmul_forward_cublaslt(floatX* out,
+                     floatX* inp, floatX* weight, floatX* bias,
+                     int B, int T, int C, int OC, cudaStream_t stream,
+                     floatX* pre_gelu=NULL, int gelu_fusion=1) {
+    // Only fuse GELU for H100+ as cuBLAS seems to be inefficient for fused GELU on Ada/Ampere (?!)
+    if (gelu_fusion < 1 && pre_gelu) {
+        matmul_cublaslt(pre_gelu, weight, inp, bias, OC, B*T, C, stream, true, false, 0, 0, 0, 0, false, NULL, false);
+        gelu_forward(out, pre_gelu, B*T*OC, stream);
+    } else {
+        matmul_cublaslt(out, weight, inp, bias, OC, B*T, C, stream, true, false, 0, 0, 0, 0, false, pre_gelu, false);
+    }
 }
 
 void matmul_backward(floatX* dinp, floatX* dweight, floatX* dbias,
                      floatX* dout, floatX* inp, floatX* weight,
                      float* dbias_buffer,
-                     int B, int T, int C, int OC, cudaStream_t stream) {
+                     int B, int T, int C, int OC, cudaStream_t stream,
+                     floatX* pre_gelu=NULL, int gelu_fusion=1) {
     NVTX_RANGE_FN();
-    float one = 1.0f, zero = 0.0f;
 
     // backward to bias, if given, does a +=
     if (dbias != NULL) {
@@ -204,17 +269,21 @@ void matmul_backward(floatX* dinp, floatX* dweight, floatX* dbias,
             reduce_add_sum_kernel<<<CEIL_DIV(OC, 256 * f128::size), 256, 0, stream>>>(dbias, dbias_buffer, OC, grid_size_y);
             cudaCheck(cudaGetLastError());
         }
+        dbias = NULL; // prevent dbias calculation from also being fused in matmul_cublaslt below
     }
 
     // backward to input, uses = in the backward pass (set the gradient)
-    cublasCheck(cublasSetStream(cublas_handle, stream));
-    cublasCheck(cublasSetWorkspace(cublas_handle, cublaslt_workspace, cublaslt_workspace_size));
-    cublasCheck(cublasGemmEx(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, C, B*T, OC, &one,
-                             weight, CUBLAS_LOWP, C, dout, CUBLAS_LOWP, OC, &zero,
-                             dinp, CUBLAS_LOWP, C, cublas_compute, CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+    matmul_cublaslt(dinp, weight, dout, NULL, C, B*T, OC, stream, false, false, 0, 0, 0, 0, false,
+                    gelu_fusion >= 2 ? pre_gelu : NULL, true);
+
+    if (gelu_fusion < 2 && pre_gelu) {
+        // TODO: not fusing in cuBLASLt as it reduces accuracy (/performance?) with BF16 :(
+        gelu_backward_inplace(dinp, pre_gelu, B*T*C, stream);
+    }
+
     // backward to weight, uses += in the backward pass (accumulate the gradient) by setting alpha=one
-    cublasCheck(cublasGemmEx(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_T, C, OC, B*T, &one,
-                             inp, CUBLAS_LOWP, C, dout, CUBLAS_LOWP, OC, &one,
-                             dweight, CUBLAS_LOWP, C, cublas_compute, CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+    matmul_cublaslt(dweight, inp, dout, NULL /*dbias*/, C, OC, B*T, stream, false, true, 0, 0, 0, 0,
+                    true /* accumulate */, NULL, true);
+
     cudaCheck(cudaGetLastError());
 }

--- a/llmc/matmul.cuh
+++ b/llmc/matmul.cuh
@@ -7,7 +7,7 @@ Matrix Multiplication, with help from cuBLASLt
 #include "cuda_common.h"
 #include "cuda_utils.cuh"
 #include "cublas_common.h"
-// GELU forward can be either fused (cublasLt) or non-fused (gelu.h)
+// GELU can be either fused (cublasLt) or non-fused (gelu.h)
 #include "gelu.cuh"
 
 // ----------------------------------------------------------------------------

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -121,6 +121,7 @@ int main(int argc, char *argv[]) {
         if (argv[i][0] != '-') { exit(EXIT_FAILURE); } // must start with dash
         if (argv[i][1] == 'w') { model.use_master_weights = atoi(argv[i+1]); }
         else if (argv[i][1] == 'r') { model.recompute = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { model.gelu_fusion = atoi(argv[i+1]); }
     }
 
     // load additional information that we will use for debugging and error checking

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -118,6 +118,7 @@ int main(int argc, char *argv[]) {
 
     for (int i = 1; i < argc; i+=2) {
         if (i + 1 >= argc) { exit(EXIT_FAILURE);  } // must have arg after flag
+        if (!(strlen(argv[i]) == 2 || strlen(argv[i]) == 3)) { exit(EXIT_FAILURE); } // must be -x[y] (one dash, one or two letters)
         if (argv[i][0] != '-') { exit(EXIT_FAILURE); } // must start with dash
         if (argv[i][1] == 'w') { model.use_master_weights = atoi(argv[i+1]); }
         else if (argv[i][1] == 'r') { model.recompute = atoi(argv[i+1]); }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -399,7 +399,7 @@ void gpt2_init_common(GPT2 *model) {
     model->rng_state = 13371337 + multi_gpu_config.process_rank; // used in stochastic rounding
     model->use_master_weights = 1; // safe default: do keep master weights in fp32
     model->recompute = 1; // good default: recompute gelu but not layernorm
-    model->gelu_fusion = deviceProp.major >= 9 ? 1 : 0; // default: fuse gelu forward on H100+
+    model->gelu_fusion = deviceProp.major >= 9 ? 2 : 0; // default: fuse on H100+ (if changed, also update main())
 }
 
 void gpt2_write_to_checkpoint(GPT2 *model, const char* checkpoint_path) {
@@ -1492,7 +1492,7 @@ int main(int argc, char *argv[]) {
     // calculate sensible default for total batch size as assuming no gradient accumulation
     if (total_batch_size == -1) { total_batch_size = tokens_per_fwdbwd; }
     // if unspecified, set gelu fusion to 2 for SM90+ and 0 for other GPUs
-    if (gelu_fusion == -1) { gelu_fusion = (deviceProp.major >= 9) ? 2 : 0; }
+    if (gelu_fusion == -1) { gelu_fusion = (deviceProp.major >= 9) ? 2 : 0; } // in gpt2_init_common for test_gpt2cu...
     // calculate the number of gradient accumulation steps from the desired total batch size
     assert(total_batch_size % tokens_per_fwdbwd == 0);
     int grad_accum_steps = total_batch_size / tokens_per_fwdbwd;

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -850,7 +850,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         floatX* l_ln2 = (model->recompute < 2) ? acts.ln2 + l * B * T * C : acts.lnf;
         float* l_ln2_mean = acts.ln2_mean + l * B * T;
         float* l_ln2_rstd = acts.ln2_rstd + l * B * T;
-        floatX* l_fch = acts.fch + l * B * T * 4*C;
+        floatX* l_fch_pre_gelu = acts.fch + l * B * T * 4*C;
         floatX* l_fch_gelu = (model->recompute < 1) ? acts.fch_gelu + l * B * T * 4*C : acts.fch_gelu;
         // get the pointers of the gradients of the activations for this layer
         // notice that there is no l *, because we just have a single copy, and keep

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -399,7 +399,7 @@ void gpt2_init_common(GPT2 *model) {
     model->rng_state = 13371337 + multi_gpu_config.process_rank; // used in stochastic rounding
     model->use_master_weights = 1; // safe default: do keep master weights in fp32
     model->recompute = 1; // good default: recompute gelu but not layernorm
-    model->gelu_fusion = deviceProp.major >= 9 ? 2 : 0; // default: fuse on H100+ (if changed, also update main())
+    model->gelu_fusion = 0; //deviceProp.major >= 9 ? 2 : 0; // default: off for now (default must match main())
 }
 
 void gpt2_write_to_checkpoint(GPT2 *model, const char* checkpoint_path) {
@@ -1491,8 +1491,8 @@ int main(int argc, char *argv[]) {
     int tokens_per_fwdbwd = B * T * multi_gpu_config.num_processes; // one micro-batch processes this many tokens
     // calculate sensible default for total batch size as assuming no gradient accumulation
     if (total_batch_size == -1) { total_batch_size = tokens_per_fwdbwd; }
-    // if unspecified, set gelu fusion to 2 for SM90+ and 0 for other GPUs
-    if (gelu_fusion == -1) { gelu_fusion = (deviceProp.major >= 9) ? 2 : 0; } // in gpt2_init_common for test_gpt2cu...
+    // in the future, we might want to set gelu fusion to 2 for SM90+ and 0 for other GPUs
+    if (gelu_fusion == -1) { gelu_fusion = 0; } // (deviceProp.major >= 9) ? 2 : 0; } // in gpt2_init_common for test_gpt2cu...
     // calculate the number of gradient accumulation steps from the desired total batch size
     assert(total_batch_size % tokens_per_fwdbwd == 0);
     int grad_accum_steps = total_batch_size / tokens_per_fwdbwd;

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -47,8 +47,8 @@ GPT-2 Transformer Neural Net training loop. See README.md for usage.
 #include "llmc/encoder.cuh"
 // defines: layernorm_forward, residual_forward, fused_residual_forward5, layernorm_backward
 #include "llmc/layernorm.cuh"
-// defines: gelu_forward, gelu_backward_inplace
-#include "llmc/gelu.cuh"
+// defines: matmul_cublaslt, matmul_forward, matmul_backward, gelu_forward, gelu_backward_inplace
+#include "llmc/matmul.cuh"
 #ifdef ENABLE_CUDNN
 // defines: create_cudnn, destroy_cudnn, attention_forward_cudnn, attention_backward_cudnn
 #include "llmc/cudnn_att.h"
@@ -56,8 +56,6 @@ GPT-2 Transformer Neural Net training loop. See README.md for usage.
 // defines: attention_forward, attention_backward
 #include "llmc/attention.cuh"
 #endif
-// defines: matmul_forward, matmul_backward
-#include "llmc/matmul.cuh"
 // defines: fused_classifier
 #include "llmc/fused_classifier.cuh"
 // defines: adamw_kernel3
@@ -366,6 +364,7 @@ typedef struct {
     float* cpu_losses; // CPU buffer to copy the losses to, allocated with cudaMallocHost
     unsigned long long rng_state; // the RNG state for seeding stochastic rounding etc.
     int use_master_weights; // keep master weights copy in float for optim update? 0|1
+    int gelu_fusion; // fuse gelu via cuBLASLt (0=none, 1=forward, 2=forward+backward)
     int recompute; // recompute gelu | layernorm forward during model backward? 0|1|2
     // todo - if other functions need cpu scratch buffers in the future, reuse as generic scratch?
     int* workload_indices; // encoder_backward, B*T*num_c_groups (int)
@@ -685,8 +684,7 @@ void gpt2_forward(GPT2 *model, const int* inputs, size_t B, size_t T) {
 
         matmul_forward_cublaslt(l_attproj, l_atty, l_attprojw, l_attprojb, B, T, C, C, main_stream);
         fused_residual_forward5(l_residual2, l_ln2, l_ln2_mean, l_ln2_rstd, residual, l_attproj, l_ln2w, l_ln2b, B*T, C, main_stream);
-        matmul_forward_cublaslt(l_fch, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream);
-        gelu_forward(l_fch_gelu, l_fch, B*T*4*C, main_stream);
+        matmul_forward_cublaslt(l_fch_gelu, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream, l_fch, model->gelu_fusion);
         matmul_forward_cublaslt(l_fcproj, l_fch_gelu, l_fcprojw, l_fcprojb, B, T, 4*C, C, main_stream);
 
         // OK, fusion across blocks.
@@ -863,10 +861,9 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         if(model->recompute >= 1) {
             // recompute >= 1 means we recompute gelu. in this case,
             // l_fch_gelu is just a buffer, so re-compute the gelu from l_fch here
-            gelu_forward(l_fch_gelu, l_fch, B*T*4*C, main_stream);
+            gelu_forward(l_fch_gelu, l_fch_pre_gelu, B*T*4*C, main_stream);
         }
-        matmul_backward(dl_bt4c, dl_fcprojw, dl_fcprojb, dresidual, l_fch_gelu, l_fcprojw, scratchF, B, T, 4*C, C, main_stream);
-        gelu_backward_inplace(dl_bt4c, l_fch, B*T*4*C, main_stream);
+        matmul_backward(dl_bt4c, dl_fcprojw, dl_fcprojb, dresidual, l_fch_gelu, l_fcprojw, scratchF, B, T, 4*C, C, main_stream, l_fch_pre_gelu, model->gelu_fusion);
         if(model->recompute >= 2) {
             // same as gelu above, l_ln1 and l_ln2 are just buffers if recompute >= 2, recompute them here on demand
             layernorm_forward(l_ln2, l_ln2_mean, l_ln2_rstd, l_residual2, l_ln2w, l_ln2b, B, T, C, main_stream);
@@ -883,7 +880,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         floatX* l_att = acts.att + l * B * NH * T * T;
         // we need B x T x (4)C buffers. l_atty and l_fch aren't needed anymore at this point, so reuse their memory
         floatX* buffer_a = l_atty;
-        floatX* buffer_b = l_fch;        // this is B x T x 4C, so even larger than what we need
+        floatX* buffer_b = l_fch_pre_gelu;        // this is B x T x 4C, so even larger than what we need
         attention_backward(dl_bt4c, buffer_b, scratchX, buffer_a, dl_btc, l_qkvr, l_att, B, T, C, NH, main_stream);
         #endif
         if(model->recompute >= 2) {
@@ -1167,13 +1164,11 @@ void common_start(bool override_enable_tf32 = true, bool print_device_info = tru
     nvtxNameCudaStreamA(main_stream, "main stream");
 
     // set up cuBLAS and cuBLASLt
-    cublasCheck(cublasCreate(&cublas_handle));
     cublasCheck(cublasLtCreate(&cublaslt_handle));
     cudaCheck(cudaMalloc(&cublaslt_workspace, cublaslt_workspace_size));
 
     // TF32 precision is equivalent to torch.set_float32_matmul_precision('high')
     bool enable_tf32 = PRECISION_MODE == PRECISION_FP32 && deviceProp.major >= 8 && override_enable_tf32;
-    cublasCheck(cublasSetMathMode(cublas_handle, enable_tf32 ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH));
     cublas_compute = enable_tf32 ? CUBLAS_COMPUTE_32F_FAST_TF32 : CUBLAS_COMPUTE_32F;
 
     #ifdef ENABLE_CUDNN
@@ -1184,7 +1179,6 @@ void common_start(bool override_enable_tf32 = true, bool print_device_info = tru
 void common_free(GPT2 &model) {
     cudaCheck(cudaStreamDestroy(main_stream));
     cudaCheck(cudaFree(cublaslt_workspace));
-    cublasCheck(cublasDestroy(cublas_handle));
     cublasCheck(cublasLtDestroy(cublaslt_handle));
     #ifdef ENABLE_CUDNN
     destroy_cudnn();
@@ -1386,6 +1380,7 @@ void error_usage() {
     // numerics
     fprintf(stderr, "  -f <int>    enable_tf32 override (default: 1, set to 0 to disable tf32)\n");
     fprintf(stderr, "  -w <int>    keep f32 copy of weights for the optimizer? (default: 1)\n");
+    fprintf(stderr, "  -ge <int>   gelu fusion: 0=none, 1=forward, 2=forward+backward (default: 1 for >=SM90, 0 for older GPUs)\n");
     // memory management
     fprintf(stderr, "  -z <int>    zero_stage, Zero Optimization Stage, 0,1,2,3 (default = 0)\n");
     fprintf(stderr, "  -r <int>    recompute: less memory but less speed. (default = 1), 0|1|2 = none,gelu,gelu+ln\n");
@@ -1429,6 +1424,7 @@ int main(int argc, char *argv[]) {
     int max_steps = -1;
     int override_enable_tf32 = 1;
     int use_master_weights = 1;
+    int gelu_fusion = 1; // 0 = none, 1 = forward, 2 = forward+backward
     int recompute = 1; // recompute during backward setting, 0 = none, 1 = recompute gelu
     int zero_stage = 0; // Zero Optimization Stage for Multi-GPU training
     int hellaswag_eval = 0;
@@ -1461,6 +1457,7 @@ int main(int argc, char *argv[]) {
         else if (argv[i][1] == 'v') { val_loss_every = atoi(argv[i+1]); }
         else if (argv[i][1] == 'm') { val_max_steps = atoi(argv[i+1]); }
         else if (argv[i][1] == 's' && argv[i][2] == '\0') { sample_every = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { gelu_fusion = atoi(argv[i+1]); }
         else if (argv[i][1] == 'g') { genT = atoi(argv[i+1]); }
         else if (argv[i][1] == 'a') { overfit_single_batch = atoi(argv[i+1]); }
         else if (argv[i][1] == 'f') { override_enable_tf32 = atoi(argv[i+1]); }
@@ -1522,6 +1519,7 @@ int main(int argc, char *argv[]) {
     printf0("| genT                  | %-50d |\n", genT);
     printf0("| overfit_single_batch  | %-50d |\n", overfit_single_batch);
     printf0("| use_master_weights    | %-50s |\n", use_master_weights ? "enabled" : "disabled");
+    printf0("| gelu_fusion           | %-50d |\n", gelu_fusion);
     printf0("| recompute             | %-50d |\n", recompute);
     printf0("+-----------------------+----------------------------------------------------+\n");
 
@@ -1568,6 +1566,7 @@ int main(int argc, char *argv[]) {
     }
 
     model.use_master_weights = use_master_weights;
+    model.gelu_fusion = gelu_fusion;
     model.recompute = recompute;
     printf0("| weight init method    | %-50s |\n", resuming == 1 ? "intermediate checkpoint" : (load_filename[0] == 'd' ? "random" : "OpenAI's GPT-2 checkpoint"));
     printf0("| max_sequence_length T | %-50d |\n", model.config.max_seq_len);


### PR DESCRIPTION
In preparation for FP8, this replaces all cuBLAS calls by cuBLASLt which is now wrapped by a single matmul_cublaslt() function.

It also adds support for GELU fusion which can be controlled on the command line with "-ge": 0 for disabled, 1 for forward only, 2 for forward+backward. The default is 2 is for H100+ and 0 for older GPUs based on seeing regressions on RTX 4090 previously _**but you might want to consider disabling it by default before merging due to the following:**_

In terms of accuracy and validation loss, the fused GELU seems very slightly worse than ours (how/why?!) which is not ideal especially when combined with GELU recomputation since it means the activations used for the backward pass won't be bit-for-bit identical to the ones used in the forward pass.

It's hard to tell how much this is just noise because the loss is only slightly worse for fused GELU (and the tensor thresholds are still too aggressive by default, so out of sheer luck the fused GELU passes but the non-fused doesn't on my system!) - based on this data, I think it's probably real. But then again with the non-deterministic cuDNN performance runs below (before my other PR) the "best" val loss is seen with "-ge 1" and the worst with "-ge 0" so it's very much within the noise threshold in that case... so who knows?

The performance is noticeably improved (H100 with cuDNN enabled) - I did 2 runs of each since it wasn't deterministic due to cuDNN:
```
./train_gpt2cu -r 1 -ge 0 -b 24 -e "d48" ==> 31653 tok/s (val loss 6.893524)
./train_gpt2cu -r 1 -ge 0 -b 24 -e "d48" ==> 31464 tok/s (val loss 6.890060)

./train_gpt2cu -r 1 -ge 1 -b 24 -e "d48" ==> 32192 tok/s (val loss 6.889246)
./train_gpt2cu -r 1 -ge 1 -b 24 -e "d48" ==> 32227 tok/s (val loss 6.891509)

./train_gpt2cu -r 1 -ge 2 -b 24 -e "d48" ==> 32716 tok/s (val loss 6.891244)
./train_gpt2cu -r 1 -ge 2 -b 24 -e "d48" ==> 32851 tok/s (val loss 6.891099)
```
**==> +3.4%!** (for results of the 1st run)


### -r 0 -ge 0 (BF16 cuDNN disabled so **fully deterministic**):
```TENSOR OK, max diff: 7.150e-01, with rel error: 9.268e-02 (calculated=  7.000000, ref=  7.714991), 85.08% of maximum error
TENSOR OK, max diff: 3.901e-03, with rel error: 4.284e+00 (calculated=  0.002991, ref= -0.000911), 95.81% of maximum error
TENSOR OK, max diff: 1.192e-01, with rel error: 8.910e-02 (calculated=  1.218750, ref=  1.337970), 86.91% of maximum error
TENSOR OK, max diff: 3.112e-02, with rel error: 2.968e+00 (calculated= -0.020630, ref=  0.010485), 87.19% of maximum error
TENSOR OK, max diff: 2.367e-02, with rel error: 1.522e-01 (calculated= -0.131836, ref= -0.155501), 73.30% of maximum error
TENSOR OK, max diff: 2.460e-02, with rel error: 5.366e-01 (calculated= -0.021240, ref= -0.045837), 73.16% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR OK, max diff: 1.142e-02, with rel error: 1.212e+00 (calculated=  0.001999, ref= -0.009424), 72.55% of maximum error
TENSOR OK, max diff: 2.934e-04, with rel error: 4.422e-02 (calculated=  0.006927, ref=  0.006634), 41.86% of maximum error
TENSOR OK, max diff: 7.905e-03, with rel error: 1.528e+01 (calculated=  0.008423, ref=  0.000517), 98.31% of maximum error
TENSOR OK, max diff: 2.274e-03, with rel error: 1.098e-01 (calculated= -0.018433, ref= -0.020706), 86.76% of maximum error
TENSOR OK, max diff: 2.454e-03, with rel error: 4.789e-01 (calculated=  0.002670, ref=  0.005125), 84.49% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.595e-02, with rel error: 5.161e+00 (calculated= -0.019043, ref= -0.003091), 78.80% of maximum error

loss ok at step 1: 5.242411 5.270009
loss ok at step 2: 4.045264 4.060681
loss ok at step 3: 3.299340 3.320085
loss ok at step 4: 2.719682 2.717550
loss ok at step 5: 2.199129 2.181066
loss ok at step 6: 1.658379 1.653923
loss ok at step 7: 1.178264 1.168050
loss ok at step 8: 0.757203 0.736873
loss ok at step 9: 0.409954 0.401021
loss ok at step 10: 0.197095 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.718741
```

### -r 0 -ge 1:

```TENSOR OK, max diff: 7.775e-01, with rel error: 1.008e-01 (calculated=  6.937500, ref=  7.714991), 71.96% of maximum error
TENSOR OK, max diff: 3.703e-03, with rel error: 4.067e+00 (calculated=  0.002792, ref= -0.000911), 90.94% of maximum error
TENSOR OK, max diff: 1.250e-01, with rel error: 1.096e-01 (calculated=  1.015625, ref=  1.140599), 87.85% of maximum error
TENSOR OK, max diff: 3.160e-02, with rel error: 3.014e+00 (calculated= -0.021118, ref=  0.010485), 89.61% of maximum error
TENSOR OK, max diff: 2.600e-02, with rel error: 1.756e-01 (calculated= -0.122070, ref= -0.148071), 82.03% of maximum error
TENSOR OK, max diff: 2.631e-02, with rel error: 5.739e-01 (calculated= -0.019531, ref= -0.045837), 78.24% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 1.361e-02, with rel error: 1.444e+00 (calculated=  0.004181, ref= -0.009424), 86.41% of maximum error
TENSOR OK, max diff: 2.415e-04, with rel error: 1.233e-01 (calculated= -0.001717, ref= -0.001958), 36.88% of maximum error
TENSOR OK, max diff: 7.966e-03, with rel error: 1.539e+01 (calculated=  0.008484, ref=  0.000517), 99.07% of maximum error
TENSOR OK, max diff: 2.518e-03, with rel error: 1.216e-01 (calculated= -0.018188, ref= -0.020706), 92.08% of maximum error
TENSOR OK, max diff: 2.622e-03, with rel error: 5.117e-01 (calculated=  0.002502, ref=  0.005125), 90.27% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.607e-02, with rel error: 5.200e+00 (calculated= -0.019165, ref= -0.003091), 79.40% of maximum error

loss ok at step 1: 5.258774 5.270009
loss ok at step 2: 4.040064 4.060681
loss ok at step 3: 3.311543 3.320085
loss ok at step 4: 2.704113 2.717550
loss ok at step 5: 2.185935 2.181066
loss ok at step 6: 1.654894 1.653923
loss ok at step 7: 1.190601 1.168050
loss ok at step 8: 0.762185 0.736873
loss ok at step 9: 0.423399 0.401021
loss ok at step 10: 0.201602 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.725565
```

### -r 0 -ge 2:

```TENSOR OK, max diff: 7.775e-01, with rel error: 1.008e-01 (calculated=  6.937500, ref=  7.714991), 71.96% of maximum error
TENSOR OK, max diff: 3.733e-03, with rel error: 4.100e+00 (calculated=  0.002823, ref= -0.000911), 91.69% of maximum error
TENSOR OK, max diff: 1.250e-01, with rel error: 1.096e-01 (calculated=  1.015625, ref=  1.140599), 86.91% of maximum error
TENSOR OK, max diff: 3.185e-02, with rel error: 3.037e+00 (calculated= -0.021362, ref=  0.010485), 89.27% of maximum error
TENSOR OK, max diff: 2.659e-02, with rel error: 1.710e-01 (calculated= -0.128906, ref= -0.155501), 83.57% of maximum error
TENSOR OK, max diff: 2.606e-02, with rel error: 5.686e-01 (calculated= -0.019775, ref= -0.045837), 77.52% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 1.199e-02, with rel error: 1.272e+00 (calculated=  0.002563, ref= -0.009424), 76.14% of maximum error
TENSOR OK, max diff: 2.338e-04, with rel error: 1.194e-01 (calculated= -0.001724, ref= -0.001958), 35.72% of maximum error
TENSOR OK, max diff: 7.966e-03, with rel error: 1.539e+01 (calculated=  0.008484, ref=  0.000517), 99.07% of maximum error
TENSOR OK, max diff: 2.518e-03, with rel error: 1.216e-01 (calculated= -0.018188, ref= -0.020706), 93.12% of maximum error
TENSOR OK, max diff: 2.576e-03, with rel error: 5.027e-01 (calculated=  0.002548, ref=  0.005125), 88.69% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.607e-02, with rel error: 5.200e+00 (calculated= -0.019165, ref= -0.003091), 79.40% of maximum error

loss ok at step 1: 5.258774 5.270009
loss ok at step 2: 4.061561 4.060681
loss ok at step 3: 3.322728 3.320085
loss ok at step 4: 2.727595 2.717550
loss ok at step 5: 2.185776 2.181066
loss ok at step 6: 1.665764 1.653923
loss ok at step 7: 1.181406 1.168050
loss ok at step 8: 0.760672 0.736873
loss ok at step 9: 0.411712 0.401021
loss ok at step 10: 0.202858 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.732559
```

### -r 2 -ge 0:

```TENSOR OK, max diff: 7.150e-01, with rel error: 9.268e-02 (calculated=  7.000000, ref=  7.714991), 85.08% of maximum error
TENSOR OK, max diff: 3.901e-03, with rel error: 4.284e+00 (calculated=  0.002991, ref= -0.000911), 95.81% of maximum error
TENSOR OK, max diff: 1.192e-01, with rel error: 8.910e-02 (calculated=  1.218750, ref=  1.337970), 86.91% of maximum error
TENSOR OK, max diff: 3.112e-02, with rel error: 2.968e+00 (calculated= -0.020630, ref=  0.010485), 87.19% of maximum error
TENSOR OK, max diff: 2.367e-02, with rel error: 1.522e-01 (calculated= -0.131836, ref= -0.155501), 73.30% of maximum error
TENSOR OK, max diff: 2.460e-02, with rel error: 5.366e-01 (calculated= -0.021240, ref= -0.045837), 73.16% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR NOT OK, max diff: 6.596e-02, with rel error: 5.363e-02 (calculated=  1.164062, ref=  1.230026), 103.83% of maximum error
TENSOR OK, max diff: 1.142e-02, with rel error: 1.212e+00 (calculated=  0.001999, ref= -0.009424), 72.55% of maximum error
TENSOR OK, max diff: 2.934e-04, with rel error: 4.422e-02 (calculated=  0.006927, ref=  0.006634), 41.86% of maximum error
TENSOR OK, max diff: 7.905e-03, with rel error: 1.528e+01 (calculated=  0.008423, ref=  0.000517), 98.31% of maximum error
TENSOR OK, max diff: 2.274e-03, with rel error: 1.098e-01 (calculated= -0.018433, ref= -0.020706), 86.76% of maximum error
TENSOR OK, max diff: 2.454e-03, with rel error: 4.789e-01 (calculated=  0.002670, ref=  0.005125), 84.49% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.595e-02, with rel error: 5.161e+00 (calculated= -0.019043, ref= -0.003091), 78.80% of maximum error

loss ok at step 1: 5.242411 5.270009
loss ok at step 2: 4.045264 4.060681
loss ok at step 3: 3.299340 3.320085
loss ok at step 4: 2.719682 2.717550
loss ok at step 5: 2.199129 2.181066
loss ok at step 6: 1.658379 1.653923
loss ok at step 7: 1.178264 1.168050
loss ok at step 8: 0.757203 0.736873
loss ok at step 9: 0.409954 0.401021
loss ok at step 10: 0.197095 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.718741
```

### -r 2 -ge 1

```TENSOR OK, max diff: 7.775e-01, with rel error: 1.008e-01 (calculated=  6.937500, ref=  7.714991), 71.96% of maximum error
TENSOR OK, max diff: 3.703e-03, with rel error: 4.067e+00 (calculated=  0.002792, ref= -0.000911), 90.94% of maximum error
TENSOR OK, max diff: 1.250e-01, with rel error: 1.096e-01 (calculated=  1.015625, ref=  1.140599), 87.85% of maximum error
TENSOR OK, max diff: 3.160e-02, with rel error: 3.014e+00 (calculated= -0.021118, ref=  0.010485), 89.61% of maximum error
TENSOR OK, max diff: 2.600e-02, with rel error: 1.756e-01 (calculated= -0.122070, ref= -0.148071), 82.03% of maximum error
TENSOR OK, max diff: 2.631e-02, with rel error: 5.739e-01 (calculated= -0.019531, ref= -0.045837), 78.24% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 1.361e-02, with rel error: 1.444e+00 (calculated=  0.004181, ref= -0.009424), 86.41% of maximum error
TENSOR OK, max diff: 2.415e-04, with rel error: 1.233e-01 (calculated= -0.001717, ref= -0.001958), 36.88% of maximum error
TENSOR OK, max diff: 7.966e-03, with rel error: 1.539e+01 (calculated=  0.008484, ref=  0.000517), 99.07% of maximum error
TENSOR OK, max diff: 2.518e-03, with rel error: 1.216e-01 (calculated= -0.018188, ref= -0.020706), 92.08% of maximum error
TENSOR OK, max diff: 2.622e-03, with rel error: 5.117e-01 (calculated=  0.002502, ref=  0.005125), 90.27% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.607e-02, with rel error: 5.200e+00 (calculated= -0.019165, ref= -0.003091), 79.40% of maximum error

loss ok at step 1: 5.258774 5.270009
loss ok at step 2: 4.031170 4.060681
loss ok at step 3: 3.303350 3.320085
loss ok at step 4: 2.718124 2.717550
loss ok at step 5: 2.191558 2.181066
loss ok at step 6: 1.654259 1.653923
loss ok at step 7: 1.177093 1.168050
loss ok at step 8: 0.748835 0.736873
loss ok at step 9: 0.415033 0.401021
loss ok at step 10: 0.197646 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.732420
```

### -r 2 -ge 2

```TENSOR OK, max diff: 7.775e-01, with rel error: 1.008e-01 (calculated=  6.937500, ref=  7.714991), 71.96% of maximum error
TENSOR OK, max diff: 3.733e-03, with rel error: 4.100e+00 (calculated=  0.002823, ref= -0.000911), 91.69% of maximum error
TENSOR OK, max diff: 1.250e-01, with rel error: 1.096e-01 (calculated=  1.015625, ref=  1.140599), 86.91% of maximum error
TENSOR OK, max diff: 3.185e-02, with rel error: 3.037e+00 (calculated= -0.021362, ref=  0.010485), 89.27% of maximum error
TENSOR OK, max diff: 2.659e-02, with rel error: 1.710e-01 (calculated= -0.128906, ref= -0.155501), 83.57% of maximum error
TENSOR OK, max diff: 2.606e-02, with rel error: 5.686e-01 (calculated= -0.019775, ref= -0.045837), 77.52% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 6.925e-02, with rel error: 6.878e-02 (calculated= -0.937500, ref= -1.006749), 93.92% of maximum error
TENSOR OK, max diff: 1.199e-02, with rel error: 1.272e+00 (calculated=  0.002563, ref= -0.009424), 76.14% of maximum error
TENSOR OK, max diff: 2.338e-04, with rel error: 1.194e-01 (calculated= -0.001724, ref= -0.001958), 35.72% of maximum error
TENSOR OK, max diff: 7.966e-03, with rel error: 1.539e+01 (calculated=  0.008484, ref=  0.000517), 99.07% of maximum error
TENSOR OK, max diff: 2.518e-03, with rel error: 1.216e-01 (calculated= -0.018188, ref= -0.020706), 93.12% of maximum error
TENSOR OK, max diff: 2.576e-03, with rel error: 5.027e-01 (calculated=  0.002548, ref=  0.005125), 88.69% of maximum error
TENSOR OK, max diff: 1.018e-01, with rel error: 7.858e-01 (calculated= -0.231445, ref= -0.129603), 92.38% of maximum error
TENSOR OK, max diff: 1.607e-02, with rel error: 5.200e+00 (calculated= -0.019165, ref= -0.003091), 79.40% of maximum error

loss ok at step 1: 5.258774 5.270009
loss ok at step 2: 4.043187 4.060681
loss ok at step 3: 3.321911 3.320085
loss ok at step 4: 2.713270 2.717550
loss ok at step 5: 2.186564 2.181066
loss ok at step 6: 1.655319 1.653923
loss ok at step 7: 1.184024 1.168050
loss ok at step 8: 0.750603 0.736873
loss ok at step 9: 0.422000 0.401021
loss ok at step 10: 0.199289 0.187493

Validation loss for ./train_gpt2cu -e "d48" on tinyshakespeare:
val loss 6.725532
```