### PR TITLE
Update README.md with prerequisite of libomp

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ make train_gpt2
 OMP_NUM_THREADS=8 ./train_gpt2
 ```
 
+Note that to be able to train on multiple CPU cores, you will need to install `libomp` before `make train_gpt2` by running:
+ - On Linux:
+    ```bash
+    sudo apt-get update && sudo apt-get install -y libomp-dev
+    ```
+ - On MacOS X:
+    ```bash
+    brew install libomp
+    ```
+
 If you'd prefer to avoid running the starter pack script, then as mentioned in the previous section you can reproduce the exact same .bin files and artifacts by running `python dev/data/tinyshakespeare.py` and then `python train_gpt2.py`.
 
 The above lines (1) download an already tokenized [tinyshakespeare](https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt) dataset and download the GPT-2 (124M) weights, (3) init from them in C and train for 40 steps on tineshakespeare with AdamW (using batch size 4, context length only 64), evaluate validation loss, and sample some text. Honestly, unless you have a beefy CPU (and can crank up the number of OMP threads in the launch command), you're not going to get that far on CPU training LLMs, but it might be a good demo/reference. The output looks like this on my MacBook Pro (Apple Silicon M3 Max):


### PR DESCRIPTION
I followed README.me to `train_gpt2` with CPU on my Macbook and found there is only one core was actively training. After digging a bit I found that I need to install `libomp` locally.

Updating README.md to prepare users to this reprequisite. The Linux and MacOS commands were copied form `.github/workflows/ci.yml`.