### PR TITLE
Add RoPE positional encoding - llama3 feature branch

### DIFF
--- a/llmc/attention.cuh
+++ b/llmc/attention.cuh
@@ -205,7 +205,7 @@ __global__ void rope_rotate_kernel(floatX* q, floatX* k, float* rope_freqs, int 
     int t = rest / n;
     int i = rest % n;
 
-    float* rope_freqs_t = rope_freqs + t * HS + i * (x128::size / 2);
+    float* rope_freqs_t = rope_freqs + t * (HS / 2) + i * (x128::size / 2);
     f128 freqs_reg = load128(rope_freqs_t);  // caching the frequencies
 
     int idx = b * NH * T * HS + nh * T * HS + t * HS + i * x128::size;

--- a/llmc/attention.cuh
+++ b/llmc/attention.cuh
@@ -204,8 +204,7 @@ __global__ void rope_rotate_kernel(floatX* q, floatX* k, const float* rope_freqs
     int hs = rest % HS_half;
 
     // TODO(gordicaleksa): optimize load x128...
-    // TODO(gordicaleksa): since we're not using half of rope freqs reduce the freq table
-    float freq = rope_freqs[t * HS + 2*hs];
+    float freq = rope_freqs[t * HS + hs];
     int idx1 = b * NH * T * HS + nh * T * HS + t * HS + 2*hs;
     int idx2 = b * NH * T * HS + nh * T * HS + t * HS + 2*hs + 1;
 

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -160,11 +160,11 @@ __global__ void wpe_backward_kernel(floatX* dwpe,
 
 __global__ void init_rope_freqs_kernel(float* rope_freqs, float rope_base_freq) {
     int m = blockIdx.x;
-    int HS = blockDim.x;
-    int out_idx = m * HS + threadIdx.x;
-    int i = threadIdx.x / 2 + 1;
+    int d_half = blockDim.x;
+    int out_idx = m * d_half + threadIdx.x;
+    int i = threadIdx.x + 1;
 
-    float theta_i = __powf(rope_base_freq, -2.0f * (float)(i - 1) / (float)HS);
+    float theta_i = __powf(rope_base_freq, -2.0f * (float)(i - 1) / (2.f * (float)d_half));
     rope_freqs[out_idx] = (float)m * theta_i;
 }
 

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -151,8 +151,24 @@ __global__ void wpe_backward_kernel(floatX* dwpe,
     store128(dwpe_tc, packed_dwpe);
 }
 
+__global__ void init_rope_freqs_kernel(floatX* rope_freqs, float rope_base_freq) {
+    int m = blockIdx.x;
+    int HS = blockDim.x;
+    int out_idx = m * HS + threadIdx.x;
+    int i = threadIdx.x / 2 + 1;
+
+    float theta_i = __powf(rope_base_freq, -2.0f * (float)(i - 1) / (float)HS);
+    rope_freqs[out_idx] = (floatX)((float)m * theta_i);
+}
+
 // ----------------------------------------------------------------------------
 // kernel launchers
+
+void init_rope_freqs(floatX* rope_freqs, int max_seq_len, int HS, float rope_base_freq, cudaStream_t stream) {
+    NVTX_RANGE_FN();
+    init_rope_freqs_kernel<<<max_seq_len, HS, 0, stream>>>(rope_freqs, rope_base_freq);
+    cudaCheck(cudaGetLastError());
+}
 
 void encoder_forward(floatX* out,
                      const int* inp, const floatX* wte, const floatX* wpe,

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -38,7 +38,7 @@ __global__ void encoder_forward_kernel3(floatX* out,
     x128 wte128 = load128cs(wte_ix);
     x128 wpe128;
     if (!use_rope) {
-        load128cs(wpe_tc);
+        wpe128 = load128cs(wpe_tc);
     }
     for (int k = 0; k < x128::size; k++) {
         if (!use_rope) {
@@ -161,8 +161,8 @@ __global__ void wpe_backward_kernel(floatX* dwpe,
 __global__ void init_rope_freqs_kernel(float* rope_freqs, float rope_base_freq) {
     int m = blockIdx.x;
     int d_half = blockDim.x;
-    int out_idx = m * d_half + threadIdx.x;
     int i = threadIdx.x + 1;
+    int out_idx = m * d_half + i - 1;
 
     float theta_i = __powf(rope_base_freq, -2.0f * (float)(i - 1) / (2.f * (float)d_half));
     rope_freqs[out_idx] = (float)m * theta_i;

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -17,7 +17,7 @@ In the backward pass, the gradients flow to both, handled by different kernels
 // CUDA kernels
 
 __global__ void encoder_forward_kernel3(floatX* out,
-                               const int* inp, const floatX* wte, const floatX* wpe,
+                               const int* inp, const floatX* wte, const floatX* wpe, int use_rope,
                                int B, int T, int C) {
     int idx = (blockIdx.x * blockDim.x + threadIdx.x) * x128::size;
     int N = B * T * C;
@@ -36,9 +36,16 @@ __global__ void encoder_forward_kernel3(floatX* out,
 
     x128 packed_out;
     x128 wte128 = load128cs(wte_ix);
-    x128 wpe128 = load128cs(wpe_tc);
+    x128 wpe128;
+    if (!use_rope) {
+        load128cs(wpe_tc);
+    }
     for (int k = 0; k < x128::size; k++) {
-        packed_out[k] = (floatX)((float)wte128[k] + (float)wpe128[k]);
+        if (!use_rope) {
+            packed_out[k] = (floatX)((float)wte128[k] + (float)wpe128[k]);
+        } else {
+            packed_out[k] = wte128[k];
+        }
     }
     store128(out_btc, packed_out);
 }
@@ -171,13 +178,13 @@ void init_rope_freqs(float* rope_freqs, int max_seq_len, int HS, float rope_base
 }
 
 void encoder_forward(floatX* out,
-                     const int* inp, const floatX* wte, const floatX* wpe,
+                     const int* inp, const floatX* wte, const floatX* wpe, int use_rope,
                      int B, int T, int C, cudaStream_t stream) {
     NVTX_RANGE_FN();
     const int block_size = 256;
     const int N = B * T * C;
     const int grid_size = CEIL_DIV(N, (int)(block_size * x128::size));
-    encoder_forward_kernel3<<<grid_size, block_size, 0, stream>>>(out, inp, wte, wpe, B, T, C);
+    encoder_forward_kernel3<<<grid_size, block_size, 0, stream>>>(out, inp, wte, wpe, use_rope, B, T, C);
     cudaCheck(cudaGetLastError());
 }
 
@@ -185,15 +192,17 @@ void encoder_forward(floatX* out,
 void encoder_backward(floatX* dwte, floatX* dwpe, floatX* scratch, // gpu outputs & scratch
                       int* workload_indices, int4* bucket_info,    // cpu scratch buffers
                       const floatX* dout, const int* inp, const int* inputs_cpu, // cpu/gpu inputs
-                      int B, int T, int C, unsigned int seed, cudaStream_t stream) {
+                      int use_rope, int B, int T, int C, unsigned int seed, cudaStream_t stream) {
     NVTX_RANGE_FN();
 
-    // Launch wpe kernel first (so it runs on the GPU in parallel with the CPU pre-processing for wte)
-    const int block_size = 256;
-    const int N = T * C / x128::size;
-    const int grid_size = CEIL_DIV(N, block_size);
-    wpe_backward_kernel<<<grid_size, block_size, 0, stream>>>(dwpe, dout, inp, B, T, C, seed);
-    cudaCheck(cudaGetLastError());
+    if (!use_rope) {
+        // Launch wpe kernel first (so it runs on the GPU in parallel with the CPU pre-processing for wte)
+        const int block_size = 256;
+        const int N = T * C / x128::size;
+        const int grid_size = CEIL_DIV(N, block_size);
+        wpe_backward_kernel<<<grid_size, block_size, 0, stream>>>(dwpe, dout, inp, B, T, C, seed);
+        cudaCheck(cudaGetLastError());
+    }
 
     // check the GPU scratch buffer is large enough to hold the bucket info and workload indices
     // todo - this is trivially true given hardcoded scratch buffer size here, is this useful?

--- a/llmc/encoder.cuh
+++ b/llmc/encoder.cuh
@@ -151,20 +151,20 @@ __global__ void wpe_backward_kernel(floatX* dwpe,
     store128(dwpe_tc, packed_dwpe);
 }
 
-__global__ void init_rope_freqs_kernel(floatX* rope_freqs, float rope_base_freq) {
+__global__ void init_rope_freqs_kernel(float* rope_freqs, float rope_base_freq) {
     int m = blockIdx.x;
     int HS = blockDim.x;
     int out_idx = m * HS + threadIdx.x;
     int i = threadIdx.x / 2 + 1;
 
     float theta_i = __powf(rope_base_freq, -2.0f * (float)(i - 1) / (float)HS);
-    rope_freqs[out_idx] = (floatX)((float)m * theta_i);
+    rope_freqs[out_idx] = (float)m * theta_i;
 }
 
 // ----------------------------------------------------------------------------
 // kernel launchers
 
-void init_rope_freqs(floatX* rope_freqs, int max_seq_len, int HS, float rope_base_freq, cudaStream_t stream) {
+void init_rope_freqs(float* rope_freqs, int max_seq_len, int HS, float rope_base_freq, cudaStream_t stream) {
     NVTX_RANGE_FN();
     init_rope_freqs_kernel<<<max_seq_len, HS, 0, stream>>>(rope_freqs, rope_base_freq);
     cudaCheck(cudaGetLastError());

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -529,6 +529,7 @@ void multi_gpu_async_reduce_gradient(
     cudaCheck(cudaStreamWaitEvent(config->nccl_stream, config->compute_nccl_sync));
     ncclCheck(ncclGroupStart()); // NCCL group: aggregate all pointers in a single NCCL GPU kernel.
     for (int i = 0; i < N; ++i) {
+        if (pointers[i] == NULL) continue;
         if(config->zero_stage == 0) {
             ncclCheck(ncclAllReduce(
                     pointers[i], pointers[i],

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -372,9 +372,10 @@ void gpt2_allocate_weights(GPT2 *model) {
     // allocate memory for rope frequencies
     if (model->use_rope) {
         int HS = model->config.channels / model->config.num_heads;
-        cudaCheck(cudaMalloc((float**)&model->rope_freqs, model->config.max_seq_len * HS * sizeof(float)));
+        assert(HS % 2 == 0); // HS must be even for RoPE
+        cudaCheck(cudaMalloc((float**)&model->rope_freqs, model->config.max_seq_len * (HS / 2) * sizeof(float)));
         // TODO(gordicaleksa): will floatX mess up the rope frequencies?
-        init_rope_freqs(model->rope_freqs, model->config.max_seq_len, HS, model->rope_base_freq, main_stream);
+        init_rope_freqs(model->rope_freqs, model->config.max_seq_len, HS / 2, model->rope_base_freq, main_stream);
     }
 }
 

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -997,7 +997,7 @@ float gpt2_calculate_grad_norm(GPT2 *model, MultiGpuConfig* multi_gpu_config) {
         // so we only calculate the grad norm at the grads_memory belonging to the local shards
         for (int i = 0; i < NUM_PARAMETER_TENSORS; i++) {
             if (model->use_rope && i == 1) {
-                // skip the wpe tensor if we are using RoPE -> minor optimization
+                // skip the wpe tensor if we are using RoPE -> minor optimization, results would be correct without this as well
                 continue;
             }
             ShardInfo tensor = gpt2_get_tensor_at_layer(model, 0, i);
@@ -1436,7 +1436,7 @@ int main(int argc, char *argv[]) {
     int zero_stage = 0; // Zero Optimization Stage for Multi-GPU training
     int hellaswag_eval = 0;
     // architectural settings
-    int use_rope = 1; // use RoPE positional embeddings
+    int use_rope = 0; // use RoPE positional embeddings
     float rope_base_freq = 10000.0f; // base frequency for RoPE
     // multi-node settings
     int num_processes = 1;  // this should be set by the slurm environment

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -320,7 +320,7 @@ typedef struct {
     int4* bucket_info;     // encoder_backward, B*T*num_c_groups (int4) - size for worst case
     int use_rope; // use rope position encoding
     float rope_base_freq; // base frequency for rope position encoding
-    floatX* rope_freqs; // rope position encoding frequencies
+    float* rope_freqs; // rope position encoding frequencies
 } GPT2;
 
 void gpt2_init_common(GPT2 *model) {
@@ -373,10 +373,9 @@ void gpt2_allocate_weights(GPT2 *model) {
     // allocate memory for rope frequencies
     if (model->use_rope) {
         int HS = model->config.channels / model->config.num_heads;
-        cudaCheck(cudaMalloc((floatX**)&model->rope_freqs, model->config.max_seq_len * HS * sizeof(floatX)));
+        cudaCheck(cudaMalloc((float**)&model->rope_freqs, model->config.max_seq_len * HS * sizeof(float)));
         init_rope_freqs(model->rope_freqs, model->config.max_seq_len, HS, model->rope_base_freq, main_stream);
     }
-    // TODO: test rope freq table with Python
 }
 
 void gpt2_allocate_state(GPT2 *model, int B, int T) {
@@ -1427,7 +1426,7 @@ int main(int argc, char *argv[]) {
     int zero_stage = 0; // Zero Optimization Stage for Multi-GPU training
     int hellaswag_eval = 0;
     // architectural settings
-    int use_rope = 0; // use RoPE positional embeddings
+    int use_rope = 1; // use RoPE positional embeddings
     float rope_base_freq = 10000.0f; // base frequency for RoPE
     // multi-node settings
     int num_processes = 1;  // this should be set by the slurm environment

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -951,7 +951,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
         #endif
         cudaCheck(cudaMemcpyAsync(&model->mean_loss, model->accumulated_mean_loss, sizeof(float), cudaMemcpyDeviceToHost, main_stream));
         // reduce the gradients for non-transformer block parameters
-        floatX* const pointers[] = {grads.wte, grads.wpe, grads.lnfw, grads.lnfb};
+        floatX* const pointers[] = {grads.wte, model->use_rope ? NULL : grads.wpe, grads.lnfw, grads.lnfb};
         const size_t nelem[] = {Vp * C, T * C, C, C};
         multi_gpu_async_reduce_gradient(pointers, nelem, &multi_gpu_config, main_stream);
     }


### PR DESCRIPTION
Implemented RoPE - rotary position embedding from the [RoFormer](https://arxiv.org/abs/2104.09864) paper.

Note:
1) I do not conditionally remove the allocation of our learnable position embedding buffer (`wpe`) as that would require touching many parts of the codebase that rely on the particular order inside the parameter buffer (e.g. `wpe` has index 1).
2) I do turn off fwd/bwd computation / grad norm computation / update for the `wpe` buffer.
The explicit tradeoff is: suffer a minimal memory bloat (`maxT * C`) but the PR has minimal impact on the readability of the codebase.

Tests:
I ran an A/B experiment: trained a 124M GPT-2 on 10B tokens (FineWeb subset) with:
a) learnable positional embeddings (default, `-er` == 0)
b) RoPE (`-er` == 1)
c) no positional embedding at all
all other settings being the same same.

Results:
![image](https://github.com/user-attachments/assets/35c1547a-e827-42bd-9f5b-cde567a0de3a)

Conclusions:
* The validation loss is significantly better with RoPE
* RoPE implementation slightly decresed the performance (consistent with what [EleutherAI folks](https://blog.eleuther.ai/rotary-embeddings/) observed). I observed a drop ~1_632_000 -> ~1_603_000 tok/s (~1.7% perf hit).