### PR TITLE
Add Habana gaudi2 tpc kernel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Lastly, I will be a lot more sensitive to complexity in the root folder of the p
 
 - Zig
   - [llm.zig](https://github.com/Saimirbaci/llm.zig) by @[saimirbaci](https://github.com/Saimirbaci): a Zig port of this project
+ 
+- Habana Gaudi2
+  - [llm.tpc](https://github.com/abhilash1910/llm.tpc) by @[abhilash1910](https://github.com/abhilash1910): a Habana Gaudi2 port of this project 
 
 ## discussions
 


### PR DESCRIPTION
From discussion #572 , supporting initial Habana Gaudi2 accelerator port of llm.c (TPC)
cc @karpathy 