### PR TITLE
Allocate managed memory if device memory runs out

### DIFF
--- a/llmc/cuda_common.h
+++ b/llmc/cuda_common.h
@@ -49,13 +49,13 @@ constexpr std::bool_constant<true> False;
 // Error checking
 
 // CUDA error checking
-inline void cudaCheck(cudaError_t error, const char *file, int line) {
+inline void cudaCheck_(cudaError_t error, const char *file, int line) {
   if (error != cudaSuccess) {
     printf("[CUDA ERROR] at file %s:%d:\n%s\n", file, line, cudaGetErrorString(error));
     exit(EXIT_FAILURE);
   }
 };
-#define cudaCheck(err) (cudaCheck(err, __FILE__, __LINE__))
+#define cudaCheck(err) (cudaCheck_(err, __FILE__, __LINE__))
 
 // like cudaFree, but checks for errors _and_ resets the pointer.
 template<class T>

--- a/llmc/cuda_utils.cuh
+++ b/llmc/cuda_utils.cuh
@@ -222,6 +222,7 @@ void cudaMallocConditionallyManaged(void** out, size_t bytes, const char *file, 
         // reset the error before the next API call
         cudaGetLastError();
         cudaCheck_(cudaMallocManaged(out, bytes), file, line);
+        cudaCheck_(cudaMemAdvise(*out, bytes, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId), file, line);
     } else {
         cudaCheck_(err, file, line);
     }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -393,13 +393,13 @@ void gpt2_allocate_state(GPT2 *model, int B, int T) {
     printf0("allocating %zu MiB for AdamW optimizer state v\n", (shard_num_parameters * sizeof(float)) >> 20);
     assert(model->m_memory == nullptr);
     assert(model->v_memory == nullptr);
-    cudaCheck(cudaMalloc((void**)&model->m_memory, shard_num_parameters * sizeof(float)));
-    cudaCheck(cudaMalloc((void**)&model->v_memory, shard_num_parameters * sizeof(float)));
+    cudaMallocConditionallyManaged((void**)&model->m_memory, shard_num_parameters * sizeof(float));
+    cudaMallocConditionallyManaged((void**)&model->v_memory, shard_num_parameters * sizeof(float));
 
     if (model->use_master_weights == 1) {
         assert(model->master_weights == nullptr);
         printf0("allocating %zu MiB for master copy of params\n", (shard_num_parameters * sizeof(float)) >> 20);
-        cudaCheck(cudaMalloc((void**) &model->master_weights, shard_num_parameters * sizeof(float)));
+        cudaMallocConditionallyManaged((void**) &model->master_weights, shard_num_parameters * sizeof(float));
     }
 
     size_t free, total;


### PR DESCRIPTION
Use cudaMallocManaged to allocate optimizer states if we run out of device memory, so we can still train (slowly) even if we cannot fit the optimizer state
This is based on #694 , which should be merged first