### PR TITLE
Set RNG seed manually with '-rg' parameter

### DIFF
--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
         if (argv[i][0] != '-') { exit(EXIT_FAILURE); } // must start with dash
         if (argv[i][1] == 'w') { model.use_master_weights = atoi(argv[i+1]); }
         else if (argv[i][1] == 'r' && argv[i][2] == '\0') { model.recompute = atoi(argv[i+1]); }
-        else if (argv[i][1] == 'r' && argv[i][2] == 'g') { model.rng_state += atoi(argv[i+1]); }
+        else if (argv[i][1] == 'r' && argv[i][2] == 'g') { model.rng_state = atoi(argv[i+1]) + multi_gpu_config.process_rank; }
     }
 
     // load additional information that we will use for debugging and error checking

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -120,7 +120,8 @@ int main(int argc, char *argv[]) {
         if (i + 1 >= argc) { exit(EXIT_FAILURE);  } // must have arg after flag
         if (argv[i][0] != '-') { exit(EXIT_FAILURE); } // must start with dash
         if (argv[i][1] == 'w') { model.use_master_weights = atoi(argv[i+1]); }
-        else if (argv[i][1] == 'r') { model.recompute = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'r' && argv[i][2] == '\0') { model.recompute = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'r' && argv[i][2] == 'g') { model.rng_state += atoi(argv[i+1]); }
     }
 
     // load additional information that we will use for debugging and error checking


### PR DESCRIPTION
This adds a '-rg' parameter to manually set the RNG seed. This is useful to see if a change is beneficial or not when the difference is potentially real but smaller than the noise threshold. As we are fully deterministic (for a given system), we can't just run multiple time with the same settings anymore.

The same seed will be used for both gpt2_init_common() and gpt2_build_from_random(), so this effectively changes the default seed from 42 to 13371337 for gpt2_build_from_random(). It does not change the default seed for the non-random initialisation path or test_gpt2cu in any way.