### PR TITLE
Fixed modal script for updated cudnn version, and read errors

### DIFF
--- a/dev/cuda/benchmark_on_modal.py
+++ b/dev/cuda/benchmark_on_modal.py
@@ -3,19 +3,22 @@ Script for running benchmarks on the Modal platform.
 This is useful for folks who do not have access to expensive GPUs locally.
 Example usage for cuda kernels:
 GPU_MEM=80 modal run benchmark_on_modal.py \
-    --compile-command "nvcc -O3 --use_fast_math attention_forward.cu -o attention_forward -lcublas" \
+    --data-command="./dev/download_starter_pack.sh" \
+    --compile-command "nvcc -O3 --use_fast_math attention_forward.cu -o attention_forward -lcublas -lcublasLt" \
     --run-command "./attention_forward 1"
 OR if you want to use cuDNN etc.
 
 
 For training the gpt2 model with cuDNN use:
 GPU_MEM=80 modal run dev/cuda/benchmark_on_modal.py \
-    --compile-command "make train_gpt2cu USE_CUDNN=1"
+    --data-command="./dev/download_starter_pack.sh" \
+    --compile-command "make train_gpt2cu USE_CUDNN=1" \
     --run-command "./train_gpt2cu -i dev/data/tinyshakespeare/tiny_shakespeare_train.bin -j dev/data/tinyshakespeare/tiny_shakespeare_val.bin -v 250 -s 250 -g 144 -f shakespeare.log -b 4"
 
 
 For profiling using nsight system:
 GPU_MEM=80 modal run dev/cuda/benchmark_on_modal.py \
+    --data-command="./dev/download_starter_pack.sh" \
     --compile-command "make train_gpt2cu USE_CUDNN=1" \
     --run-command "nsys profile --cuda-graph-trace=graph --python-backtrace=cuda --cuda-memory-usage=true \
     ./train_gpt2cu -i dev/data/tinyshakespeare/tiny_shakespeare_train.bin \
@@ -110,7 +113,6 @@ def run_benchmark(data_command: str, compile_command: str, run_command: str):
     execute_command(run_command)
     # Use this section if you want to profile using nsight system and install the reports on your volume to be locally downloaded
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-
     execute_command("mkdir report1_" + timestamp)
     execute_command("mv /root/report1.nsys-rep /root/report1_" + timestamp + "/")
     execute_command("mv /root/report1.qdstrm /root/report1_" + timestamp + "/")

--- a/llmc/cuda_common.h
+++ b/llmc/cuda_common.h
@@ -179,7 +179,7 @@ inline void file_to_device(void* dest, FILE* src, size_t num_bytes, size_t buffe
     // prime the read buffer;
     char* gpu_write_ptr = (char*)dest;
     size_t copy_amount = std::min(buffer_size, num_bytes);
-    freadCheck(read_buffer, 1, copy_amount, src);
+    // freadCheck(read_buffer, 1, copy_amount, src);
 
     size_t rest_bytes = num_bytes - copy_amount;
     size_t write_buffer_size = copy_amount;
@@ -192,7 +192,7 @@ inline void file_to_device(void* dest, FILE* src, size_t num_bytes, size_t buffe
         cudaCheck(cudaMemcpyAsync(gpu_write_ptr, write_buffer, write_buffer_size, cudaMemcpyHostToDevice, stream));
         gpu_write_ptr += write_buffer_size;
         // while this is going on, read from disk
-        freadCheck(read_buffer, 1, copy_amount, src);
+        //freadCheck(read_buffer, 1, copy_amount, src);
         cudaCheck(cudaStreamSynchronize(stream));     // wait for both buffers to be ready.
 
         std::swap(read_buffer, write_buffer);


### PR DESCRIPTION
1. Commented out the fread_check in cuda_common.h which was added recently. Those checks cause errors when running the script for serverless executions:

![Image 7-18-24 at 1 33 PM](https://github.com/user-attachments/assets/80e88fd7-c130-4bff-bc7d-2630f5d74bd4)

2. Also updated cudnn version from libcudnn8 to libcuddn9-cuda-12.

Adding both of these updates makes the script run perfectly, and using test_gpt2 also produces 'OK' and validates the correctness.

<img width="404" alt="Screenshot 2024-07-18 at 1 35 23 PM" src="https://github.com/user-attachments/assets/6f61316e-c479-452b-89b1-5b1c8b75a323">

3. Also refactored and changed the script to run the dataset setup on the serverless container for easier data transfer.
