### PR TITLE
Fix data race between two writes on a shared memory in soft_max_autoregressive_backward_kernel

### DIFF
--- a/dev/cuda/attention_backward.cu
+++ b/dev/cuda/attention_backward.cu
@@ -650,6 +650,7 @@ __global__ void softmax_autoregressive_backward_kernel7(float* dpreatt, const fl
     if(warp.meta_group_rank() == 0) {
         block_acc[warp.thread_rank()] = 0;
     }
+    block.sync();
 
     float local_sum = 0;
     for(int t2 = block.thread_rank(); t2 <= t; t2 += BlockSize) {
@@ -690,6 +691,7 @@ __global__ void softmax_autoregressive_backward_kernel8(float* dpreatt, const fl
     if (warp.meta_group_rank() == 0) {
         block_acc[warp.thread_rank()] = 0;
     }
+    block.sync();
 
     for(int to = 0; to < T_per_block; ++to) {
         int t = t0 - to;

--- a/train_gpt2_fp32.cu
+++ b/train_gpt2_fp32.cu
@@ -462,6 +462,7 @@ __global__ void softmax_autoregressive_backward_kernel(float* dpreatt, const flo
     if (warp.meta_group_rank() == 0) {
         block_acc[warp.thread_rank()] = 0;
     }
+    block.sync();
 
     for(int to = 0; to < T_per_block; ++to) {
         int t = t0 - to;


### PR DESCRIPTION
…ax_autoregressive_backward_kernel

There are three access sites to block_acc in softmax_autoregressive_backward_kernel:

A. Initialization write
B. Per-warp local sum write
C. Block-wide read of accumulated values

The indexing differs across these accesses. The initialization (A) is performed by threads in warp 0 and indexed by the thread’s lane ID. The per-warp writes (B) are indexed by the warp ID, while the read (C) is indexed again by thread ID.

Although there is a synchronization barrier between (B) and (C), there is no synchronization between (A) and (B). As a result, the relative ordering between initialization and per-warp writes is not guaranteed.

In particular, if warp 1 executes its write (B) before warp 0 completes initialization (A), warp 0 may overwrite a previously written local sum with zero. This creates a data race, and the subsequent block-wide read (C) may observe incorrect values.

Thus, it may cause wrong result due to data race.