### PR TITLE
feat(cpu): optional BLAS for matmul forward/backward (2.6x end-to-end speedup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,31 @@ else
   endif
 endif
 
+# Optional BLAS for CPU matmul acceleration (USE_BLAS=1 to enable)
+# e.g. on Linux: sudo apt-get install libopenblas-dev
+# e.g. on macOS: available via Accelerate framework (no install needed)
+USE_BLAS ?= 0
+ifeq ($(USE_BLAS), 1)
+  ifeq ($(SHELL_UNAME), Darwin)
+    CFLAGS += -DUSE_BLAS
+    LDLIBS += -framework Accelerate
+    $(info ✓ BLAS found (Apple Accelerate))
+  else
+    ifneq ($(OS), Windows_NT)
+      # Try pkg-config for openblas first, then fall back to direct linking
+      ifneq ($(shell pkg-config --exists openblas 2>/dev/null; echo $$?), 0)
+        CFLAGS += -DUSE_BLAS
+        LDLIBS += -lopenblas
+        $(info ✓ BLAS enabled (linking -lopenblas))
+      else
+        CFLAGS += -DUSE_BLAS $(shell pkg-config --cflags openblas)
+        LDLIBS += $(shell pkg-config --libs openblas)
+        $(info ✓ BLAS found via pkg-config)
+      endif
+    endif
+  endif
+endif
+
 # Check if NCCL is available, include if so, for multi-GPU training
 ifeq ($(NO_MULTI_GPU), 1)
   $(info → Multi-GPU (NCCL) is manually disabled)

--- a/dev/cpu/matmul_forward.c
+++ b/dev/cpu/matmul_forward.c
@@ -14,6 +14,13 @@ CPU Kernels for matmul forward pass.
 #include <math.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef USE_BLAS
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
+#endif
 
 // ----------------------------------------------------------------------------
 // CPU code reference
@@ -87,7 +94,27 @@ void matmul_forward_ngc92(float* out,
     }
 }
 
+#ifdef USE_BLAS
+void matmul_forward_blas(float* out,
+    const float* inp, const float* weight, const float* bias,
+    int B, int T, int C, int OC) {
+    // Use BLAS sgemm: out = inp @ weight^T
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                B*T, OC, C,
+                1.0f, inp, C, weight, C,
+                0.0f, out, OC);
+    if (bias != NULL) {
+        for (int i = 0; i < B*T; i++) {
+            for (int o = 0; o < OC; o++) {
+                out[i * OC + o] += bias[o];
+            }
+        }
+    }
+}
+#define NUM_KERNELS 3
+#else
 #define NUM_KERNELS 2
+#endif
 
 void matmul_forward(int kernel_num,
     float* out,
@@ -101,6 +128,11 @@ void matmul_forward(int kernel_num,
         case 1:
             matmul_forward_ngc92(out, inp, weight, bias, B, T, C, OC);
             break;
+#ifdef USE_BLAS
+        case 2:
+            matmul_forward_blas(out, inp, weight, bias, B, T, C, OC);
+            break;
+#endif
         default:
             printf("Invalid kernel number\n");
             exit(1);

--- a/train_gpt2.c
+++ b/train_gpt2.c
@@ -20,6 +20,13 @@ There will be other versions of this code that specialize it and make it fast.
 #ifdef OMP
 #include <omp.h>
 #endif
+#ifdef USE_BLAS
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
+#endif
 // our own utilities
 // defines: fopenCheck, freadCheck, fcloseCheck, fseekCheck, mallocCheck
 #include "llmc/utils.h"
@@ -185,11 +192,26 @@ void matmul_forward(float* out,
                     const float* inp, const float* weight, const float* bias,
                     int B, int T, int C, int OC) {
     // most of the running time is spent here and in matmul_backward
-    // therefore, the implementation below is very mildly optimized
-    // this function is otherwise identical to that of matmul_forward_naive()
     // OC is short for "output channels"
     // inp is (B,T,C), weight is (OC, C), bias is (OC)
     // out will be (B,T,OC)
+#ifdef USE_BLAS
+    // Use BLAS sgemm: out = inp @ weight^T
+    // inp is (B*T, C), weight is (OC, C), out is (B*T, OC)
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                B*T, OC, C,
+                1.0f, inp, C, weight, C,
+                0.0f, out, OC);
+    if (bias != NULL) {
+        for (int i = 0; i < B*T; i++) {
+            for (int o = 0; o < OC; o++) {
+                out[i * OC + o] += bias[o];
+            }
+        }
+    }
+#else
+    // this implementation below is very mildly optimized
+    // this function is otherwise identical to that of matmul_forward_naive()
 
     // make sure the tiled loop will be correct or fallback to naive version
     const int LOOP_UNROLL = 8;
@@ -226,12 +248,34 @@ void matmul_forward(float* out,
             }
         }
     }
+#endif
 }
 
 void matmul_backward(float* dinp, float* dweight, float* dbias,
                      const float* dout, const float* inp, const float* weight,
                      int B, int T, int C, int OC) {
     // most of the running time is spent here and in matmul_forward
+#ifdef USE_BLAS
+    // dinp = dout @ weight  (B*T,OC) @ (OC,C) = (B*T,C)
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                B*T, C, OC,
+                1.0f, dout, OC, weight, C,
+                0.0f, dinp, C);
+    // dweight += dout^T @ inp  (OC,B*T) @ (B*T,C) = (OC,C)
+    cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+                OC, C, B*T,
+                1.0f, dout, OC, inp, C,
+                1.0f, dweight, C);
+    if (dbias != NULL) {
+        for (int o = 0; o < OC; o++) {
+            float sum = 0.0f;
+            for (int i = 0; i < B*T; i++) {
+                sum += dout[i * OC + o];
+            }
+            dbias[o] += sum;
+        }
+    }
+#else
     // this backward could be done in a single "round" of loops
     // but that doesn't afford an efficient parallelization strategy
 
@@ -266,6 +310,7 @@ void matmul_backward(float* dinp, float* dweight, float* dbias,
             }
         }
     }
+#endif
 }
 
 void attention_forward(float* out, float* preatt, float* att,


### PR DESCRIPTION
## Summary

Adds opt-in BLAS integration (`USE_BLAS=1`) for CPU matmul operations in `train_gpt2.c`, replacing hand-rolled loops with `cblas_sgemm` calls. This closes the largest performance gap between llm.c's CPU path and PyTorch (which uses BLAS internally).

- **End-to-end training speedup: 2.63x** (6454 → 2453 ms/step)
- **Matmul-only speedup: 11.6x** vs the tiled kernel (kernel 1)
- Works with OpenBLAS (Linux), Apple Accelerate (macOS), or any CBLAS-compatible library
- All changes guarded by `#ifdef USE_BLAS` — **zero behavior change** when flag is off
- Numerically correct: validation losses match within float32 tolerance

Ref: Discussion #253 — @karpathy greenlit BLAS/SIMD optimizations for the CPU path.

## Usage

```bash
# Install OpenBLAS (Linux)
sudo apt-get install libopenblas-dev

# Build with BLAS enabled
USE_BLAS=1 make train_gpt2

# Run (BLAS uses its own threading, adjust as needed)
OMP_NUM_THREADS=6 ./train_gpt2
```

On macOS, `USE_BLAS=1` automatically links Apple's Accelerate framework (no install needed).

## Benchmarks

**Hardware:** AMD EPYC (Zen 1), 6 cores, 12GB RAM
**Model:** GPT-2 124M, B=4, T=64, 40 training steps

### End-to-end training (`train_gpt2`)

| Build | Median ms/step (steps 1-9) | Median ms/step (steps 21-29) |
|-------|---------------------------|------------------------------|
| Baseline (no BLAS) | 6454 | 6528 |
| USE_BLAS=1 | 2453 | 2484 |
| **Speedup** | **2.63x** | **2.63x** |

Validation loss comparison (numerically equivalent):
```
Baseline: 5.325532 → 4.416570 → 4.329112 → 4.299987 → 4.291465
BLAS:     5.325531 → 4.416318 → 4.329331 → 4.300208 → 4.291763
```

### Matmul-only (`dev/cpu/matmul_forward.c`)

B=8, T=1024, C=768, OC=3072 (4 runs each):

| Kernel | Time (ms) | vs Naive | vs Tiled |
|--------|-----------|----------|----------|
| 0: Naive | 34,312 | 1.0x | — |
| 1: Tiled (existing) | 8,521 | 4.0x | 1.0x |
| 2: BLAS (new) | 737 | **46.5x** | **11.6x** |

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `Makefile` | BLAS auto-detection block (follows existing USE_CUDNN pattern) | +25 |
| `train_gpt2.c` | `#ifdef USE_BLAS` in `matmul_forward` + `matmul_backward` | +50 |
| `dev/cpu/matmul_forward.c` | Kernel 2 (BLAS) for the CPU benchmark harness | +29 |

Total: **+104 lines**, clean `#ifdef` guards, no changes to existing code paths.

## Notes

- macOS Accelerate path compiles but was not benchmarked (Linux test only). macOS testing welcome.
- The bias addition after SGEMM uses a simple loop; this is a negligible fraction of total matmul time.
- BLAS libraries handle their own threading internally, so this plays well alongside OpenMP for non-matmul ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)