### PR TITLE
Add SwiGLU support - llama3 feature branch

### DIFF
--- a/llmc/gelu.cuh
+++ b/llmc/gelu.cuh
@@ -48,17 +48,19 @@ __global__ void swiglu_forward_kernel(floatX* out, const floatX* inp1, const flo
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
 
     x128 packed_out;
-    x128 packed_inp1 = load128cs(inp1 + idx);
+    x128 packed_inp1 = load128cs(inp1 + idx); // load and do not keep in cache
     x128 packed_inp2 = load128cs(inp2 + idx);
     for(int k = 0; k < packed_inp1.size; ++k) {
         float x1 = (float)packed_inp1[k];
         float x2 = (float)packed_inp2[k];
+        // swish(x1) = x1 * sigmoid(x1) = x1 / (1.0 + exp(-x1))
+        // swiglu(x1, x2) = swish(x1) * x2
         packed_out[k] = (floatX)((x1 * x2) / (1.0f + expf(-x1)));
     }
     store128(out + idx, packed_out);
 }
 
-__global__ void swiglu_backward_kernel(floatX* dinp_out1, floatX* dinp2, const floatX* inp1, const floatX* inp2) {
+__global__ void swiglu_backward_inplace_kernel(floatX* dinp_out1, floatX* dinp2, const floatX* inp1, const floatX* inp2) {
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
 
     x128 packed_dinp1;
@@ -70,6 +72,10 @@ __global__ void swiglu_backward_kernel(floatX* dinp_out1, floatX* dinp2, const f
         float x1 = (float)packed_inp1[k];
         float x2 = (float)packed_inp2[k];
         float sig_x1 = 1.0f / (1.0f + expf(-x1));
+        // swiglu(x1, x2) = swish(x1) * x2
+        // -> dout/dx1 = x2 * sigmoid(x1) + x2 * x1 * sigmoid(x1) * (1 - sigmoid(x1))
+        // ---> dout/dx1 = x2 * sigmoid(x1) * (1 + x1 * (1 - sigmoid(x1)))
+        // -> dout/dx2 = swish(x1) = x1 * sigmoid(x1)
         float local_grad1 = x2 * sig_x1 * (1.0f + x1 * (1.0f - sig_x1));
         float local_grad2 = x1 * sig_x1;
         packed_dinp1[k] = (floatX)(local_grad1 * (float)packed_dinp_out1[k]);
@@ -114,6 +120,6 @@ void swiglu_backward_inplace(floatX* dinp_out1, floatX* dinp2, const floatX* inp
     const int block_size = 128;
     assert(N % (block_size * x128::size) == 0);
     const int grid_size = CEIL_DIV(N, block_size * x128::size);
-    swiglu_backward_kernel<<<grid_size, block_size, 0, stream>>>(dinp_out1, dinp2, inp1, inp2);
+    swiglu_backward_inplace_kernel<<<grid_size, block_size, 0, stream>>>(dinp_out1, dinp2, inp1, inp2);
     cudaCheck(cudaGetLastError());
 }

--- a/llmc/gelu.cuh
+++ b/llmc/gelu.cuh
@@ -25,20 +25,6 @@ __global__ void gelu_forward_kernel2(floatX* out, const floatX* inp) {
     store128(out + idx, packed_out);
 }
 
-__global__ void swiglu_forward_kernel(floatX* out, const floatX* inp1, const floatX* inp2) {
-    int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
-
-    x128 packed_out;
-    x128 packed_inp1 = load128cs(inp1 + idx);
-    x128 packed_inp2 = load128cs(inp2 + idx);
-    for(int k = 0; k < packed_inp1.size; ++k) {
-        float x1 = (float)packed_inp1[k];
-        float x2 = (float)packed_inp2[k];
-        packed_out[k] = (floatX)((x1 * x2) / (1.0f + expf(-x1)));
-    }
-    store128(out + idx, packed_out);
-}
-
 __global__ void gelu_backward_inplace_kernel(floatX* d_in_out, const floatX* inp) {
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
 
@@ -56,6 +42,41 @@ __global__ void gelu_backward_inplace_kernel(floatX* d_in_out, const floatX* inp
         packed_dinp[k] = (floatX)(local_grad * (float)packed_dout[k]);
     }
     store128(d_in_out + idx, packed_dinp);
+}
+
+__global__ void swiglu_forward_kernel(floatX* out, const floatX* inp1, const floatX* inp2) {
+    int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
+
+    x128 packed_out;
+    x128 packed_inp1 = load128cs(inp1 + idx);
+    x128 packed_inp2 = load128cs(inp2 + idx);
+    for(int k = 0; k < packed_inp1.size; ++k) {
+        float x1 = (float)packed_inp1[k];
+        float x2 = (float)packed_inp2[k];
+        packed_out[k] = (floatX)((x1 * x2) / (1.0f + expf(-x1)));
+    }
+    store128(out + idx, packed_out);
+}
+
+__global__ void swiglu_backward_kernel(floatX* dinp_out1, floatX* dinp2, const floatX* inp1, const floatX* inp2) {
+    int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
+
+    x128 packed_dinp1;
+    x128 packed_dinp2;
+    x128 packed_inp1 = load128cs(inp1 + idx);
+    x128 packed_inp2 = load128cs(inp2 + idx);
+    x128 packed_dinp_out1 = load128(dinp_out1 + idx);
+    for (int k = 0; k < packed_inp1.size; ++k) {
+        float x1 = (float)packed_inp1[k];
+        float x2 = (float)packed_inp2[k];
+        float sig_x1 = 1.0f / (1.0f + expf(-x1));
+        float local_grad1 = x2 * sig_x1 * (1.0f + x1 * (1.0f - sig_x1));
+        float local_grad2 = x1 * sig_x1;
+        packed_dinp1[k] = (floatX)(local_grad1 * (float)packed_dinp_out1[k]);
+        packed_dinp2[k] = (floatX)(local_grad2 * (float)packed_dinp_out1[k]);
+    }
+    store128(dinp_out1 + idx, packed_dinp1);
+    store128(dinp2 + idx, packed_dinp2);
 }
 
 // ----------------------------------------------------------------------------
@@ -85,5 +106,14 @@ void swiglu_forward(floatX* out, const floatX* inp1, const floatX* inp2, int N, 
     assert(N % (block_size * x128::size) == 0);
     const int grid_size = CEIL_DIV(N, block_size * x128::size);
     swiglu_forward_kernel<<<grid_size, block_size, 0, stream>>>(out, inp1, inp2);
+    cudaCheck(cudaGetLastError());
+}
+
+void swiglu_backward_inplace(floatX* dinp_out1, floatX* dinp2, const floatX* inp1, const floatX* inp2, const int N, cudaStream_t stream) {
+    NVTX_RANGE_FN();
+    const int block_size = 128;
+    assert(N % (block_size * x128::size) == 0);
+    const int grid_size = CEIL_DIV(N, block_size * x128::size);
+    swiglu_backward_kernel<<<grid_size, block_size, 0, stream>>>(dinp_out1, dinp2, inp1, inp2);
     cudaCheck(cudaGetLastError());
 }

--- a/llmc/matmul.cuh
+++ b/llmc/matmul.cuh
@@ -234,10 +234,13 @@ void matmul_forward_cublaslt(floatX* out,
                      const char* act_func, floatX* pre_act=NULL, int act_func_fusion=1) {
     // By default only fuse GELU/{act_func} for H100+ as cuBLAS seems to be inefficient for fused GELU on Ada/Ampere (?)
     if (act_func_fusion < 1 && pre_act) {
+        assert(strcmp(act_func, "gelu") == 0);
         matmul_cublaslt(pre_act, weight, inp, bias, OC, B*T, C, stream, true, false, 0, 0, 0, 0, false, NULL, false);
         gelu_forward(out, pre_act, B*T*OC, stream);
     } else {
-        assert(strcmp(act_func, "gelu") == 0);  // currently only GELU is supported for fusion
+        if (pre_act != NULL) {
+            assert(strcmp(act_func, "gelu") == 0);  // currently only GELU is supported for fusion
+        }
         matmul_cublaslt(out, weight, inp, bias, OC, B*T, C, stream, true, false, 0, 0, 0, 0, false, pre_act, false);
     }
 }

--- a/llmc/matmul.cuh
+++ b/llmc/matmul.cuh
@@ -260,7 +260,7 @@ void matmul_forward_fc1(floatX* out,
 void matmul_backward(floatX* dinp1, floatX* dinp2, floatX* dweight, floatX* dbias,
                      floatX* dout, floatX* inp, floatX* weight,
                      float* dbias_buffer,
-                     int B, int T, int C, int OC, cudaStream_t stream,
+                     int B, int T, int C, int OC, cudaStream_t stream, int accumulate_input,
                      const char* act_func, floatX* pre_act1=NULL, floatX* pre_act2=NULL, int gelu_fusion=1) {
     NVTX_RANGE_FN();
 
@@ -294,8 +294,8 @@ void matmul_backward(floatX* dinp1, floatX* dinp2, floatX* dweight, floatX* dbia
     int is_gelu = strcmp(act_func, "gelu") == 0;
 
     // backward to input, uses = in the backward pass (set the gradient)
-    matmul_cublaslt(dinp1, weight, dout, NULL, C, B*T, OC, stream, false, false, 0, 0, 0, 0, false,
-                    is_gelu && gelu_fusion >= 2 ? pre_act1 : NULL, true);
+    matmul_cublaslt(dinp1, weight, dout, NULL, C, B*T, OC, stream, false, false, 0, 0, 0, 0,
+        accumulate_input /* accumulate */, is_gelu && gelu_fusion >= 2 ? pre_act1 : NULL, true);
 
     // backward GELU (if it wasn't fused into the matmul above)
     if (is_gelu && gelu_fusion < 2 && pre_act1) {

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -529,6 +529,7 @@ void multi_gpu_async_reduce_gradient(
     cudaCheck(cudaStreamWaitEvent(config->nccl_stream, config->compute_nccl_sync));
     ncclCheck(ncclGroupStart()); // NCCL group: aggregate all pointers in a single NCCL GPU kernel.
     for (int i = 0; i < N; ++i) {
+        if (pointers[i] == NULL) continue;
         if(config->zero_stage == 0) {
             ncclCheck(ncclAllReduce(
                     pointers[i], pointers[i],

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -59,6 +59,8 @@ typedef struct {
     float*  ln2b; // (L, C)
     float*  fcw; // (L, 4*C, C)
     float*  fcb; // (L, 4*C)
+    float*  gatew; // (L, 4*C, C)
+    float*  gateb; // (L, 4*C)
     float*  fcprojw; // (L, C, 4*C)
     float*  fcprojb; // (L, C)
     float*  lnfw; // (C)
@@ -78,6 +80,7 @@ float* float_cpu_malloc_and_point_parameters(FloatParameterTensors* params, size
     float** ptrs[] = {
         &params->wte, &params->wpe, &params->ln1w, &params->ln1b, &params->qkvw, &params->qkvb,
         &params->attprojw, &params->attprojb, &params->ln2w, &params->ln2b, &params->fcw, &params->fcb,
+        &params->gatew, &params->gateb,
         &params->fcprojw, &params->fcprojb, &params->lnfw, &params->lnfb
     };
     float* params_memory_iterator = params_memory;

--- a/test_gpt2.cu
+++ b/test_gpt2.cu
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
         if (argv[i][0] != '-') { exit(EXIT_FAILURE); } // must start with dash
         if (argv[i][1] == 'w') { model.use_master_weights = atoi(argv[i+1]); }
         else if (argv[i][1] == 'r') { model.recompute = atoi(argv[i+1]); }
-        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { model.gelu_fusion = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { model.act_func_fusion = atoi(argv[i+1]); }
     }
 
     // load additional information that we will use for debugging and error checking

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -949,6 +949,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
                 dl_attprojw, dl_attprojb,
                 dl_ln2w, dl_ln2b,
                 dl_fcw, dl_fcb,
+                gated_ffn ? dl_gatew : NULL, gated_ffn ? dl_gateb : NULL,
                 dl_fcprojw, dl_fcprojb
             };
             const size_t nelem[] = {
@@ -956,6 +957,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
                 3 * C * C, 3 * C,
                 C * C, C,
                 C, C,
+                4 * C * C, 4 * C,
                 4 * C * C, 4 * C,
                 C * 4 * C, C
             };
@@ -998,7 +1000,7 @@ ShardInfo gpt2_get_tensor_at_layer(const GPT2 *model, int layer_id, int param_te
     }
     size_t size = model->param_elements[param_tensor_id] ;
     // if we are in the transformer block, we need to additionally offset by the layer id
-    if(2 <= param_tensor_id && param_tensor_id <= 13) {
+    if(2 <= param_tensor_id && param_tensor_id <= 15) {
         size /= model->config.num_layers;
         offset += (ptrdiff_t)(layer_id * size);
     }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -186,7 +186,7 @@ typedef struct {
     float* ln2_mean; // (L, B, T)
     float* ln2_rstd; // (L, B, T)
     floatX* fch; // (L, B, T, 4*C)
-    floatX* fch_gelu; // (L, B, T, 4*C)
+    floatX* fch_act; // (L, B, T, 4*C)
     floatX* residual3; // (L, B, T, C)
     floatX* lnf; // (B, T, C);   if LN recomputation is enabled (-r 2 and above), will be used for _all_ layernorms
     float* lnf_mean; // (B, T)
@@ -239,8 +239,8 @@ void fill_in_activation_sizes(const ActivationTensors* data, TensorSpec (&tensor
     tensors[8] = TENSOR_SPEC(data->ln2_mean, L * B * T);
     tensors[9] = TENSOR_SPEC(data->ln2_rstd, L * B * T);
     tensors[10] = TENSOR_SPEC(data->fch, L * B * T * 4*C);
-    // if recompute >= 1 then we will recompute gelu_forward during backward and use this as scratch buffer
-    tensors[11] = TENSOR_SPEC(data->fch_gelu, (recompute < 1) ? L * B * T * 4*C : B * T * 4*C);
+    // if recompute >= 1 then we will recompute gelu/{act_func}_forward during backward and use this as scratch buffer
+    tensors[11] = TENSOR_SPEC(data->fch_act, (recompute < 1) ? L * B * T * 4*C : B * T * 4*C);
     tensors[12] = TENSOR_SPEC(data->residual3, L * B * T * C);
     tensors[13] = TENSOR_SPEC(data->lnf, B * T * C);
     tensors[14] = TENSOR_SPEC(data->lnf_mean, B * T);
@@ -313,8 +313,8 @@ typedef struct {
     unsigned long long rng_state; // the RNG state for seeding stochastic rounding etc.
     int use_master_weights;     // keep master weights copy in float for optim update? 0|1
     bool init_state;   // set to true if master weights need to be initialized
-    int gelu_fusion; // fuse gelu via cuBLASLt (0=none, 1=forward, 2=forward+backward)
-    int recompute; // recompute gelu | layernorm forward during model backward? 0|1|2
+    int act_func_fusion; // fuse gelu/{act_func} via cuBLASLt (0=none, 1=forward, 2=forward+backward)
+    int recompute; // recompute gelu/{act_func} | layernorm forward during model backward? 0|1|2
     // todo - if other functions need cpu scratch buffers in the future, reuse as generic scratch?
     int* workload_indices; // encoder_backward, B*T*num_c_groups (int)
     int4* bucket_info;     // encoder_backward, B*T*num_c_groups (int4) - size for worst case
@@ -345,8 +345,8 @@ void gpt2_init_common(GPT2 *model) {
     model->rng_state = 13371337 + multi_gpu_config.process_rank; // used in stochastic rounding
     model->use_master_weights = 1; // safe default: do keep master weights in fp32
     model->init_state = true;
-    model->recompute = 1; // good default: recompute gelu but not layernorm
-    model->gelu_fusion = 0; //deviceProp.major >= 9 ? 2 : 0; // default: off for now (default must match main())
+    model->recompute = 1; // good default: recompute gelu/{act_func} but not layernorm
+    model->act_func_fusion = 0; //deviceProp.major >= 9 ? 2 : 0; // default: off for now (default must match main())
 }
 
 void gpt2_allocate_weights(GPT2 *model) {
@@ -684,9 +684,9 @@ void gpt2_forward(GPT2 *model, const int* inputs, size_t B, size_t T) {
         float* l_ln2_mean = acts.ln2_mean + l * B * T;
         float* l_ln2_rstd = acts.ln2_rstd + l * B * T;
         floatX* l_fch = acts.fch + l * B * T * 4*C;
-        // reuse the same activation buffer at each layer, as we'll re-compute the gelu during backward
+        // reuse the same activation buffer at each layer, as we'll re-compute the gelu/{act_func} during backward
         // very useful because we dramatically reduce VRAM usage, and may be able to fit larger batch size
-        floatX* l_fch_gelu = (model->recompute < 1) ? acts.fch_gelu + l * B * T * 4*C : acts.fch_gelu;
+        floatX* l_fch_act = (model->recompute < 1) ? acts.fch_act + l * B * T * 4*C : acts.fch_act;
         floatX* l_residual3 = acts.residual3 + l * B * T * C;
         floatX* scratch = (floatX*)acts.output; // used for non-cudnn attention, fcproj, attproj, etc.
 
@@ -708,8 +708,8 @@ void gpt2_forward(GPT2 *model, const int* inputs, size_t B, size_t T) {
 
         matmul_forward_cublaslt(scratch, l_atty, l_attprojw, l_attprojb, B, T, C, C, main_stream);
         fused_residual_forward5(l_residual2, l_ln2, l_ln2_mean, l_ln2_rstd, residual, scratch, l_ln2w, l_ln2b, B*T, C, main_stream);
-        matmul_forward_cublaslt(l_fch_gelu, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream, l_fch, model->gelu_fusion);
-        matmul_forward_cublaslt(scratch, l_fch_gelu, l_fcprojw, l_fcprojb, B, T, 4*C, C, main_stream);
+        matmul_forward_cublaslt(l_fch_act, l_ln2, l_fcw, l_fcb, B, T, C, 4*C, main_stream, l_fch, model->act_func_fusion);
+        matmul_forward_cublaslt(scratch, l_fch_act, l_fcprojw, l_fcprojb, B, T, 4*C, C, main_stream);
         // OK, fusion across blocks.
         if(l+1 != L) {
             floatX* l_ln1 = (model->recompute < 2) ? acts.ln1 + (l + 1) * B * T * C : acts.lnf;
@@ -859,8 +859,8 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         floatX* l_ln2 = (model->recompute < 2) ? acts.ln2 + l * B * T * C : acts.lnf;
         float* l_ln2_mean = acts.ln2_mean + l * B * T;
         float* l_ln2_rstd = acts.ln2_rstd + l * B * T;
-        floatX* l_fch_pre_gelu = acts.fch + l * B * T * 4*C;
-        floatX* l_fch_gelu = (model->recompute < 1) ? acts.fch_gelu + l * B * T * 4*C : acts.fch_gelu;
+        floatX* l_fch_pre_act = acts.fch + l * B * T * 4*C;
+        floatX* l_fch_act = (model->recompute < 1) ? acts.fch_act + l * B * T * 4*C : acts.fch_act;
         // get the pointers of the gradients of the activations for this layer
         // notice that there is no l *, because we just have a single copy, and keep
         // re-using this memory in every Transformer block as we calculate backward pass
@@ -871,11 +871,11 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         if(model->recompute >= 1) {
             // recompute >= 1 means we recompute gelu. in this case,
             // l_fch_gelu is just a buffer, so re-compute the gelu from l_fch here
-            gelu_forward(l_fch_gelu, l_fch_pre_gelu, B*T*4*C, main_stream);
+            gelu_forward(l_fch_act, l_fch_pre_act, B*T*4*C, main_stream);
         }
-        matmul_backward(dl_bt4c, dl_fcprojw, dl_fcprojb, dresidual, l_fch_gelu, l_fcprojw, scratchF, B, T, 4*C, C, main_stream, l_fch_pre_gelu, model->gelu_fusion);
+        matmul_backward(dl_bt4c, dl_fcprojw, dl_fcprojb, dresidual, l_fch_act, l_fcprojw, scratchF, B, T, 4*C, C, main_stream, l_fch_pre_act, model->act_func_fusion);
         if(model->recompute >= 2) {
-            // same as gelu above, l_ln1 and l_ln2 are just buffers if recompute >= 2, recompute them here on demand
+            // same as gelu/{act_func} above, l_ln1 and l_ln2 are just buffers if recompute >= 2, recompute them here on demand
             layernorm_forward(l_ln2, l_ln2_mean, l_ln2_rstd, l_residual2, l_ln2w, l_ln2b, B, T, C, main_stream);
         }
         matmul_backward(dl_btc, dl_fcw, dl_fcb, dl_bt4c, l_ln2, l_fcw, scratchF, B, T, C, 4 * C, main_stream);
@@ -890,7 +890,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         floatX* l_att = acts.att + l * B * NH * T * T;
         // we need B x T x (4)C buffers. l_atty and l_fch aren't needed anymore at this point, so reuse their memory
         floatX* buffer_a = l_atty;
-        floatX* buffer_b = l_fch_pre_gelu;        // this is B x T x 4C, so even larger than what we need
+        floatX* buffer_b = l_fch_pre_act;        // this is B x T x 4C, so even larger than what we need
         attention_backward(dl_bt4c, buffer_b, scratchX, buffer_a, dl_btc, l_qkvr, l_att, B, T, C, NH, main_stream);
         #endif
         if(model->recompute >= 2) {
@@ -1360,10 +1360,10 @@ void error_usage() {
     // numerics
     fprintf(stderr, "  -f <int>    enable_tf32 override (default: 1, set to 0 to disable tf32)\n");
     fprintf(stderr, "  -w <int>    keep f32 copy of weights for the optimizer? (default: 1)\n");
-    fprintf(stderr, "  -ge <int>   gelu fusion: 0=none, 1=forward, 2=forward+backward (default: 2 for >=SM90, 0 for older GPUs)\n");
+    fprintf(stderr, "  -ge <int>   activation function fusion: 0=none, 1=forward, 2=forward+backward (default: 2 for >=SM90, 0 for older GPUs)\n");
     // memory management
     fprintf(stderr, "  -z <int>    zero_stage, Zero Optimization Stage, 0,1,2,3 (default = 0)\n");
-    fprintf(stderr, "  -r <int>    recompute: less memory but less speed. (default = 1), 0|1|2 = none,gelu,gelu+ln\n");
+    fprintf(stderr, "  -r <int>    recompute: less memory but less speed. (default = 1), 0|1|2 = none,act_func,act_func+ln\n");
     // multi-node settings
     fprintf(stderr, "  -pn <int>    num_processes (default = 1)\n");
     fprintf(stderr, "  -pr <int>    process_rank (default = 0)\n");
@@ -1404,8 +1404,8 @@ int main(int argc, char *argv[]) {
     int max_steps = -1;
     int override_enable_tf32 = 1;
     int use_master_weights = 1;
-    int gelu_fusion = -1; // 0 = none, 1 = forward, 2 = forward+backward (-1 => per-GPU default)
-    int recompute = 1; // recompute during backward setting, 0 = none, 1 = recompute gelu
+    int act_func_fusion = -1; // 0 = none, 1 = forward, 2 = forward+backward (-1 => per-GPU default)
+    int recompute = 1; // recompute during backward setting, 0 = none, 1 = recompute gelu/{act_func}
     int zero_stage = 0; // Zero Optimization Stage for Multi-GPU training
     int hellaswag_eval = 0;
     // multi-node settings
@@ -1437,7 +1437,7 @@ int main(int argc, char *argv[]) {
         else if (argv[i][1] == 'v') { val_loss_every = atoi(argv[i+1]); }
         else if (argv[i][1] == 'm') { val_max_steps = atoi(argv[i+1]); }
         else if (argv[i][1] == 's' && argv[i][2] == '\0') { sample_every = atoi(argv[i+1]); }
-        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { gelu_fusion = atoi(argv[i+1]); }
+        else if (argv[i][1] == 'g' && argv[i][2] == 'e') { act_func_fusion = atoi(argv[i+1]); }
         else if (argv[i][1] == 'g') { genT = atoi(argv[i+1]); }
         else if (argv[i][1] == 'a') { overfit_single_batch = atoi(argv[i+1]); }
         else if (argv[i][1] == 'f') { override_enable_tf32 = atoi(argv[i+1]); }
@@ -1470,8 +1470,8 @@ int main(int argc, char *argv[]) {
     int tokens_per_fwdbwd = B * T * multi_gpu_config.num_processes; // one micro-batch processes this many tokens
     // calculate sensible default for total batch size as assuming no gradient accumulation
     if (total_batch_size == -1) { total_batch_size = tokens_per_fwdbwd; }
-    // in the future, we might want to set gelu fusion to 2 for SM90+ and 0 for other GPUs
-    if (gelu_fusion == -1) { gelu_fusion = 0; } // (deviceProp.major >= 9) ? 2 : 0; } // in gpt2_init_common for test_gpt2cu...
+    // in the future, we might want to set gelu/{act_func} fusion to 2 for SM90+ and 0 for other GPUs
+    if (act_func_fusion == -1) { act_func_fusion = 0; } // (deviceProp.major >= 9) ? 2 : 0; } // in gpt2_init_common for test_gpt2cu...
     // calculate the number of gradient accumulation steps from the desired total batch size
     assert(total_batch_size % tokens_per_fwdbwd == 0);
     int grad_accum_steps = total_batch_size / tokens_per_fwdbwd;
@@ -1503,7 +1503,7 @@ int main(int argc, char *argv[]) {
     printf0("| genT                  | %-50d |\n", genT);
     printf0("| overfit_single_batch  | %-50d |\n", overfit_single_batch);
     printf0("| use_master_weights    | %-50s |\n", use_master_weights ? "enabled" : "disabled");
-    printf0("| gelu_fusion           | %-50d |\n", gelu_fusion);
+    printf0("| act_func_fusion       | %-50d |\n", act_func_fusion);
     printf0("| recompute             | %-50d |\n", recompute);
     printf0("+-----------------------+----------------------------------------------------+\n");
     const char* precision_str = (PRECISION_MODE == PRECISION_FP32)
@@ -1543,7 +1543,7 @@ int main(int argc, char *argv[]) {
     }
 
     model.use_master_weights = use_master_weights;
-    model.gelu_fusion = gelu_fusion;
+    model.act_func_fusion = act_func_fusion;
     model.recompute = recompute;
     printf0("| weight init method    | %-50s |\n", resuming == 1 ? "intermediate checkpoint" : load_filename);
     printf0("| max_sequence_length T | %-50d |\n", model.config.max_seq_len);


### PR DESCRIPTION
Implemented SwiGLU - swish GLU activation function from the "GLU Variants Improve Transformer" [paper](https://arxiv.org/pdf/2002.05202).

Note: there is an increase in memory footprint as a consequence of adding an additional FC layer (params/grads/optimizer states + 2 new activation buffers `(L+1)*B*T*4*C` in total for the activations). I'm sure we can optimize this, can be done in the subsequent PR as well.

Tests:
I ran an A/B experiment: trained a 124M GPT-2 on 10B tokens (FineWeb subset) with:
a) GELU
b) SwiGLU (note: currently SwiGLU model actually has 152M params)

Results:
![image](https://github.com/user-attachments/assets/88ad119a-d682-4be2-bf49-1760a79e5fca)

Conclusion: SwiGLU converges to a lower loss, so I'm confident the implementation is correct, but unclear whether the perf comes from SwiGLU or more params (152M vs 124M).

After normalizing for the number of params (multiplying the inner FFN module dimension by 2/3) I get:
![image](https://github.com/user-attachments/assets/937cf469-d05a-4f88-a911-88c08b11f919)

Conclusion: SwiGLU does start converging faster than GELU but they end up at a pretty much same loss. Actually the trend seems to go in favor of GELU looking at the gradient of the curves.

Given that SwiGLU complicates the code, it's unclear to me that it offers a clear advantage over GELU/ReLU/etc. In general i doubt any of these activation functions are more powerful than ReLU. You just want more params / compute. :)

Next steps (can be done in follow-up PRs):
* Reduce memory footprint
* Speed up kernels / logic

Appendix:
In case it helps here is a diagram I drew to make it easier for me to implement the backward pass:
![swiglu_bwd](https://github.com/user-attachments/assets/14a6e20f-2bc8-4159-b2a0-5fb0a209d2e8)

