### PR TITLE
Fix: Offset cast to int in fseekCheck breaks datasets >2GB

### DIFF
--- a/llmc/dataloader.h
+++ b/llmc/dataloader.h
@@ -210,7 +210,7 @@ void dataloader_load_batch(DataLoader* loader) {
     size_t B = loader->B;
     size_t T = loader->T;
     // read B*T+1 uint16_t tokens from the file into buffer
-    fseekCheck(loader->tokens_file, (int) current_offset, SEEK_SET);
+    fseekCheck(loader->tokens_file, current_offset, SEEK_SET);
     freadCheck(loader->buffer, sizeof(uint16_t), B*T+1, loader->tokens_file);
     // decode the buffer into inputs and targets (cast to int)
     for (int i = 0; i < B*T; i++) {


### PR DESCRIPTION
There is a mismatch between the Python dataloader (`dev/data/data_common.py`) and the C implementation (`llmc/dataloader.h`).

In `dev/data/data_common.py`, the dataset explicitly allows up to 2^31 tokens:

https://github.com/karpathy/llm.c/blob/master/dev/data/data_common.py
```python
assert len(toks) < 2**31, "token count too large" # ~2.1B tokens
```
Since tokens are stored as uint16 (in the gpt-2 dataset), this corresponds to a maximum file size of 2 * 2^31 = 2^32 bytes (4GB).

However, in llm.c the offset passed to fseek is cast to int:
https://github.com/karpathy/llm.c/blob/master/llmc/dataloader.h
```C
fseekCheck(loader->tokens_file, (int) current_offset, SEEK_SET);
```

This cast truncates the 64-bit offset to a 32-bit signed int, which reduces the maximum supported offset to 2^31 bytes (2GB) and causes overflow for larger datasets.

Effectively:
- Python side: allows up to 2^31 tokens (4GB file).
- C side: only supports up to 2GB offsets due to (int) cast (2^30 tokens).

Solution:
Remove downcast to int.
```C
fseekCheck(loader->tokens_file, current_offset, SEEK_SET);
```