### PR TITLE
BF16 opt state (m/v) with stochastic rounding (Llama3 branch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,11 @@ else
   PFLAGS = -DENABLE_BF16
 endif
 
+# Optimizer precision settings, enable to allow BF16 for AdamW m/v state (also affects state file)
+ifeq ($(OPTIMIZER_LOW_PRECISION), 1)
+  PFLAGS += -DOPTIMIZER_LOW_PRECISION
+endif
+
 # PHONY means these targets will always be executed
 .PHONY: all train_llama3cu train_gpt2 test_gpt2 train_gpt2cu test_gpt2cu train_gpt2fp32cu test_gpt2fp32cu profile_gpt2cu
 

--- a/llmc/adamw.cuh
+++ b/llmc/adamw.cuh
@@ -16,22 +16,28 @@ __device__ float lerp(float start, float end, float weight) {
 }
 
 template <typename Tp, typename Tg>
-__device__ void adamw_update(Tp* params_memory, float* master_params_memory, Tg* grads_memory, float* m_memory, float* v_memory, size_t num_parameters,
+__device__ void adamw_update(Tp* params_memory, float* master_params_memory, Tg* grads_memory, floatOpt* m_memory, floatOpt* v_memory, size_t num_parameters,
                              float learning_rate, float beta1, float beta2, float beta1_correction, float beta2_correction, float eps, float weight_decay,
                              float grad_scale, unsigned int seed) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= num_parameters) { return; }  // guard
 
+    // random number generation (reuse same rng shifted, since 32 bits is overkill for FP32->BF16)
+    // note this all gets optimised away by the compiler if everything is FP32
+    unsigned int random = Get2dNoiseUint(idx, blockIdx.y, seed);
+    unsigned int random_m = __funnelshift_l(random, random, 10); // rotate by 10 bits
+    unsigned int random_v = __funnelshift_l(random, random, 20); // rotate by 20 bits
+
     // get the gradient, m, and v for this parameter
     float grad = grad_scale * (float)grads_memory[idx];
-    float m = m_memory[idx];
-    float v = v_memory[idx];
+    float m = (float)m_memory[idx];
+    float v = (float)v_memory[idx];
     // update the first moment (momentum)
     m = lerp(grad, m, beta1);
-    m_memory[idx] = m;
+    stochastic_rounding(m, &m_memory[idx], random_m, false);
     // update the second moment (RMSprop)
     v = lerp(grad * grad, v, beta2);
-    v_memory[idx] = v;
+    stochastic_rounding(v, &v_memory[idx], random_v, false);
     m /= beta1_correction;  // m_hat
     v /= beta2_correction;  // v_hat
     // fetch the old value of this parameter as a float, from either source
@@ -40,14 +46,14 @@ __device__ void adamw_update(Tp* params_memory, float* master_params_memory, Tg*
     float param = old_param - (learning_rate * (m / (sqrtf(v) + eps) + weight_decay * old_param));
     // update our low precision version of the parameters using stochastic rounding
     // this will be used in the next forward pass
-    stochastic_rounding(param, &params_memory[idx], seed);
+    stochastic_rounding(param, &params_memory[idx], random, false);
     // write the full, float version of the param into our master copy, if we maintain one
     // this will be used in the next update
     if (master_params_memory != NULL) { master_params_memory[idx] = param; }
 }
 
 template <typename Tp, typename Tg>
-__global__ void adamw_kernel3(Tp* params_memory, float* master_params_memory, Tg* grads_memory, float* m_memory, float* v_memory, size_t num_parameters,
+__global__ void adamw_kernel3(Tp* params_memory, float* master_params_memory, Tg* grads_memory, floatOpt* m_memory, floatOpt* v_memory, size_t num_parameters,
                               ptrdiff_t w_stride, ptrdiff_t g_stride, ptrdiff_t s_stride,
                               float learning_rate, float beta1, float beta2, float beta1_correction, float beta2_correction, float eps, float weight_decay,
                               float grad_scale, unsigned int seed) {
@@ -72,7 +78,7 @@ __global__ void init_from_master_kernel(Tp* params_memory, float* master_params_
 }
 
 template <typename Tp, typename Tg>
-void adamw_update(Tp* params_memory, float* master_params_memory, Tg* grads_memory, float* m_memory, float* v_memory, size_t num_parameters,
+void adamw_update(Tp* params_memory, float* master_params_memory, Tg* grads_memory, floatOpt* m_memory, floatOpt* v_memory, size_t num_parameters,
                   ptrdiff_t w_stride, ptrdiff_t g_stride, ptrdiff_t s_stride,  int num_slices, float learning_rate, float beta1, float beta2, int t, float eps, float weight_decay,
                   float grad_scale, unsigned int seed, cudaStream_t stream) {
     // AdamW update

--- a/llmc/cuda_common.h
+++ b/llmc/cuda_common.h
@@ -91,6 +91,12 @@ typedef __nv_bfloat16 floatX;
 #define PRECISION_MODE PRECISION_BF16
 #endif
 
+#if defined(OPTIMIZER_LOW_PRECISION)
+typedef floatX floatOpt;
+#else
+typedef float floatOpt;
+#endif
+
 // ----------------------------------------------------------------------------
 // Load and store with streaming cache hints
 // Older nvcc does not provide __ldcs and __stcs for bfloat16, despite these

--- a/llmc/cuda_utils.cuh
+++ b/llmc/cuda_utils.cuh
@@ -266,20 +266,20 @@ __device__ __host__ constexpr unsigned int Get2dNoiseUint(int indexX, int indexY
 }
 
 // stochastic rounding built on top of Squirel Noise above (with seed updated per step via xorshift)
-__device__ __forceinline__ void stochastic_rounding(float in, __nv_bfloat16 *out, unsigned int seed) {
+__device__ __forceinline__ void stochastic_rounding(float in, __nv_bfloat16 *out, unsigned int seed, bool noise=true) {
     // todo - is this stochastic rounding *too good*? can we cut any corners?
     // makes sure each thread gets a different random number
-    unsigned int random = Get2dNoiseUint(threadIdx.x, blockIdx.x * blockDim.x + blockIdx.y, seed);
+    unsigned int random = noise ? Get2dNoiseUint(threadIdx.x, blockIdx.x * blockDim.x + blockIdx.y, seed) : seed;
     unsigned int threshold = random & 0xFFFF;
     unsigned int float_bits = __float_as_uint(in);
     unsigned int rounded_bits = float_bits & 0x0000FFFF;
     float_bits = (rounded_bits > threshold) ? (float_bits | 0xFFFF) : (float_bits  & ~0xFFFF);
     *out = __float2bfloat16_rn(__uint_as_float(float_bits));
 }
-__device__ __forceinline__ void stochastic_rounding(float in, half *out, unsigned int random) {
+__device__ __forceinline__ void stochastic_rounding(float in, half *out, unsigned int random, bool noise=true) {
     *out = (float)in; // todo - implement this...
 }
-__device__ __forceinline__ void stochastic_rounding(float in, float *out, unsigned int random) {
+__device__ __forceinline__ void stochastic_rounding(float in, float *out, unsigned int random, bool noise=true) {
     *out = in; // dummy function for when floatX is float (FP32 mode)
 }
 

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -295,8 +295,8 @@ typedef struct {
     ParameterTensors grads;
     void* grads_memory;
     // buffers for the AdamW optimizer
-    float* m_memory;
-    float* v_memory;
+    floatOpt* m_memory;
+    floatOpt* v_memory;
     float* master_weights;     // is NULL unless fp32 weights is enabled.
     // the activations of the model, and their sizes
     ActivationTensors acts;
@@ -395,12 +395,12 @@ void gpt2_allocate_state(GPT2 *model, int B, int T) {
     // we will now init the optimizer states and master weights
     // this is usually a substantial amount of memory allocation right here.
     size_t shard_num_parameters = multi_gpu_config.shard_num_parameters; // num parameters we are responsible for
-    printf0("allocating %zu MiB for AdamW optimizer state m\n", (shard_num_parameters * sizeof(float)) >> 20);
-    printf0("allocating %zu MiB for AdamW optimizer state v\n", (shard_num_parameters * sizeof(float)) >> 20);
+    printf0("allocating %zu MiB for AdamW optimizer state m\n", (shard_num_parameters * sizeof(floatOpt)) >> 20);
+    printf0("allocating %zu MiB for AdamW optimizer state v\n", (shard_num_parameters * sizeof(floatOpt)) >> 20);
     assert(model->m_memory == nullptr);
     assert(model->v_memory == nullptr);
-    memory_status |= cudaMallocConditionallyManaged((void**)&model->m_memory, shard_num_parameters * sizeof(float));
-    memory_status |= cudaMallocConditionallyManaged((void**)&model->v_memory, shard_num_parameters * sizeof(float));
+    memory_status |= cudaMallocConditionallyManaged((void**)&model->m_memory, shard_num_parameters * sizeof(floatOpt));
+    memory_status |= cudaMallocConditionallyManaged((void**)&model->v_memory, shard_num_parameters * sizeof(floatOpt));
 
     if (model->use_master_weights == 1) {
         assert(model->master_weights == nullptr);
@@ -1050,8 +1050,8 @@ void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, flo
     if(init_state) {
         model->init_state = false;
         NvtxRange rng("InitOpt");
-        cudaCheck(cudaMemset(model->m_memory, 0, multi_gpu_config->shard_num_parameters * sizeof(float)));
-        cudaCheck(cudaMemset(model->v_memory, 0, multi_gpu_config->shard_num_parameters * sizeof(float)));
+        cudaCheck(cudaMemset(model->m_memory, 0, multi_gpu_config->shard_num_parameters * sizeof(floatOpt)));
+        cudaCheck(cudaMemset(model->v_memory, 0, multi_gpu_config->shard_num_parameters * sizeof(floatOpt)));
     }
 
     // save RNG state at this point so we can round from master weights identically when restoring from a checkpoint
@@ -1082,8 +1082,8 @@ void gpt2_update(GPT2 *model, float learning_rate, float beta1, float beta2, flo
         floatX* grad_ptr = (floatX*)model->grads_memory + local_offset_full;
 
         ptrdiff_t opt_state_offset = multi_gpu_config->zero_stage < 1 ?  local_offset_full : local_offset_partial;
-        float* m_ptr = model->m_memory + opt_state_offset;
-        float* v_ptr = model->v_memory + opt_state_offset;
+        floatOpt* m_ptr = model->m_memory + opt_state_offset;
+        floatOpt* v_ptr = model->v_memory + opt_state_offset;
         float* master_ptr = nullptr;
         if (model->master_weights != nullptr) { master_ptr = model->master_weights + opt_state_offset; }
         if(init_state && model->master_weights != nullptr ) {
@@ -1228,10 +1228,10 @@ void save_state(const char* filename, int step, GPT2* model, DataLoader* loader)
     *((size_t*)&state_header[32]) = loader->current_sample_idx; // position in shard
     fwriteCheck(state_header, sizeof(int), 256, state_file);
 
-    // write AdamW m, v, and master_weights here (they are all float)
+    // write AdamW m, v, and master_weights here (they are all float, unless OPTIMIZER_LOW_PRECISION is defined)
     size_t shard_num_parameters = multi_gpu_config.shard_num_parameters;
-    device_to_file(state_file, model->m_memory, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);
-    device_to_file(state_file, model->v_memory, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);
+    device_to_file(state_file, model->m_memory, shard_num_parameters * sizeof(floatOpt), IO_BUF_SIZE, main_stream);
+    device_to_file(state_file, model->v_memory, shard_num_parameters * sizeof(floatOpt), IO_BUF_SIZE, main_stream);
     if(model->use_master_weights) {
         device_to_file(state_file, model->master_weights, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);
     }
@@ -1276,8 +1276,8 @@ void load_state(int* step, GPT2* model, DataLoader* loader, const char* filename
     model->init_state = false;      // we just got the state from file, no need to do first-touch init
     assert(model->m_memory != nullptr);
     assert(model->v_memory != nullptr);
-    file_to_device(model->m_memory, state_file, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);
-    file_to_device(model->v_memory, state_file, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);
+    file_to_device(model->m_memory, state_file, shard_num_parameters * sizeof(floatOpt), IO_BUF_SIZE, main_stream);
+    file_to_device(model->v_memory, state_file, shard_num_parameters * sizeof(floatOpt), IO_BUF_SIZE, main_stream);
     if(model->use_master_weights) {
         assert(model->master_weights != nullptr);
         file_to_device(model->master_weights, state_file, shard_num_parameters * sizeof(float), IO_BUF_SIZE, main_stream);


### PR DESCRIPTION
Seems to work extremely well for tinyshakespeare on both GPT2 & Llama3.

For GPT2, val loss with BF16 m/v and *no master weights* is actually a tiny bit lower than FP32 m/v + master weights! (after 74 steps: 3.499682 vs 3.506536... this might just be noise of course, but it's encouraging)

This requires using the new Makefile option "OPTIMIZER_LOW_PRECISION=1" - it would be much messier if it was a command line option, like this it barely affects the code (the stochastic rounding gets optimized away automatically when it's disabled, since FP32 stochastic rounding is a no-op).