### PR TITLE
Outlier detection: catch more outliers by not updating moving average with skipped updates

### DIFF
--- a/llmc/outlier_detector.h
+++ b/llmc/outlier_detector.h
@@ -13,12 +13,13 @@ reconsider this choice in the future, as the compute cost here is minimal.
 #include <math.h>
 
 // use compile-time constant for window size to avoid dynamic memory allocations
-#define OUTLIER_DETECTOR_WINDOW_SIZE 128
+#define OUTLIER_DETECTOR_WINDOW_SIZE 64
 
 typedef struct {
     double buffer[OUTLIER_DETECTOR_WINDOW_SIZE];
     int count;
     int index;
+    int skipped_in_a_row;
     double sum;
     double sum_sq;
 } OutlierDetector;
@@ -33,13 +34,14 @@ void init_detector(OutlierDetector *detector) {
     detector->sum_sq = 0.0;
 }
 
-double update_detector(OutlierDetector *detector, double new_value) {
+double update_detector(OutlierDetector *detector, double new_value, double skip_update_threshold) {
 
     if (detector->count < OUTLIER_DETECTOR_WINDOW_SIZE) {
         // here we are still building up a window of observations
         detector->buffer[detector->count] = new_value;
         detector->sum += new_value;
         detector->sum_sq += new_value * new_value;
+        detector->skipped_in_a_row = 0;
         detector->count++;
         return nan(""); // not enough data yet
 
@@ -64,6 +66,22 @@ double update_detector(OutlierDetector *detector, double new_value) {
             return 0.0;
         }
         double z = (new_value - mean) / std_dev;
+
+        if (skip_update_threshold != 0.0 && z > skip_update_threshold) {
+            // let's go back in time and pretend this never happened
+            // i.e. don't let bad outliers affect the threshold for detecting future outliers
+            // otherwise the detector will get less picky and accept things it really shouldn't!
+            // but we do update on the 3rd consecutive outlier, to avoid getting stuck completely
+            detector->skipped_in_a_row++;
+            if (detector->skipped_in_a_row < 3) {
+                detector->sum += old_value - new_value;
+                detector->sum_sq += (old_value * old_value) - (new_value * new_value);
+                detector->buffer[detector->index] = old_value;
+                detector->index = (detector->index - 1) % OUTLIER_DETECTOR_WINDOW_SIZE;
+            }
+        } else {
+            detector->skipped_in_a_row = 0;
+        }
 
         return z;
     }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -1791,12 +1791,12 @@ int main(int argc, char *argv[]) {
             // backward pass. all model params accumulate gradients with += inside this inner loop
             gpt2_backward_and_reduce(&model, train_loader.inputs, train_loader.targets, grad_accum_steps, micro_step);
         }
-        float zloss = (float)(update_detector(&loss_outlier_detector, (double)model.mean_loss)); // loss z-score
+        float zloss = (float)(update_detector(&loss_outlier_detector, (double)model.mean_loss, (double)skip_update_lossz)); // loss z-score
         // fetch the next learning rate
         float step_learning_rate = get_learning_rate(&lr_scheduler, step);
         // calculate the gradient norm and how much we wish to scale the gradient
         float grad_norm = gpt2_calculate_grad_norm(&model, &multi_gpu_config);
-        float zgrad = (float)(update_detector(&grad_norm_outlier_detector, (double)grad_norm)); // grad z-score
+        float zgrad = (float)(update_detector(&grad_norm_outlier_detector, (double)grad_norm, (double)skip_update_gradz)); // grad z-score
         // update the model parameters
         if (isfinite(zloss) && skip_update_lossz != 0.0f && zloss > skip_update_lossz) {
             printf0("skipping update due to loss z-score of %f\n", zloss);


### PR DESCRIPTION
This is an improvement to the znorm/zgrad update skipping mechanisms (-sl and -sg) to avoid skipping updates for outliers. Note that znorm will still be updated if zgrad is an outlier that causes the update to be skipped (and vice-versa), but that shouldn't matter much.

Combined with "-sg 5" my intuition is that this should significantly improve stability (famous last words...) - we should still try to root cause the instability as much as possible after that of course.