### PR TITLE
Fix: Correct typo in code comment (logile -> logfile)

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -840,7 +840,7 @@ if __name__ == "__main__":
         # the 0th iteration is often an outlier (much slower) => skip logging it
         tokens_per_second = grad_accum_steps * ddp_world_size * B * T / (t1-t0)
         print0(f"step {step+1:4d}/{args.num_iterations} | train loss {lossf:.6f} | norm {norm:.4f} | lr {lr:.2e} | ({(t1-t0)*1000:.2f} ms | {tokens_per_second:.0f} tok/s)")
-        # log to logile
+        # log to logfile
         if master_process and logfile is not None:
             with open(logfile, "a") as f:
                 f.write("s:%d trl:%f\n" % (step, lossf))

--- a/train_llama3.py
+++ b/train_llama3.py
@@ -1235,7 +1235,7 @@ if __name__ == "__main__":
         # the 0th iteration is often an outlier (much slower) => skip logging it
         tokens_per_second = grad_accum_steps * ddp_world_size * B * T / (t1-t0)
         print0(f"step {step+1:4d}/{args.num_iterations} | train loss {lossf:.6f} | norm {norm:.4f} | lr {lr:.2e} | ({(t1-t0)*1000:.2f} ms | {tokens_per_second:.0f} tok/s)")
-        # log to logile
+        # log to logfile
         if master_process and logfile is not None:
             with open(logfile, "a") as f:
                 f.write("s:%d trl:%f\n" % (step, lossf))


### PR DESCRIPTION
This pull request addresses a minor typographical error found in a code comment.

The commit `b384303` corrects 'logile' to 'logfile'.

This change improves code readability and maintainability by ensuring comments are accurate.