### PR TITLE
fix: false-positive check for nccl install on ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ else
     # Detect if running on macOS or Linux
     ifeq ($(SHELL_UNAME), Darwin)
       $(info ✗ Multi-GPU on CUDA on Darwin is not supported, skipping NCCL support)
-    else ifeq ($(shell dpkg -l | grep -q nccl && echo "exists"), exists)
+    else ifeq ($(shell dpkg -l | grep nccl | grep -q cuda && echo "exists"), exists)
       $(info ✓ NCCL found, OK to train with multiple GPUs)
       NVCC_FLAGS += -DMULTI_GPU
       NVCC_LDLIBS += -lnccl


### PR DESCRIPTION
Closes #774 

I found that `dpkg -l` will output a version name for each package it lists, and the version name for `nccl` includes the substring `"cuda"`, so I just chained another grep call and it works :)