### PR TITLE
LLama3 MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,18 @@ jobs:
 
       - name: Build project
         run: make -j4 -C dev/cuda
+
+  build-llama3:
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build FP32
+        run: PRECISION=FP32 make test_llama3cu train_llama3cu
+
+      - name: Build BF16
+        run: PRECISION=BF16 make test_llama3cu train_llama3cu

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -137,7 +137,7 @@ jobs:
         run: python dev/data/tinyshakespeare.py --model_desc llama-3
 
       - name: Train model
-        run: python train_llama3.py --write_tensors 1 --dtype float32
+        run: python train_llama3.py --write_tensors 1 --dtype float32 --offload 1
 
       - name: Build FP32 precision
         run: PRECISION=FP32 make test_llama3cu

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -9,9 +9,10 @@ on:
   pull_request:
     branches:
       - master
+      - llama3
 
 jobs:
-  build-and-test-gpu:
+  build-and-test-gpt2:
     runs-on: ubicloud-gpu-standard-1-latest
 
     steps:
@@ -116,6 +117,53 @@ jobs:
 
       - name: Execute testing program fp32 with cuDNN
         run: ./test_gpt2fp32cu
+
+  build-and-test-llama3:
+    runs-on: ubicloud-gpu-standard-1-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install OpenMP
+        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run preprocessing
+        run: python dev/data/tinyshakespeare.py --model_desc llama-3
+
+      - name: Train model
+        # modle is too big to fit on our runner GPUs. Thus, we run it on cpu :(
+        run: python train_llama3.py --write_tensors 1 --dtype float32 --device cpu
+
+      - name: Build FP32 precision
+        run: PRECISION=FP32 make test_llama3cu
+
+      - name: Run default
+        run: ./test_llama3cu
+
+      - name: Run no recompute GeLU
+        run: ./test_llama3cu -r 0
+
+      - name: Run recompute LN
+        run: ./test_llama3cu -r 2
+
+      - name: Build BF16 precision
+        run: PRECISION=BF16 make train_llama3cu test_llama3cu
+
+      - name: Run default
+        run: ./test_llama3cu
+
+      - name: Run no recompute GeLU
+        run: ./test_llama3cu -r 0
+
+      - name: Run no master weights
+        run: ./test_llama3cu -w 0
+
+      - name: Run recompute LN
+        run: ./test_llama3cu -r 2
 
   unit-tests-gpu:
     runs-on: ubicloud-gpu-standard-1-latest

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -120,10 +120,12 @@ jobs:
 
   build-and-test-llama3:
     runs-on: ubicloud-gpu-standard-1-latest
-
+    env:
+      HF_TOKEN: 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
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - run: echo "::add-mask::$HF_TOKEN"
 
       - name: Install OpenMP
         run: sudo apt-get update && sudo apt-get install -y libomp-dev
@@ -173,3 +175,4 @@ jobs:
 
       - name: Test Device<->File IO
         run: cd dev/test && nvcc -o device_file_io device_file_io.cu && ./device_file_io
+

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -135,8 +135,7 @@ jobs:
         run: python dev/data/tinyshakespeare.py --model_desc llama-3
 
       - name: Train model
-        # modle is too big to fit on our runner GPUs. Thus, we run it on cpu :(
-        run: python train_llama3.py --write_tensors 1 --dtype float32 --device cpu
+        run: python train_llama3.py --write_tensors 1 --dtype float32
 
       - name: Build FP32 precision
         run: PRECISION=FP32 make test_llama3cu

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ ifeq ($(OPTIMIZER_LOW_PRECISION), 1)
 endif
 
 # PHONY means these targets will always be executed
-.PHONY: all train_llama3cu train_gpt2 test_gpt2 train_gpt2cu test_gpt2cu train_gpt2fp32cu test_gpt2fp32cu profile_gpt2cu
+.PHONY: all train_llama3cu test_llama3cu train_gpt2 test_gpt2 train_gpt2cu test_gpt2cu train_gpt2fp32cu test_gpt2fp32cu profile_gpt2cu
 
 # Add targets
 TARGETS = train_gpt2 test_gpt2
@@ -291,6 +291,9 @@ profile_gpt2cu: profile_gpt2.cu $(NVCC_CUDNN)
 	$(NVCC) $(NVCC_FLAGS) $(PFLAGS) -lineinfo $^ $(NVCC_LDFLAGS) $(NVCC_INCLUDES) $(NVCC_LDLIBS)  $(CUDA_OUTPUT_FILE)
 
 train_llama3cu: train_llama3.cu $(NVCC_CUDNN)
+	$(NVCC) $(NVCC_FLAGS) $(PFLAGS) $^ $(NVCC_LDFLAGS) $(NVCC_INCLUDES) $(NVCC_LDLIBS) $(CUDA_OUTPUT_FILE)
+
+test_llama3cu: test_llama3.cu $(NVCC_CUDNN)
 	$(NVCC) $(NVCC_FLAGS) $(PFLAGS) $^ $(NVCC_LDFLAGS) $(NVCC_INCLUDES) $(NVCC_LDLIBS) $(CUDA_OUTPUT_FILE)
 
 clean:

--- a/llmc/zero.cuh
+++ b/llmc/zero.cuh
@@ -529,6 +529,7 @@ void multi_gpu_async_reduce_gradient(
     cudaCheck(cudaStreamWaitEvent(config->nccl_stream, config->compute_nccl_sync));
     ncclCheck(ncclGroupStart()); // NCCL group: aggregate all pointers in a single NCCL GPU kernel.
     for (int i = 0; i < N; ++i) {
+        if(pointers[i] == nullptr) continue;
         if(config->zero_stage == 0) {
             ncclCheck(ncclAllReduce(
                     pointers[i], pointers[i],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tiktoken
 transformers
 datasets
 requests
+torchao

--- a/test_llama3.cu
+++ b/test_llama3.cu
@@ -294,7 +294,7 @@ int main(int argc, char *argv[]) {
 
         float grad_norm = llama3_calculate_grad_norm(&model, &multi_gpu_config);
         float grad_scale = (grad_norm > 1.0f) ? 1.0f / grad_norm : 1.0f;
-        llama3_update(&model, 1e-4f, 0.9f, 0.95f, 1e-8f, 0.0f, grad_scale, step+1, &multi_gpu_config);
+        llama3_update(&model, 1e-5f, 0.9f, 0.95f, 1e-8f, 0.0f, grad_scale, step+1, &multi_gpu_config);
 
         // print the timing information at the end
         printf("step %d: loss %f (took %f ms)\n", step+1, model.mean_loss, time_elapsed_s * 1000);

--- a/train_llama3.cu
+++ b/train_llama3.cu
@@ -495,16 +495,25 @@ void llama3_write_to_checkpoint(LLama3 *model, const char* checkpoint_path) {
     // write the header first
     int model_header[256];
     memset(model_header, 0, sizeof(model_header));
-    model_header[0] = 20240326; // magic number
+    model_header[0] = 20240803; // magic number
     assert(PRECISION_MODE == PRECISION_FP32 || PRECISION_MODE == PRECISION_BF16);
     model_header[1] = PRECISION_MODE == PRECISION_FP32 ? 3 : 5; // version
     model_header[2] = model->config.max_seq_len;
     model_header[3] = model->config.vocab_size;
     model_header[4] = model->config.num_layers;
     model_header[5] = model->config.num_heads;
-    model_header[6] = model->config.channels;
-    model_header[7] = model->config.padded_vocab_size;
+    model_header[6] = model->config.num_kv_heads;
+    model_header[7] = model->config.channels;
+    model_header[8] = model->config.multiple_of;
+    model_header[9] = model->config.use_scaled_rope;
+    model_header[10] = 3;
+    model_header[11] = 1;
     fwriteCheck(model_header, sizeof(int), 256, model_file);
+    float float_header[256];
+    float_header[0] = model->config.ffn_dim_multiplier;
+    float_header[1] = model->config.norm_eps;
+    float_header[2] = model->config.rope_theta;
+    fwriteCheck(float_header, sizeof(float), 256, model_file);
     // write the parameters
     device_to_file(model_file, model->params_memory, model->num_parameters_bytes,
                    IO_BUF_SIZE, main_stream);

--- a/train_llama3.py
+++ b/train_llama3.py
@@ -242,14 +242,15 @@ class Block(nn.Module):
 
 @dataclass
 class LlamaConfig:
-    version: str = "3.1"
+    version: str
+    n_layer: int
+    n_head: int
+    n_embd: int
+    ffn_dim_multiplier: float
+    tied_embeddings: bool
     block_size: int = 8192
     vocab_size: int = 128256
-    n_layer: int = 32
-    n_head: int = 32
     n_kv_head: int = 8
-    n_embd: int = 4096
-    ffn_dim_multiplier: float = 1.3
     multiple_of: int = 1024
     norm_eps: float = 1e-5
     rope_theta: float = 500000.0
@@ -258,13 +259,46 @@ class LlamaConfig:
     use_kv: bool = True
     flash: bool = False  # use flashattention?
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            if hasattr(self, k):
-                setattr(self, k, v)
+    def __post_init__(self):
         assert self.n_kv_head <= self.n_head
         assert self.n_head % self.n_kv_head == 0
         assert self.n_embd % self.n_head == 0
+
+
+LLama3_8BConfig = LlamaConfig(
+    version="3.1",
+    n_layer=32,
+    n_head=32,
+    n_embd=4096,
+    ffn_dim_multiplier=1.3,
+    tied_embeddings=False
+)
+
+LLama3_3BConfig = LlamaConfig(
+    version="3.2",
+    n_layer=28,
+    n_head=24,
+    n_embd=3072,
+    ffn_dim_multiplier=1.0,
+    tied_embeddings=True
+)
+
+LLama3_1BConfig = LlamaConfig(
+    version="3.2",
+    n_layer=16,
+    n_head=32,
+    n_embd=2048,
+    ffn_dim_multiplier=1.4,
+    tied_embeddings=True
+)
+
+
+MODEL_DICT: Dict[str, LlamaConfig] = {
+    "meta-llama/Meta-Llama-3.1-8B": LLama3_8BConfig,
+    "meta-llama/Llama-3.2-3B": LLama3_3BConfig,
+    "meta-llama/Llama-3.2-1B": LLama3_1BConfig,
+}
+
 
 class LLaMA(nn.Module):
 
@@ -401,8 +435,7 @@ class LLaMA(nn.Module):
     def from_pretrained_llama3_hf(cls, model_id):
         """Loads pretrained LLaMA model weights from HuggingFace"""
         from transformers import AutoModelForCausalLM, AutoTokenizer
-        assert model_id == "meta-llama/Meta-Llama-3.1-8B", "Only the 8B-base model is supported for now"
-        model_args = LlamaConfig()
+        model_args = MODEL_DICT[model_id]
 
         model = AutoModelForCausalLM.from_pretrained(model_id)
         checkpoint = LLaMA.adapt_llama_state_dict_keys_hf(model.state_dict(), model_args)
@@ -422,7 +455,7 @@ class LLaMA(nn.Module):
     @classmethod
     def from_pretrained_llama3_meta(cls, ckpt_dir, tokenizer_path):
         """Loads pretrained LLaMA model weights from a checkpoint directory"""
-        model_args = LlamaConfig()
+        model_args = LLama3_8BConfig
 
         ckpt_path = sorted(Path(ckpt_dir).glob("*.pth"))[0]
         checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
@@ -942,8 +975,9 @@ def write_state(model, x, y, logits, loss, filename):
     # this can be used for checking the computation correctness in C
     header = torch.zeros(256, dtype=torch.int32)
     header[0] = 20240803 # magic
-    header[1] = x.size(0) # batch size of the batch, B
-    header[2] = x.size(1) # temporal extent of the batch, T
+    header[1] = 2 # version
+    header[2] = x.size(0) # batch size of the batch, B
+    header[3] = x.size(1) # temporal extent of the batch, T
     grads = {name: param.grad.cpu() for name, param in model.named_parameters()}
     with open(filename, "wb") as file:
         # header
@@ -982,7 +1016,7 @@ if __name__ == "__main__":
     parser.add_argument("--input_bin", type=str, default="dev/data/tinyshakespeare/tiny_shakespeare_val.bin", help="input .bin to train on")
     parser.add_argument("--input_val_bin", type=str, default="", help="input .bin to eval validation loss on")
     parser.add_argument("--output_dir", type=str, default="", help="output directory to which to write logs and checkpoints")
-    parser.add_argument("--model", type=str, default="meta-llama/Meta-Llama-3.1-8B", help="chose the llama model")
+    parser.add_argument("--model", type=str, default="meta-llama/Llama-3.2-1B", help="chose the llama model")
     # token layout for each step of the optimization
     parser.add_argument("--batch_size", type=int, default=4, help="batch size, in units of #batch dimensions")
     parser.add_argument("--sequence_length", type=int, default=64, help="sequence length")
@@ -1017,7 +1051,7 @@ if __name__ == "__main__":
     B, T = args.batch_size, args.sequence_length
     assert 1 <= T <= 8192, "sequence length must be between 1 and 8192"
     assert args.dtype in {"float32", "float16", "bfloat16"}
-    assert args.model in {"meta-llama/Meta-Llama-3.1-8B"}  # only 8B base model supported for now
+    assert args.model in MODEL_DICT.keys()
 
     # create the logging directory if it does not exist
     logfile = None
@@ -1123,10 +1157,10 @@ if __name__ == "__main__":
         logits, loss = model(x, y)
         loss.backward()
         # save model params, in bfloat16
-        model_to_size = {"meta-llama/Meta-Llama-3.1-8B": "8B"}
-        model_size_str = model_to_size[args.model] # e.g. "8B"
-        write_model(model, os.path.join(args.output_dir, f"llama3.1_{model_size_str}.bin"), dtype="float32")
-        write_model(model, os.path.join(args.output_dir, f"llama3.1_{model_size_str}_bf16.bin"), dtype="bfloat16")
+        model_size_str = args.model.split("-")[-1]
+        model_version = MODEL_DICT[args.model].version
+        write_model(model, os.path.join(args.output_dir, f"llama{model_version}_{model_size_str}.bin"), dtype="float32")
+        write_model(model, os.path.join(args.output_dir, f"llama{model_version}_{model_size_str}_bf16.bin"), dtype="bfloat16")
         # save x, y, logits, loss, and parameter gradients, for debugging C
         # always store these in fp32 to have an accurate reference (?)
         write_state(model, x, y, logits, loss, os.path.join(args.output_dir, f"llama3_{model_size_str}_debug_state.bin"))

--- a/train_llama3.py
+++ b/train_llama3.py
@@ -122,7 +122,7 @@ def precompute_freqs_cis(
         freqs = apply_scaling(freqs)
     freqs = torch.outer(t, freqs)
     freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+    return torch.view_as_real(freqs_cis)
 
 # -----------------------------------------------------------------------------
 # LLaMA building blocks
@@ -331,7 +331,7 @@ class LLaMA(nn.Module):
 
         # forward the LLaMA model itself
         x = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
-        freqs_cis = self.freqs_cis[start_pos:start_pos+t]
+        freqs_cis = torch.view_as_complex(self.freqs_cis[start_pos:start_pos+t])
         mask = torch.triu(torch.ones((t, t), device=next(self.parameters()).device, dtype=torch.bool), diagonal=1)
 
         for i, block in enumerate(self.transformer.h):


### PR DESCRIPTION
This implements the minimum necessary changes to get an implementation of LLama3 that is functional.
Key fixes compared to the current llama3 branch:
* ignore bias terms during backward
* ensure learning rate matches pytorch reference
* fix gradient checking (#801)

When trying to set up CI, we run into the problem that even the 1B model is too large to fit for training; I've tried two different things:
a) run reference code with `--device=cpu`. This works, but we see numerical differences quite prominently, would need to increase tolerances by ~10x for fp32 mode
b) use torchao's CPUOffloadOptimizer. Works, but introduces another dependency on the python side. ~Also changes the numerics, but only for the optimizer, so it doesn't break the gradient step.~ EDIT: CPUOffloadOptimizer is not compatible with gradient clipping, so I had to add a terrible hack :(  The loss values set as targets in `test_llama3.cu` _are_ generated from the `.py` file, but I ran it on a larger GPU so that these are without offloading.

What is still missing:
* cuDNN support
* tied weights (i.e., actually reproducing 1B/3B models)
* evaluation in the C training loop
* generating models from scratch
* haven't checked the non-HF code path for the python reference



Q: Do we really want to store the hidden dimension size as a floating-point factor , followed by 1024-roudning? Instead of just specifying `hidden_dim` explicitly? The factor would make sense if it was the same across all models, but it differs.

I do have code for all of these, but I'd like to keep the PRs at a managable size, so these changes aren't included here.