### PR TITLE
Faster inference by changing (B,T) to (1,t)

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1733,7 +1733,7 @@ int main(int argc, char *argv[]) {
                 // on cuDNN 9.2.1 with cuDNN FrontEnd 1.5.2, T >= 256 seems bit-for-bit identical
                 // (but even if it wasn't fully identical that's probably not the end of the world)
                 // note this is still somewhat wasteful because we don't have a KV cache!
-                gpt2_forward(&model, gen_tokens, 1, CEIL_DIV(t, 256) * 256);
+                gpt2_forward(&model, gen_tokens, 1, CEIL_DIV(t, min(T,256)) * min(T,256));
                 // get the V-dimensional vector probs[0, t-1, :]
                 floatX* logits = model.acts.output + (t - 1) * model.config.padded_vocab_size;
                 // move probs back to CPU and sample (note we only move the first vocab_size logits, ignoring the padding)


### PR DESCRIPTION
The inference sanity checks currently process all (B,T) despite only needing (1,64) by default.

This PR is bit-for-bit identical to previous versions while reducing this to (1,t) where t is rounded up to the next multiple of 256 - that value was selected so cuDNN (currently) uses the same algorithm as for the full 1024, otherwise it might give slightly different results (which shouldn't matter in practice but it's a nice property to keep if we can, and it's still massively faster than our current inference path).

It also fixes a potential non-determinism issue for the non-CUDNN path in the process: [cudaMalloc does *not* clear the memory](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g37d37965bfb4803b6d4e59ff26856356), so in theory we might end up with a non-zeroed attention buffer, and our kernels only write the attention values above the diagonal (since the others are always 0 due to the causal mask - but without memset, these might end up non-zero). In practice, that memset might be redundant because I suspect NVIDIA does clear the memory for security reasons if it was previously used by another process, and we only do a single big allocation so there's nothing to reuse from our own process at that point - but that is very much undefined behaviour...

This is relevant because the values which we assume to be initialised to 0 depend on the value of T, so if we reduce T, then the att@v matmul might read non-zero values written by previous softmax_forward_kernel5() calls with larger values of T. This is fixed by adding a memset in the non-CUDNN path for that specific case (note that this is not required when increasing T back for the next training step).