### PR TITLE
Fix integer overflow by using `size_t` for parameter sizes.

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -563,7 +563,7 @@ void gpt_build_from_descriptor(GPT2 *model, const char* descriptor) {
             // weights tensors are handled here
             if ((l == 0 && (i == 0 || i == 1)) // only at l = 0, init the wte and wpe tensors
               || i == 4 || i == 6 || i == 10 || i == 12) {
-                int n = model->param_elements[i];
+                size_t n = model->param_elements[i];
                 size_t layer_offset = 0;
                 if (i == 0) {
                     // for wte tensor (padded vocab) override to init V instead of Vp rows


### PR DESCRIPTION
Due to some parameters in the GPT-2 7.3B model being quite large, the current `llm.c` code has integer overflow issues. This is because it uses a 32-bit `int` to store the number of bytes for weights and perform `malloc` operations. These large values exceed the maximum value that a 32-bit `int` can hold, causing overflow.

This PR changes to use `size_t` in `gpt_build_from_descriptor`, making the type consistent with `param_elements` in the code: https://github.com/karpathy/llm.c/blob/72698a5ba32482789fb3b14fcff8b6b6d20931d9/train_gpt2.cu#L313
