### PR TITLE
cuDNN for llama3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,11 @@ jobs:
 
       - name: Build BF16
         run: PRECISION=BF16 make test_llama3cu train_llama3cu
+
+      - name: Get cudnn
+        run: |
+          apt-get update && apt-get install -y git
+          git clone https://github.com/NVIDIA/cudnn-frontend.git
+
+      - name: Build cuDNN
+        run: PRECISION=BF16 USE_CUDNN=1 make test_llama3cu train_llama3cu

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -115,29 +115,29 @@ jobs:
   build-and-test-llama3:
     name: Build and test LLama3.2 1B
     runs-on: ubicloud-gpu-standard-1-latest
-    env:
-      HF_TOKEN: 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
+    container:
+      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - run: echo "::add-mask::$HF_TOKEN"
+      - run: echo "::add-mask::$(echo us_xrYQGKBiJeqDMlTxkGhSgjelZKYbJHTgDY | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
 
       - name: Install OpenMP
-        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+        run: apt-get update && apt-get install -y libomp-dev libopenmpi-dev python3-pip
 
       - name: Install dependencies
         run: pip install -r requirements.txt
 
       - name: Run preprocessing
-        run: python dev/data/tinyshakespeare.py --model_desc llama-3
+        run: HF_TOKEN=$(echo us_xrYQGKBiJeqDMlTxkGhSgjelZKYbJHTgDY | tr 'A-Za-z' 'N-ZA-Mn-za-m') python3 dev/data/tinyshakespeare.py --model_desc llama-3
 
       - name: Train model
         # use the first 10 layers, so that everything fits into the 20GB of
         # the A4000 Ada that we have in CI
-        run: python train_llama3.py --write_tensors 1 --dtype float32 --depth 10
+        run: HF_TOKEN=$(echo us_xrYQGKBiJeqDMlTxkGhSgjelZKYbJHTgDY | tr 'A-Za-z' 'N-ZA-Mn-za-m') python3 train_llama3.py --write_tensors 1 --dtype float32 --depth 10
 
       - name: Build FP32 precision
-        run: PRECISION=FP32 make test_llama3cu
+        run: PRECISION=FP32 NO_MULTI_GPU=1 make test_llama3cu
 
       - name: Run default
         run: ./test_llama3cu
@@ -149,7 +149,7 @@ jobs:
         run: ./test_llama3cu -r 2
 
       - name: Build BF16 precision
-        run: PRECISION=BF16 make train_llama3cu test_llama3cu
+        run: PRECISION=BF16 NO_MULTI_GPU=1 make train_llama3cu test_llama3cu
 
       - name: Run default (BF16)
         run: ./test_llama3cu
@@ -166,15 +166,12 @@ jobs:
   build-and-test-llama3-untied:
     name: Build and test LLama3.2 1B with untie weights
     runs-on: ubicloud-gpu-standard-1-latest
-    env:
-      HF_TOKEN: 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
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - run: echo "::add-mask::$HF_TOKEN"
 
       - name: Install OpenMP
-        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+        run: sudo apt-get update && sudo apt-get install -y libomp-dev git
 
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -202,7 +199,7 @@ jobs:
           git clone https://github.com/NVIDIA/cudnn-frontend.git
 
       - name: Build with cuDNN
-        run: USE_CUDNN=1 PRECISION=BF16 make train_llama3cu test_llama3cu
+        run: USE_CUDNN=1 PRECISION=BF16 NO_MULTI_GPU=1 make train_llama3cu test_llama3cu
 
       - name: Train model with cuDNN
         run: ./train_llama3cu

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -197,6 +197,19 @@ jobs:
       - name: Run default
         run: ./test_llama3cu
 
+      - name: Install cuDNN-frontend
+        run:
+          git clone https://github.com/NVIDIA/cudnn-frontend.git
+
+      - name: Build with cuDNN
+        run: USE_CUDNN=1 PRECISION=BF16 make train_llama3cu test_llama3cu
+
+      - name: Train model with cuDNN
+        run: ./train_llama3cu
+
+      - name: Execute testing program with cuDNN
+        run: ./test_llama3cu
+
   unit-tests-gpu:
     runs-on: ubicloud-gpu-standard-1-latest
 

--- a/dev/data/fineweb.py
+++ b/dev/data/fineweb.py
@@ -66,7 +66,7 @@ elif args.type =="edu":
 
 def tokenize_llama(doc):
     # tokenizes a single document and returns a numpy array of uint32 tokens
-    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3.1-8B")
+    tokenizer = AutoTokenizer.from_pretrained("unsloth/Llama-3.2-1B")
     encode = lambda s: tokenizer.encode(s, add_special_tokens=False, verbose=False, split_special_tokens=True)
     eot = tokenizer.encode('')[0] # by default the tokenizer adds the EOT token (128000)
     tokens = [eot] # the special <|endoftext|> token delimits all documents

--- a/dev/data/tinyshakespeare.py
+++ b/dev/data/tinyshakespeare.py
@@ -50,7 +50,7 @@ def tokenize(model_desc):
         encode = lambda s: enc.encode_ordinary(s)
         eot = enc._special_tokens['<|endoftext|>'] # end of text token
     elif model_desc == "llama-3":
-        tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3.1-8B")
+        tokenizer = AutoTokenizer.from_pretrained("unsloth/Llama-3.2-1B")
         encode = lambda s: tokenizer.encode(s, add_special_tokens=False, verbose=False, split_special_tokens=True)
         eot = tokenizer.encode('')[0] # by default the tokenizer adds the EOT token (128000)
     else:

--- a/dev/data/tinystories.py
+++ b/dev/data/tinystories.py
@@ -76,7 +76,7 @@ def process_shard(shard_index, shard_filename, model_desc):
         encode = lambda s: enc.encode_ordinary(s)
         eot = enc._special_tokens['<|endoftext|>'] # end of text token
     elif model_desc == "llama-3":
-        tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3.1-8B")
+        tokenizer = AutoTokenizer.from_pretrained("unsloth/Llama-3.2-1B")
         encode = lambda s: tokenizer.encode(s, add_special_tokens=False, verbose=False, split_special_tokens=True)
         eot = tokenizer.encode('')[0] # by default the tokenizer adds the EOT token (128000)
     else:

--- a/llmc/cudnn_att.h
+++ b/llmc/cudnn_att.h
@@ -9,13 +9,13 @@ cuDNN (flash) attention
 // forward declarations of functions defined in cudnn_att.cpp
 void create_cudnn();
 void destroy_cudnn();
-void attention_forward_cudnn(floatX* out,  // output: (B, T, NH, HS)
-                             float* stats, // output for backward pass: (B, NH, T)
-                             floatX* inp,  // input: (B, T, 3, NH, HS) QKV
-                             int B, int T, int NH, int C, cudaStream_t stream);
+void attention_forward_cudnn(floatX* out,  // output: (B, T, Nq, HS)
+                             float* stats, // output for backward pass: (B, Hq, T)
+                             floatX* inp,  // input: (B, T, Hq + 2Hkv, HS) QKV
+                             int B, int T, int Hq, int Hkv, int HS, cudaStream_t stream);
 
 void attention_backward_cudnn(floatX* dqkvr,                                       // output
                               floatX* dout, floatX* qkvr, floatX* o, float* stats, // inputs
-                              int B, int T, int NH, int C, cudaStream_t stream);
+                              int B, int T, int Hq, int Hkv, int HS, cudaStream_t stream);
 
 #endif // CUDNN_ATT_H

--- a/llmc/rope.cuh
+++ b/llmc/rope.cuh
@@ -43,20 +43,27 @@ void precompute_freqs_cis(floatX *freqs_cis, int dim, int end, float theta, int 
     }
 }
 
-__global__ void rope_forward_kernel1(floatX *out, const floatX *inp, const floatX *freqs_cis, int B, int T, int n_head, int head_dim) {
+__global__ void rope_forward_kernel1(floatX *out, const floatX *inp, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int head_dim_half = head_dim / 2;
-    if (idx >= B * T * 3 * n_head * head_dim_half) return;
+    int N = Nq + 2*Nkv;
+    if (idx >= B * T * N * head_dim_half) return;
     // decode the qkv index early so we can early exit if it's a value index
-    int qkv = (idx / (n_head * head_dim_half)) % 3;
+    int h = (idx / head_dim_half) % N;
+    int qkv = 2;
+    if(h < Nq) {
+        qkv = 0;        // query head
+    } else if (h < Nq + Nkv) {
+        qkv = 1;        // key head
+        h -= Nq;
+    }
     if (qkv == 2) return; // no-op for v
     // decode the individual indices and get the input index
-    int b = idx / (T * 3 * n_head * head_dim_half);
-    int t = (idx / (3 * n_head * head_dim_half)) % T;
-    int h = (idx / head_dim_half) % n_head;
+    int b = idx / (T * N * head_dim_half);
+    int t = (idx / (N * head_dim_half)) % T;
     int d = idx % head_dim_half;
-    int idx_bt = b * (T * 3 * n_head * head_dim) + t * (3 * n_head * head_dim);
-    int idx_bth = idx_bt + qkv * (n_head * head_dim) + h * head_dim;
+    int idx_bt = b * (T * N * head_dim) + t * (N * head_dim);
+    int idx_bth = idx_bt + qkv * (Nq * head_dim) + h * head_dim;
     int idxi = idx_bth + 2 * d; // index in the input
     // fetch the freqs_cis
     int freqs_idx = t * head_dim + 2 * d;
@@ -70,20 +77,27 @@ __global__ void rope_forward_kernel1(floatX *out, const floatX *inp, const float
     out[idxi + 1] = x_real * freqs_sin + x_imag * freqs_cos;
 }
 
-__global__ void rope_backward_inplace_kernel1(floatX *dinp, const floatX *dout, const floatX *freqs_cis, int B, int T, int n_head, int head_dim) {
+__global__ void rope_backward_kernel1(floatX *dinp, const floatX *dout, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int head_dim_half = head_dim / 2;
-    if (idx >= B * T * 3 * n_head * head_dim_half) return;
+    int N = Nq + 2*Nkv;
+    if (idx >= B * T * N * head_dim_half) return;
     // decode the qkv index early so we can early exit if it's a value index
-    int qkv = (idx / (n_head * head_dim_half)) % 3;
+    int h = (idx / head_dim_half) % N;
+    int qkv = 2;
+    if(h < Nq) {
+        qkv = 0;        // query head
+    } else if (h < Nq + Nkv) {
+        qkv = 1;        // key head
+        h -= Nq;
+    }
     if (qkv == 2) return; // no-op for v
     // decode the individual indices and get the input index
-    int b = idx / (T * 3 * n_head * head_dim_half);
-    int t = (idx / (3 * n_head * head_dim_half)) % T;
-    int h = (idx / head_dim_half) % n_head;
+    int b = idx / (T * N * head_dim_half);
+    int t = (idx / (N * head_dim_half)) % T;
     int d = idx % head_dim_half;
-    int idx_bt = b * (T * 3 * n_head * head_dim) + t * (3 * n_head * head_dim);
-    int idx_bth = idx_bt + qkv * (n_head * head_dim) + h * head_dim;
+    int idx_bt = b * (T * N * head_dim) + t * (N * head_dim);
+    int idx_bth = idx_bt + qkv * (Nq * head_dim) + h * head_dim;
     int idxi = idx_bth + 2 * d; // index in the input
     // fetch the freqs_cis
     int freqs_idx = t * head_dim + 2 * d;
@@ -96,23 +110,23 @@ __global__ void rope_backward_inplace_kernel1(floatX *dinp, const floatX *dout, 
     dinp[idxi + 1] = -dout_real * freqs_sin + dout_imag * freqs_cos;
 }
 
-void rope_forward(floatX *out, const floatX *inp, const floatX *freqs_cis, int B, int T, int n_head, int head_dim, cudaStream_t stream) {
-    // the input and output to this kernel are (B, T, 3, NH, HD) where the 3 is q,k,v
+void rope_forward(floatX *out, const floatX *inp, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
+    // the input and output to this kernel are (B, T, Nq + Nk + Nv, HD)
     // we are going to launch exactly one thread per element of the output,
     // except divide by two because the work is in "tuples"
     // so this single kernel launch will do RoPE for both q and k, and the threads for v will be a no-op
     const int block_size = 128;
-    int total_threads = B * T * 3 * n_head * head_dim / 2;
+    int total_threads = B * T * (Nq + 2*Nkv) * head_dim / 2;
     int num_blocks = CEIL_DIV(total_threads, block_size);
-    rope_forward_kernel1<<<num_blocks, block_size, 0, stream>>>(out, inp, freqs_cis, B, T, n_head, head_dim);
+    rope_forward_kernel1<<<num_blocks, block_size, 0, stream>>>(out, inp, freqs_cis, B, T, Nq, Nkv, head_dim);
     cudaCheck(cudaGetLastError());
 }
 
-void rope_backward_inplace(floatX *dinp, const floatX *dout, const floatX *freqs_cis, int B, int T, int n_head, int head_dim, cudaStream_t stream) {
+void rope_backward_inplace(floatX *dinp, const floatX *dout, const floatX *freqs_cis, int B, int T, int Nq, int Nkv, int head_dim, cudaStream_t stream) {
     // backward pass of forward, mirrors the forward kernel in setup and indexing
     const int block_size = 128;
-    int total_threads = B * T * 3 * n_head * head_dim / 2;
+    int total_threads = B * T * (Nq + 2*Nkv) * head_dim / 2;
     int num_blocks = CEIL_DIV(total_threads, block_size);
-    rope_backward_inplace_kernel1<<<num_blocks, block_size, 0, stream>>>(dinp, dout, freqs_cis, B, T, n_head, head_dim);
+    rope_backward_kernel1<<<num_blocks, block_size, 0, stream>>>(dinp, dout, freqs_cis, B, T, Nq, Nkv, head_dim);
     cudaCheck(cudaGetLastError());
 }

--- a/train_gpt2.cu
+++ b/train_gpt2.cu
@@ -718,7 +718,7 @@ void gpt2_forward(GPT2 *model, const int* inputs, size_t B, size_t T) {
         #ifdef ENABLE_CUDNN
         float* l_att = (float*)acts.att + l * B * NH * T; // cuDNN needs a smaller FP32 tensor
         matmul_forward_cublaslt(l_qkvr, l_ln1, l_qkvw, l_qkvb, B, T, C, 3*C, main_stream);
-        attention_forward_cudnn(l_atty, (float*)l_att, l_qkvr, B, T, NH, C, main_stream);
+        attention_forward_cudnn(l_atty, (float*)l_att, l_qkvr, B, T, NH, NH, C / NH, main_stream);
         #else
         floatX* l_att = acts.att + l * B * NH * T * T;
         if (T != model->seq_len) { // unused parts of attention buffer must be zeroed (T-dependent)
@@ -909,7 +909,7 @@ void gpt2_backward_and_reduce(GPT2 *model, int* inputs, const int* targets, int 
 
         #ifdef ENABLE_CUDNN
         float* l_att = (float*)acts.att + l * B * NH * T; // cuDNN needs a smaller FP32 tensor
-        attention_backward_cudnn(dl_bt4c, dl_btc, l_qkvr, l_atty, (float*)l_att, B, T, NH, C, main_stream);
+        attention_backward_cudnn(dl_bt4c, dl_btc, l_qkvr, l_atty, (float*)l_att, B, T, NH, NH, C / NH, main_stream);
         #else
         floatX* l_att = acts.att + l * B * NH * T * T;
         // we need B x T x (4)C buffers. l_atty and l_fch aren't needed anymore at this point, so reuse their memory

--- a/train_llama3.cu
+++ b/train_llama3.cu
@@ -712,18 +712,21 @@ void llama3_forward(LLama3 *model, const int* inputs, size_t B, size_t T) {
         floatX* l_fch_swiglu = (model->recompute < 1) ? acts.fch_gelu + l * B * T * ffn_channels_post_gelu : acts.fch_gelu;
         floatX* l_residual3 = acts.residual3 + l * B * T * C;
         floatX* scratch = (floatX*)acts.output; // used for non-cudnn attention, fcproj, attproj, etc.
-        floatX* qkv_rep_scratch = (floatX*)acts.scratch_bt4c; // we can use the BT4C scratch for qkv replication
 
         // Attention block
         // The input l_ln1 now holds the (already layernormed) input
         #ifdef ENABLE_CUDNN
-            printf("cuDNN path TODO\n"); exit(0);
+            // 1) projection to QKV vectors (note k,v may be fewer heads than q)
             matmul_forward_cublaslt(l_qkvr, l_ln1, l_qkvw, l_qkvb, B, T, C, qkv_channels, main_stream);
+            // 2) apply RoPE to q,k in place
+            rope_forward(l_qkvr, l_qkvr, model->freqs_cis, B, T, n_head, n_kv_head, hd, main_stream);
+            // 4) attention: att <- softmax(qk^T)v
             float* l_att = (float*)acts.att + l * B * NH * T; // cuDNN needs a smaller FP32 tensor
-            attention_forward_cudnn(l_atty, (float*)l_att, l_qkvr, B, T, NH, C, main_stream);
+            attention_forward_cudnn(l_atty, (float*)l_att, l_qkvr, B, T, NH, n_kv_head, hd, main_stream);
         #else
             // unused parts of attention buffer must be zeroed (T-dependent)
             floatX* l_att = acts.att + l * B * NH * T * T;
+            floatX* qkv_rep_scratch = (floatX*)acts.scratch_bt4c; // we can use the BT4C scratch for qkv replication
             if (T != model->seq_len) { cudaCheck(cudaMemset(l_att, 0, B * NH * T * T * sizeof(floatX))); }
             // 1) projection to QKV vectors (note k,v may be fewer heads than q)
             matmul_forward_cublaslt(scratch, l_ln1, l_qkvw, l_qkvb, B, T, C, qkv_channels, main_stream);
@@ -927,18 +930,17 @@ void llama3_backward_and_reduce(LLama3 *model, int* inputs, const int* targets, 
         // <--- gradient here matches OK
 
         #ifdef ENABLE_CUDNN
-        printf("cuDNN path TODO\n"); exit(0);
         float* l_att = (float*)acts.att + l * B * NH * T; // cuDNN needs a smaller FP32 tensor
-        attention_backward_cudnn(dl_bt4c, dl_btc, l_qkvr, l_atty, (float*)l_att, B, T, NH, C, main_stream);
+        attention_backward_cudnn(dl_bt4c2, dl_btc, l_qkvr, l_atty, l_att, B, T, NH, n_kv_head, hd, main_stream);
         #else
         floatX* l_att = acts.att + l * B * NH * T * T;
         // we need B x T x (4)C buffers. l_atty and l_fch aren't needed anymore at this point, so reuse their memory
         floatX* buffer_a = l_atty;
         floatX* buffer_b = l_fch_pre_gelu;        // this is B x T x 4C, so even larger than what we need
         attention_backward(dl_bt4c, buffer_b, scratchX, buffer_a, dl_btc, l_qkvr, l_att, B, T, C, NH, main_stream);
-        #endif
         // backward repkv (use scratchX as gradient buffer here)
         repkv_backward(dl_bt4c2, dl_bt4c, B, T, NH, n_kv_head, hd, main_stream);
+        #endif
         // backward rope (this can be done in-place)
         rope_backward_inplace(dl_bt4c2, dl_bt4c2, model->freqs_cis, B, T, NH, n_kv_head, hd, main_stream);
         // backward QKV projection

--- a/train_llama3.cu
+++ b/train_llama3.cu
@@ -727,10 +727,10 @@ void llama3_forward(LLama3 *model, const int* inputs, size_t B, size_t T) {
             if (T != model->seq_len) { cudaCheck(cudaMemset(l_att, 0, B * NH * T * T * sizeof(floatX))); }
             // 1) projection to QKV vectors (note k,v may be fewer heads than q)
             matmul_forward_cublaslt(scratch, l_ln1, l_qkvw, l_qkvb, B, T, C, qkv_channels, main_stream);
-            // 2) replicate k,v so that all of q,k,v have the same number of heads. done for simplicity, for now
+            // 2) apply RoPE to q,k in place
+            rope_forward(scratch, scratch, model->freqs_cis, B, T, n_head, n_kv_head, hd, main_stream);
+            // 3) replicate k,v so that all of q,k,v have the same number of heads. done for simplicity, for now
             repkv_forward(qkv_rep_scratch, scratch, B, T, n_head, n_kv_head, hd, main_stream);
-            // 3) apply RoPE to q,k in place
-            rope_forward(qkv_rep_scratch, qkv_rep_scratch, model->freqs_cis, B, T, n_head, hd, main_stream);
             // 4) attention: att <- softmax(qk^T)v
             attention_forward(l_atty, l_qkvr, l_att, qkv_rep_scratch, B, T, C, NH, main_stream);
         #endif
@@ -937,10 +937,10 @@ void llama3_backward_and_reduce(LLama3 *model, int* inputs, const int* targets, 
         floatX* buffer_b = l_fch_pre_gelu;        // this is B x T x 4C, so even larger than what we need
         attention_backward(dl_bt4c, buffer_b, scratchX, buffer_a, dl_btc, l_qkvr, l_att, B, T, C, NH, main_stream);
         #endif
-        // backward rope (this can be done in-place)
-        rope_backward_inplace(dl_bt4c, dl_bt4c, model->freqs_cis, B, T, NH, hd, main_stream);
         // backward repkv (use scratchX as gradient buffer here)
         repkv_backward(dl_bt4c2, dl_bt4c, B, T, NH, n_kv_head, hd, main_stream);
+        // backward rope (this can be done in-place)
+        rope_backward_inplace(dl_bt4c2, dl_bt4c2, model->freqs_cis, B, T, NH, n_kv_head, hd, main_stream);
         // backward QKV projection
         if(model->recompute >= 2) {
             rmsnorm_forward(l_ln1, l_ln1_rstd, residual, l_ln1w, B, T, C, main_stream);

--- a/train_llama3.py
+++ b/train_llama3.py
@@ -297,6 +297,7 @@ MODEL_DICT: Dict[str, LlamaConfig] = {
     "meta-llama/Meta-Llama-3.1-8B": LLama3_8BConfig,
     "meta-llama/Llama-3.2-3B": LLama3_3BConfig,
     "meta-llama/Llama-3.2-1B": LLama3_1BConfig,
+    "unsloth/Llama-3.2-1B": LLama3_1BConfig,
 }
 
 
@@ -1044,7 +1045,7 @@ if __name__ == "__main__":
     parser.add_argument("--input_bin", type=str, default="dev/data/tinyshakespeare/tiny_shakespeare_val.bin", help="input .bin to train on")
     parser.add_argument("--input_val_bin", type=str, default="", help="input .bin to eval validation loss on")
     parser.add_argument("--output_dir", type=str, default="", help="output directory to which to write logs and checkpoints")
-    parser.add_argument("--model", type=str, default="meta-llama/Llama-3.2-1B", help="chose the llama model")
+    parser.add_argument("--model", type=str, default="unsloth/Llama-3.2-1B", help="chose the llama model")
     parser.add_argument("--depth", type=int, default=-1, help="load only a subset of the model's layers")
     parser.add_argument("--untie", type=int, default=False, help="Untie token embeddings and LM-head, even if they are tied in the checkpoint.")
     # token layout for each step of the optimization


### PR DESCRIPTION
adds a cudnn implementation that allows for GQA
for better compatibility, that means that our rope kernel needs to be GQA aware, too, then we can just exchange the order of rope and repkv and reuse most of the code between the cudnn/non-cudnn code-paths.