### PR TITLE
Improve compile time (simple makefile changes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ ifneq ($(CI),true) # if not in CI, then use the GPU query
   ifndef GPU_COMPUTE_CAPABILITY # set to defaults if: make GPU_COMPUTE_CAPABILITY=
     ifneq ($(call file_exists_in_path, nvidia-smi),)
       GPU_COMPUTE_CAPABILITY = $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g')
-      GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query)
       GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
     endif
   endif

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ REMOVE_FILES = rm -f
 OUTPUT_FILE = -o $@
 CUDA_OUTPUT_FILE = -o $@
 
+# Default O3 CPU optimization level for NVCC (0 for fastest compile time)
+FORCE_NVCC_O ?= 3
+
 # NVCC flags
 # -t=0 is short for --threads, 0 = number of CPUs on the machine
-NVCC_FLAGS = -O3 -t=0 --use_fast_math -std=c++17
+NVCC_FLAGS = --threads=0 -t=0 --use_fast_math -std=c++17 -O$(FORCE_NVCC_O)
 NVCC_LDFLAGS = -lcublas -lcublasLt
 NVCC_INCLUDES =
 NVCC_LDLIBS =
@@ -45,7 +48,8 @@ endif
 
 ifneq ($(CI),true) # if not in CI, then use the GPU query
   ifndef GPU_COMPUTE_CAPABILITY # set to defaults if: make GPU_COMPUTE_CAPABILITY=
-    ifneq ($(call file_exists_in_path, __nvcc_device_query),)
+    ifneq ($(call file_exists_in_path, nvidia-smi),)
+      GPU_COMPUTE_CAPABILITY = $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g')
       GPU_COMPUTE_CAPABILITY = $(shell __nvcc_device_query)
       GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
     endif


### PR DESCRIPTION
This improves compile times by:
1) Using nvidia-smi instead of __nvcc_device_query (the latter was wasting >1 second per build on a 1xH100 system!)
2) "--threads=0" allowss NVCC to use multithreading for some things (seems to improve compile times by ~5% locally.)
3) Making -O3 configurable with the FORCE_NVCC_O parameter (O0 improves compile times by >30% but significantly hurts run times; -O1 seems like a good compromise when iterating on some code.)

(1) and (2) reduce compile time with cuDNN from ~9.2s to ~8.1s.
(3) with O2/O1/O0 reduces it further to ~7.7s / ~6.5s / ~5.4s.