### PR TITLE
fix: update cudaMemAdvise host location

### DIFF
--- a/llmc/cuda_utils.cuh
+++ b/llmc/cuda_utils.cuh
@@ -217,7 +217,7 @@ int cudaMallocConditionallyManaged(void** out, size_t bytes, const char *file, i
         // if we OOM, fallback to a managed allocation. slower but at least won't crash.
         cudaGetLastError(); // reset the error before the next API call
         cudaCheck_(cudaMallocManaged(out, bytes), file, line);
-        cudaCheck_(cudaMemAdvise(*out, bytes, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId), file, line);
+        cudaCheck_(cudaMemAdvise(*out, bytes, cudaMemAdviseSetPreferredLocation, cudaMemLocation{cudaMemLocationTypeHost, 0}), file, line);
         return 1;
     } else {
         cudaCheck_(err, file, line);


### PR DESCRIPTION
## Summary
- update the managed-allocation fallback to pass a cudaMemLocation host target to cudaMemAdvise
- fixes compatibility with CUDA headers where cudaMemAdvise expects struct cudaMemLocation instead of an int device id

## Verification
- git diff --check
- C++ syntax-only check against local CUDA 13 headers: old cudaCpuDeviceId argument fails, new cudaMemLocation{cudaMemLocationTypeHost, 0} form passes

## Not run
- full nvcc build/test; this host does not have a usable x86_64 nvcc available