### PR TITLE
Add 🦀 Rust port with safety + CUDA to notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Lastly, I will be a lot more sensitive to complexity in the root folder of the p
   - [llm.c](https://github.com/krrishnarraj/llm.c) by @[krrishnarraj](https://github.com/krrishnarraj): an OpenCL port of this project
 
 - Rust
+  -  [llm.rs](https://github.com/phildav/llm.rs) by @[phildav](https://github.com/phildav): Rust port with safe/idiomatic Rust and CUDA support
   -  [llm.rs](https://github.com/yijunyu/llm.rs) by @[Yijun Yu](https://github.com/yijunyu): a Rust rewrite with the aim to have same performance
   -  [llm.rs](https://github.com/ToJen/llm.rs) by @[ToJen](https://github.com/ToJen): a Rust port of this project
 


### PR DESCRIPTION
## Motivations

**Rust is focused on performance and reliability** (cf [Rust](https://www.rust-lang.org/)), so I found it particularly interesting to see how these principles apply to an LLM training loop.

Although there are 2 Rust projects listed in notable forks, their focus is not on safety or CUDA support. This was my motivation starting this new port.

I tried to make the code as idiomatic and safe as possible, while keeping the CPU/GPU path close to the llm.c structure for easier comparison and educational value.

## Features
 - 100% safe CPU training loop
 - safe (minimal unsafe blocks for the GPU kernel launchers) and idiomatic Rust
 - CUDA support
 - training results are bit-exact with the reference implementation
 - devcontainer and modal.com support for the GPU poor 🙋

## Link
llm.rs 🦀 https://github.com/phildav/llm.rs

## Performances
Full description in the [README.md](https://github.com/phildav/llm.rs?tab=readme-ov-file#-rust-vs-c-performances)

Here is a quick preview:

<img width="589" height="435" alt="cpu_training_time" src="https://github.com/user-attachments/assets/e28ee9b2-8a65-4d1c-8f1d-9dded1bebba2" />

<img width="580" height="435" alt="gpu_training_time" src="https://github.com/user-attachments/assets/cd0ffb0e-b258-4e8f-b7ae-f58dae7e7d80" />
