### PR TITLE
Add a README link under related related projects for gpu.cpp under WebGPU C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ Lastly, I will be a lot more sensitive to complexity in the root folder of the p
   - [llm.cpp](https://github.com/gevtushenko/llm.c) by @[gevtushenko](https://github.com/gevtushenko): a port of this project using the [CUDA C++ Core Libraries](https://github.com/NVIDIA/cccl)
      - A presentation this fork was covered in [this lecture](https://www.youtube.com/watch?v=WiB_3Csfj_Q) in the [CUDA MODE Discord Server](https://discord.gg/cudamode)
 
+- WebGPU C++
+  - [gpu.cpp](https://github.com/AnswerDotAI/gpu.cpp) by @[austinvhuang](https://github.com/austinvhuang): a library for portable GPU compute in C++ using native WebGPU. Aims to be a general-purpose library, but also porting llm.c kernels to WGSL.
+
 - Go
   - [llm.go](https://github.com/joshcarp/llm.go) by @[joshcarp](https://github.com/joshcarp): a Go port of this project
 


### PR DESCRIPTION
Add a README link under related related projects for gpu.cpp under WebGPU C++.

For background - gpu.cpp is a new project I've been working on. It's a small library for writing portable GPU code in C++ that works across vendors by using a native (ie non-browser) WebGPU implementation (Dawn from Google).  It aims to be a general-purpose library, but will also port the `dev/cuda` kernels to make llm.c kernels broadly available as WebGPU kernels using the WebGPU Shading Language (WGSL).

Some relevant discussion here: https://github.com/karpathy/llm.c/discussions/670