### PR TITLE
Fix eval dataloader div by zero for < 4 batch size

### DIFF
--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -339,7 +339,12 @@ void evalloader_init(EvalLoader *loader,
                      int num_processes) {
     loader->process_rank = process_rank;
     loader->num_processes = num_processes;
-    loader->B = B;
+    if (B < ASSUMED_NUM_COMPLETIONS) {
+        printf("WARNING: Batch size too small for evaluation, increasing from %d to %d\n", (int)B, ASSUMED_NUM_COMPLETIONS);
+        loader->B = ASSUMED_NUM_COMPLETIONS;
+    } else {
+        loader->B = B;
+    }
     loader->T = T;
 
     // open the file and validate the header


### PR DESCRIPTION
We need at least batch size of 4 to support the current eval logic.

Alternatively we can rewrite the eval a bit, but that's probably overengineering at this point?

Worst case that could happen is that due to this batch increase and the user missing the warning (classic :)) the training runs until we hit eval and then it crashes due to an OOM.