### PR TITLE
Add GPT3 model series

### DIFF
--- a/scripts/multi_node/run_gpt2_124M_fs.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_fs.sbatch
@@ -74,7 +74,7 @@ srun -l -u bash -c "
     -u 700 \
     -n 5000 \
     -y 1 \
-    -e d12 \
+    -e gpt2:12 \
     -pn \$SLURM_NTASKS \
     -pr \$SLURM_PROCID \
     -pg \$SLURM_NTASKS_PER_NODE \

--- a/scripts/multi_node/run_gpt2_124M_mpi.sh
+++ b/scripts/multi_node/run_gpt2_124M_mpi.sh
@@ -45,5 +45,5 @@ mpirun -np 16 --host $host1:8,$host2:8 \
     -u 700 \
     -n 1000 \
     -y 0 \
-    -e d12 \
+    -e gpt2:12 \
     -pi "mpi" \

--- a/scripts/multi_node/run_gpt2_124M_tcp.sbatch
+++ b/scripts/multi_node/run_gpt2_124M_tcp.sbatch
@@ -75,7 +75,7 @@ srun -l -u bash -c "
     -u 700 \
     -n 5000 \
     -y 1 \
-    -e d12 \
+    -e gpt2:12 \
     -pn \$SLURM_NTASKS \
     -pr \$SLURM_PROCID \
     -pg \$SLURM_NTASKS_PER_NODE \

--- a/scripts/run_gpt2_124M.sh
+++ b/scripts/run_gpt2_124M.sh
@@ -36,7 +36,7 @@ while true; do
                 -u 700 \
                 -n 5000 \
                 -y 1 \
-                -e "d12"
+                -e "gpt2:12"
 
     sleep 1
 done

--- a/scripts/run_gpt2_1558M.sh
+++ b/scripts/run_gpt2_1558M.sh
@@ -37,7 +37,7 @@ while true; do
                 -x 32000 \
                 -ge 1 \
                 -y 1 \
-                -e "d48"
+                -e "gpt2:48"
 
     sleep 1
 done

--- a/scripts/run_gpt2_350M.sh
+++ b/scripts/run_gpt2_350M.sh
@@ -37,7 +37,7 @@ while true; do
                 -n 2000 \
                 -x 60000 \
                 -y 1 \
-                -e "d24"
+                -e "gpt2:24"
 
     sleep 1
 done

--- a/scripts/run_gpt2_774M.sh
+++ b/scripts/run_gpt2_774M.sh
@@ -37,7 +37,7 @@ while true; do
                 -n 4000 \
                 -x 286102 \
                 -y 1 \
-                -e "d36"
+                -e "gpt2:36"
 
     sleep 1
 done

--- a/scripts/run_gpt3_125M.sh
+++ b/scripts/run_gpt3_125M.sh
@@ -1,5 +1,5 @@
-# GPT-3 (124M) repro on FineWeb
-# 124M parameter model on 300B tokens
+# GPT-3 (125M) repro on FineWeb
+# 125M parameter model on 300B tokens
 # note context length: 1024 -> 2048 for GPT-3
 # => 6 * 124e6 * 300e9 = 7.44e18 ~= 2.2e20 capability model
 # 565,950 steps of 524,288 tokens/step
@@ -37,7 +37,7 @@ while true; do
                 -n 10000 \
                 -y 1 \
                 -x 565950 \
-                -e "d12"
+                -e "gpt3:768"
 
     sleep 1
 done


### PR DESCRIPTION
While GPT3 models are not uniquely identified by their _depth_, there is a one-to-one mapping of model parameter count to model _width_. This makes the specifications a bit inconsistent, as a 12-layer gpt2 model is `gpt2:12`, but for gpt3 it is `gpt3:768`, but we can get away with a single number.

Additionally, the changes enable interpolating of model sizes, so that one can adapt the number of parameters to the available GPU memory (this is not necessarily smooth, though, because interpolation adjusts just one parameter, whereas the others have discontinuous jumps based on the pre-defined models).