### PR TITLE
Restore from master weights (& allow restoring from a checkpoint of different precision)

### DIFF
--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1076,7 +1076,8 @@ void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, flo
             // this is only run when resuming training from a checkpoint with master weights
             // it allows us to restart training with a different precision amongst other things
             assert(master_ptr != NULL);
-            params_from_master(param_ptr, master_ptr, shard.size, seed, true);
+            params_from_master(param_ptr, master_ptr,
+                               shard.size, tensor.size, shard.size, num_layers, seed, main_stream);
         } else {
             // ok finally call the kernel to update the weights with AdamW
             adamw_update(param_ptr, master_ptr, grad_ptr,
@@ -1553,10 +1554,10 @@ int main(int argc, char *argv[]) {
     gpt2_init_common(&model);
     if (resuming == 1) {
         // if `-y 1` was set, then we are resuming from the latest checkpoint
-        gpt2_build_from_checkpoint(&model, filename_buffer);
+        gpt2_build_from_checkpoint(&model, filename_buffer, true);
     } else if (ends_with_bin(load_filename)) {
         // otherwise, if this is a .bin file, we assume it's a model, let's init from it
-        gpt2_build_from_checkpoint(&model, load_filename, true);
+        gpt2_build_from_checkpoint(&model, load_filename);
     } else {
         // if it's not .bin, it could be a "special descriptor". This descriptor is used to
         // construct GPT-2 / GPT-3 models in a convenient format. See the function for docs.

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -462,16 +462,20 @@ void gpt2_build_from_checkpoint(GPT2 *model, const char* checkpoint_path, bool r
         fprintf(stderr, "---> HINT: try to re-run `python train_gpt2.py`\n");
         exit(EXIT_FAILURE);
     }
-    if (PRECISION_MODE == PRECISION_BF16 && version != 5) {
-        fprintf(stderr, "Precision is configured as BF16 but model at %s is not.\n", checkpoint_path);
-        fprintf(stderr, "---> HINT: are you sure you're loading a _bf16.bin file?\n");
-        exit(EXIT_FAILURE);
-    }
-    if (PRECISION_MODE == PRECISION_FP32 && version != 3) {
-        fprintf(stderr, "Precision is configured as FP32 but model at %s is not.\n", checkpoint_path);
-        fprintf(stderr, "---> HINT: to turn on FP32 you have to compile like: `make train_gpt2cu PRECISION=FP32`\n");
-        fprintf(stderr, "---> HINT: are you sure you're loading a .bin file without any _bf16 in the name?\n");
-        exit(EXIT_FAILURE);
+
+    // check if the precision mode matches the model (don't care if restoring from master weights!)
+    if (!resuming || !model->use_master_weights) {
+        if (PRECISION_MODE == PRECISION_BF16 && version != 5) {
+            fprintf(stderr, "Precision is configured as BF16 but model at %s is not.\n", checkpoint_path);
+            fprintf(stderr, "---> HINT: are you sure you're loading a _bf16.bin file?\n");
+            exit(EXIT_FAILURE);
+        }
+        if (PRECISION_MODE == PRECISION_FP32 && version != 3) {
+            fprintf(stderr, "Precision is configured as FP32 but model at %s is not.\n", checkpoint_path);
+            fprintf(stderr, "---> HINT: to turn on FP32 you have to compile like: `make train_gpt2cu PRECISION=FP32`\n");
+            fprintf(stderr, "---> HINT: are you sure you're loading a .bin file without any _bf16 in the name?\n");
+            exit(EXIT_FAILURE);
+        }
     }
 
     // read in hyperparameters

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1077,11 +1077,9 @@ void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, flo
         }
 
         if (init_from_master_only) {
-            // this is only run when resuming training from a checkpoint with master weights
-            // it allows us to restart training with a different precision amongst other things
-            assert(master_ptr != NULL);
-            params_from_master(param_ptr, master_ptr,
-                               shard.size, tensor.size, shard.size, num_layers, seed, main_stream);
+            // when resuming training from a checkpoint with master weights
+            init_from_master(param_ptr, master_ptr,
+                             shard.size, tensor.size, shard.size, num_layers, seed, main_stream);
         } else {
             // ok finally call the kernel to update the weights with AdamW
             adamw_update(param_ptr, master_ptr, grad_ptr,


### PR DESCRIPTION
This is fully deterministic for new checkpoints where the new rng_state_last_update is saved, so that stochastic rounding from master weights is done with the exact same seeds (while restoring the actual final rng_state again afterwards, in case anything else changed it between that update and saving the checkpoint).

In the case where we are resuming from a checkpoint (not just a regular model file) and we have master weights, this simply skips loading the weights from the checkpoint completely, so it doesn't matter if they are not even the right number of bytes.

It should be useful to check if FP32 helps with runs exploding, and going forward it will allow FP8 runs to not care too much about what format the non-master weights are saved, so we don't need to worry about changes breaking compatibility etc...