### PR TITLE
Fix periodic loss spikes

### DIFF
--- a/profile_gpt2.cu
+++ b/profile_gpt2.cu
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
     // do a training step
     gpt2_forward(&model, x, B, T);
     gpt2_zero_grad(&model);
-    gpt2_backward_and_reduce(&model, x, y, 1, true);
+    gpt2_backward_and_reduce(&model, x, y, 1, 0);
     float grad_norm = gpt2_calculate_grad_norm(&model, &multi_gpu_config);
     float grad_scale = (grad_norm > 1.0f) ? 1.0f / grad_norm : 1.0f;
     gpt2_update(&model, 1e-4f, 0.9f, 0.999f, 1e-8f, 0.0f, grad_scale, 1, &multi_gpu_config);

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -218,7 +218,7 @@ int main(int argc, char *argv[]) {
         clock_gettime(CLOCK_MONOTONIC, &start);
         gpt2_forward(&model, x, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward_and_reduce(&model, x, y, 1, true);
+        gpt2_backward_and_reduce(&model, x, y, 1, 0);
         clock_gettime(CLOCK_MONOTONIC, &end);
         double time_elapsed_s = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
 
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
         dataloader_next_batch(&loader);
         gpt2_forward(&model, loader.inputs, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward_and_reduce(&model, loader.inputs, loader.targets, 1, true);
+        gpt2_backward_and_reduce(&model, loader.inputs, loader.targets, 1, 0);
         gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+11, &multi_gpu_config);
         losses[step] = model.mean_loss;
         tokens[step] = loader.inputs[0];
@@ -351,7 +351,7 @@ int main(int argc, char *argv[]) {
         dataloader_next_batch(&loader);
         gpt2_forward(&model, loader.inputs, B, T);
         gpt2_zero_grad(&model);
-        gpt2_backward_and_reduce(&model, loader.inputs, loader.targets, 1, true);
+        gpt2_backward_and_reduce(&model, loader.inputs, loader.targets, 1, 0);
         gpt2_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, 1.0f, step+11, &multi_gpu_config);
 
         if(loader.inputs[0] != tokens[step]) {

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1404,16 +1404,16 @@ void error_usage() {
 // main training loop
 int main(int argc, char *argv[]) {
     // read in the (optional) command line arguments
-    const char* train_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_train_*.bin";
-    const char* val_data_pattern = "/hdd/llmc/fineweb/bin/fineweb_val_*.bin";
-    const char* load_filename = "d12"; // bf16 weights of the model
+    const char* train_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_train.bin";
+    const char* val_data_pattern = "dev/data/tinyshakespeare/tiny_shakespeare_val.bin";
+    const char* load_filename = "gpt2_124M_bf16.bin"; // bf16 weights of the model
     const char* lr_scheduler_type = "cosine";
-    const char* output_log_dir = "/hdd/llmc/log_gpt2_124M/";
+    const char* output_log_dir = NULL;
     int checkpoint_every = 0; // write checkpoints every how many steps?
     int checkpoints_keep = 0; // how long checkpoint history do we keep? (in units of checkpoints)
     int major_checkpoint_every = 0; // major checkpoints never get deleted when maintaining history
     int resume = 0; // resume the optimization, if one is found inside output_log_dir?
-    int B = 16; // batch size
+    int B = 4; // batch size
     int T = 1024; // sequence length max
     int total_batch_size = -1; // will be calculated down below later, if not provided
     float learning_rate = 3e-4f;
@@ -1422,15 +1422,15 @@ int main(int argc, char *argv[]) {
     float weight_decay = 0.0f;
     float skip_update_lossz = 0.0f; // skip update if loss goes above this in zscore
     float skip_update_gradz = 0.0f; // skip update if grad_norm goes above this in zscore
-    int val_loss_every = 50; // every how many steps do we eval validation loss?
+    int val_loss_every = 20; // every how many steps do we eval validation loss?
     int val_max_steps = 20; // how many batches max do we eval for validation loss?
-    int sample_every = 25000; // every how many steps to do inference?
+    int sample_every = 20; // every how many steps to do inference?
     int genT = 64; // number of steps of inference we will do
     int overfit_single_batch = 0; // useful for debugging, 1 = only load a single data batch once
     int max_steps = -1;
     int override_enable_tf32 = 1;
     int use_master_weights = 1;
-    int recompute = 0; // recompute during backward setting, 0 = none, 1 = recompute gelu
+    int recompute = 1; // recompute during backward setting, 0 = none, 1 = recompute gelu
     int zero_stage = 0; // Zero Optimization Stage for Multi-GPU training
     int hellaswag_eval = 0;
     // multi-node settings

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -736,7 +736,6 @@ float gpt2_validate(GPT2 *model, const int* inputs, const int* targets, size_t B
         mean_loss += model->cpu_losses[i];
     }
     mean_loss /= B*T;
-    cudaCheck(cudaMemset(acts.losses, 0, model->batch_size * model->seq_len * sizeof(float)));
     cudaCheck(cudaDeviceSynchronize());
     return mean_loss;
 }
@@ -755,14 +754,15 @@ void gpt2_zero_grad(GPT2 *model) {
 void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int grad_accum_steps, bool last_step) {
     NVTX_RANGE_FN();
 
+    // init gradients of parameters and activations to zero
+    gpt2_zero_grad(model);
+
     // lazily allocate the memory for gradients of the weights and activations, if needed
     if (model->grads_memory == NULL) {
         NvtxRange rng("InitGrads");
         // allocate buffers for weight gradients
         printf0("allocating %d MiB for parameter gradients\n", (int)round(model->num_parameters * sizeof(floatX) / (1024 * 1024)));
         model->grads_memory = malloc_and_point_parameters(&model->grads, model->param_elements, model->param_sizeof);
-        // init gradients of parameters and activations to zero
-        gpt2_zero_grad(model);
         // initialise cpu scratch buffers for encoder backward
         size_t num_c_groups = CEIL_DIV(model->config.channels, (WARP_SIZE * x128::size));
         assert((size_t)(model->batch_size * model->seq_len) * num_c_groups < (1ULL<<31ULL)); // todo - maybe an issue for llama3-400B(?)
@@ -1814,8 +1814,6 @@ int main(int argc, char *argv[]) {
             float grad_scale = (grad_norm > grad_clip) ? grad_clip / grad_norm : 1.0f;
             gpt2_update(&model, step_learning_rate, 0.9f, 0.95f, 1e-8f, weight_decay, grad_scale, step+1, &multi_gpu_config);
         }
-        // zero out the gradients for the next iteration
-        gpt2_zero_grad(&model);
         cudaCheck(cudaEventRecord(end));
         cudaCheck(cudaEventSynchronize(end)); // wait for the end event to finish to get correct timings
         // --------------- TRAINING SECTION END -------------------


### PR DESCRIPTION
We got a similar bug introduced for similar reasons in our main code as before in PyTorch code:
Due to the fact that zero grad happens after the backward step instead of immediately before we do backprop.

Here we have `gpt2_validate` that periodically runs before our training loop and "contaminates" the `model->acts.losses` which is part of our "grad state" and which we start depositing on top of in the backward pass (valid state is all zeros).

The reason we don't see the spike in the 0th step is because we run zero grad in the 0th step of the training inside the `gpt2_backward_and_reduce`, and set the grad state to correct state just before we run backprop.

Instead we should just always do it to protect the grad state from other parts of the code that can contaminate it. This makes the code more robust.