### PR TITLE
FIX TypeError: normal_() got an unexpected keyword argument 'generator' #723

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -146,6 +146,7 @@ class GPT(nn.Module):
         self.init_rng.manual_seed(42)
         self.apply(self._init_weights)
 
+    @torch.no_grad()
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             # apply special scaled init to the residual projections, per GPT-2 paper
@@ -153,11 +154,11 @@ class GPT(nn.Module):
             # we want to skip initializing lm_head, which shares parameters with wte
             # and wte was already initialized down below during the Embedding init
             if not hasattr(module, 'LLMC_SKIP_INIT'):
-                torch.nn.init.normal_(module.weight, mean=0.0, std=std, generator=self.init_rng)
+                module.weight.normal_(mean=0.0, std=std, generator=self.init_rng)
             if module.bias is not None:
                 torch.nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
-            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02, generator=self.init_rng)
+            module.weight.normal_(mean=0.0, std=0.02, generator=self.init_rng)
 
     def forward(self, idx, targets=None, return_logits=True):
         device = idx.device


### PR DESCRIPTION
This PR fixes #723, older PyTorch versions (pre-2.2, roughly, [7fc2929](https://github.com/pytorch/pytorch/commit/7fc292930c3b8ae5f6dec0a6176d4b5ca0b29d8f)) don’t support arg `generator`, leading to the error:

```
Traceback (most recent call last):
    ...
    File "~/llm.c/train_gpt2.py", line 160, in _init_weights
    torch.nn.init.normal_(module.weight, mean=0.0, std=0.02, generator=self.init_rng)
TypeError: normal_() got an unexpected keyword argument 'generator'
```

after commit [86682af](https://github.com/karpathy/llm.c/commit/86682af9a9286714eb7879047ca59100a4cd485f) : `torch.nn.init.normal_` called with `generator`, file: train_gpt2.py [line146](https://github.com/karpathy/llm.c/blob/86682af9a9286714eb7879047ca59100a4cd485f/train_gpt2.py#L146), [line150](https://github.com/karpathy/llm.c/blob/86682af9a9286714eb7879047ca59100a4cd485f/train_gpt2.py#L150)


This PR replaces the `torch.nn.init.normal_` with `Tensor.normal_`, ensuring compatibility with older PyTorch releases.