### PR TITLE
Faster GELU forward & backward using MUFU.TANH for SM7.5+

### DIFF
--- a/llmc/gelu.cuh
+++ b/llmc/gelu.cuh
@@ -18,30 +18,47 @@ __global__ void gelu_forward_kernel2(floatX* out, const floatX* inp) {
     for(int k = 0; k < packed_inp.size; ++k) {
         float xi = (float)packed_inp[k];
         float cube = 0.044715f * xi * xi * xi;
-        packed_out[k] = (floatX)(0.5f * xi * (1.0f + tanhf(GELU_SCALING_FACTOR * (xi + cube))));
+
+        float tanh_in_out = GELU_SCALING_FACTOR * (xi + cube);
+        #if !defined(PRECISE_GELU_TANH) && __CUDA_ARCH__ >= 750
+        asm ("tanh.approx.f32 %0,%1;" : "=f"(tanh_in_out) : "f"(tanh_in_out));
+        #else
+        tanh_in_out = tanhf(tanh_in_out);
+        #endif
+
+        // the following uses FMUL+FMA instead of FMUL+FADD+FMUL for "0.5f * x * (1.0f + tanh_out)"
+        float half_xi = 0.5f * xi;
+        packed_out[k] = (floatX)(half_xi * tanh_in_out + half_xi);
     }
     // store instead of storecs (without cache streaming) in case it is useful for the
     // data to be in the cache for the next operation after this GeLU
     store128(out + idx, packed_out);
 }
 
-__global__ void gelu_backward_inplace_kernel(floatX* d_in_out, const floatX* inp) {
-    int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
+template <typename Ti, typename Tdout, typename Tdinp>
+__global__ void gelu_backward_kernel(Tdinp* dinp, const Tdout* dout, const Ti* inp) {
+    int idx = (blockIdx.x * blockDim.x + threadIdx.x) * Packed128<Tdout>::size;
 
-    x128 packed_dinp;
-    x128 packed_inp = load128cs(inp + idx);
-    x128 packed_dout = load128(d_in_out + idx);
-    for (int k = 0; k < packed_inp.size; ++k) {
+    Packed128<Tdinp> packed_dinp;
+    Packed128<Ti> packed_inp = load128cs(inp + idx);
+    Packed128<Tdout> packed_dout = load128(dout + idx);
+    for (int k = 0; k < Packed128<Tdout>::size; ++k) {
         float x = (float)packed_inp[k];
         float cube = 0.044715f * x * x * x;
-        float tanh_arg = GELU_SCALING_FACTOR * (x + cube);
-        float tanh_out = tanhf(tanh_arg);
-        float coshf_out = coshf(tanh_arg);
-        float sech_out = 1.0f / (coshf_out * coshf_out);
-        float local_grad = 0.5f * (1.0f + tanh_out) + x * 0.5f * sech_out * GELU_SCALING_FACTOR * (1.0f + 3.0f * 0.044715f * x * x);
-        packed_dinp[k] = (floatX)(local_grad * (float)packed_dout[k]);
+
+        float tanh_in_out = GELU_SCALING_FACTOR * (x + cube);
+        #if !defined(PRECISE_GELU_TANH) && __CUDA_ARCH__ >= 750
+        asm ("tanh.approx.f32 %0,%1;" : "=f"(tanh_in_out) : "f"(tanh_in_out));
+        #else
+        tanh_in_out = tanhf(tanh_in_out);
+        #endif
+
+        float sech_out = 1.0f - (tanh_in_out * tanh_in_out);
+        float local_grad = 0.5f * ((1.0f + tanh_in_out) + x * sech_out * GELU_SCALING_FACTOR * (1.0f + 3.0f * 0.044715f * x * x));
+        float result = local_grad * (float)packed_dout[k];
+        packed_dinp[k] = (Tdinp)(result);
     }
-    store128(d_in_out + idx, packed_dinp);
+    store128(dinp + idx, packed_dinp);
 }
 
 // ----------------------------------------------------------------------------
@@ -61,6 +78,6 @@ void gelu_backward_inplace(floatX* d_in_out, const floatX* inp, const int N, cud
     const int block_size = 128;
     assert(N % (block_size * x128::size) == 0);
     const int grid_size = CEIL_DIV(N, block_size * x128::size);
-    gelu_backward_inplace_kernel<<<grid_size, block_size, 0, stream>>>(d_in_out, inp);
+    gelu_backward_kernel<<<grid_size, block_size, 0, stream>>>(d_in_out, d_in_out, inp);
     cudaCheck(cudaGetLastError());
 }


### PR DESCRIPTION
These are faster GELU kernels by using the HW instruction NVIDIA introduced for this in Turing (SM7.5) but never exposed outside of PTX as far as I can tell, possibly because it's slightly less accurate - but based on the val loss we get which is slightly *better* for the backwards pass (and within noise for forward), I am pretty sure it's fine for our purposes!

This is only somewhat faster on H100 PCIe but should be much faster on H200/Blackwell as they have more DRAM bandwidth relative to compute, and also much faster with FP8 (this was originally done in the context of the FP8 branch where it was >50% faster!)

This also includes the change for backward suggested in #307 

Included the changes in /dev/cuda/ as well:
```
FORWARD PASS - BEFORE
block_size   32 | time 0.0311 ms | bandwidth 810.06 GB/s
block_size   64 | time 0.0277 ms | bandwidth 907.20 GB/s
block_size  128 | time 0.0277 ms | bandwidth 908.80 GB/s
block_size  256 | time 0.0277 ms | bandwidth 907.33 GB/s
block_size  512 | time 0.0281 ms | bandwidth 895.78 GB/s
block_size 1024 | time 0.0307 ms | bandwidth 819.99 GB/s

FORWARD PASS - AFTER
block_size   32 | time 0.0310 ms | bandwidth 810.72 GB/s
block_size   64 | time 0.0271 ms | bandwidth 927.50 GB/s
block_size  128 | time 0.0271 ms | bandwidth 928.29 GB/s
block_size  256 | time 0.0271 ms | bandwidth 928.59 GB/s
block_size  512 | time 0.0274 ms | bandwidth 919.46 GB/s
block_size 1024 | time 0.0288 ms | bandwidth 872.31 GB/s

BACKWARD PASS - BEFORE
block_size   32 | time 0.0417 ms | bandwidth 1207.47 GB/s
block_size   64 | time 0.0402 ms | bandwidth 1252.53 GB/s
block_size  128 | time 0.0403 ms | bandwidth 1249.39 GB/s
block_size  256 | time 0.0403 ms | bandwidth 1248.84 GB/s
block_size  512 | time 0.0404 ms | bandwidth 1246.94 GB/s
block_size 1024 | time 0.0407 ms | bandwidth 1235.60 GB/s

BACKWARD PASS - AFTER
block_size   32 | time 0.0333 ms | bandwidth 1509.47 GB/s
block_size   64 | time 0.0325 ms | bandwidth 1546.38 GB/s
block_size  128 | time 0.0326 ms | bandwidth 1545.97 GB/s
block_size  256 | time 0.0326 ms | bandwidth 1542.07 GB/s
block_size  512 | time 0.0329 ms | bandwidth 1531.70 GB/s
block_size 1024 | time 0.0351 ms | bandwidth 1433.92 GB/s
```

In terms of loss for a few steps of Tiny Shakespeare, 'make train_gpt2cu && ./train_gpt2cu -r 0 -ge 0 -e "d12"' gives:
```
BEFORE
step   74/74 | loss 5.935039 (+nanz)| norm 1.2940 (+nanz)| lr 3.00e-04 | 28.42 ms | 15.3% bf16 MFU | 144989 tok/s
val loss 5.955256

AFTER
step   74/74 | loss 5.920402 (+nanz)| norm 1.2239 (+nanz)| lr 3.00e-04 | 27.98 ms | 15.6% bf16 MFU | 146466 tok/s
val loss 5.948031
```

so actually slightly better (but potentially noise)! Using the new backward but the old forward pass gives a val loss of 5.942228, but again, it might be noise. Either way looks to be good enough as far as I can tell!

I believe this NVIDIA forum thread (and a few others) talk a little bit about this HW instruction: https://forums.developer.nvidia.com/t/hardware-accelerated-tanh-on-turing/173291