### PR TITLE
Fix two reward-hacking gaps in the bench harness

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -359,15 +359,23 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
     cudaCheck(cudaSetDevice(deviceIdx));
     cudaDeviceProp deviceProp;
     cudaCheck(cudaGetDeviceProperties(&deviceProp, deviceIdx));
+    // 2x L2 so a single memset is guaranteed to evict everything
     void* flush_buffer;
-    cudaCheck(cudaMalloc(&flush_buffer, deviceProp.l2CacheSize));
+    size_t flush_size = 2 * (size_t)deviceProp.l2CacheSize;
+    cudaCheck(cudaMalloc(&flush_buffer, flush_size));
+
+    // disable persisting L2 so kernels can't keep data resident across iters
+    size_t prev_persist_size = 0;
+    cudaCheck(cudaDeviceGetLimit(&prev_persist_size, cudaLimitPersistingL2CacheSize));
+    cudaCheck(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0));
 
     cudaCheck(cudaEventCreate(&start));
     cudaCheck(cudaEventCreate(&stop));
     float elapsed_time = 0.f;
     for (int i = 0; i < repeats; i++) {
-        // clear L2
-        cudaCheck(cudaMemset(flush_buffer, 0, deviceProp.l2CacheSize));
+        // clear L2 — reset before memset so any persisting lines become evictable
+        cudaCheck(cudaCtxResetPersistingL2Cache());
+        cudaCheck(cudaMemset(flush_buffer, 0, flush_size));
         // now we can start recording the timing of the kernel
         cudaCheck(cudaEventRecord(start, nullptr));
         kernel(std::forward<KernelArgs>(kernel_args)...);
@@ -380,6 +388,7 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
     }
 
     cudaCheck(cudaFree(flush_buffer));
+    cudaCheck(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, prev_persist_size));
 
     return elapsed_time / repeats;
 }

--- a/dev/cuda/layernorm_forward.cu
+++ b/dev/cuda/layernorm_forward.cu
@@ -501,6 +501,26 @@ void layernorm_forward6(float* out, float* mean, float* rstd,
     cudaCheck(cudaGetLastError());
 }
 
+// intentionally broken kernel — passes pre-bench, corrupts out[0] later, for the post-bench check
+__device__ int kernel7_call_counter = 0;
+
+__global__ void kernel7_corrupt_after_n(float* out) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        int c = atomicAdd(&kernel7_call_counter, 1);
+        if (c >= 10) {
+            out[0] = 1234.5f;
+        }
+    }
+}
+
+void layernorm_forward7(float* out, float* mean, float* rstd,
+                        const float* inp, const float* weight, const float* bias,
+                        int B, int T, int C, const int block_size) {
+    layernorm_forward5(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
+    kernel7_corrupt_after_n<<<1, 1>>>(out);
+    cudaCheck(cudaGetLastError());
+}
+
 // kernel version dispatch
 void layernorm_forward(int kernel_num,
                     float* out, float* mean, float* rstd,
@@ -525,6 +545,9 @@ void layernorm_forward(int kernel_num,
             break;
         case 6:
             layernorm_forward6(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
+            break;
+        case 7:
+            layernorm_forward7(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
             break;
         default:
             printf("Invalid kernel number\n");
@@ -610,6 +633,13 @@ int main(int argc, char **argv) {
 
         printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
+
+    // re-check correctness after the benchmark loop to catch any across-iter drift
+    printf("\nPost-benchmark correctness re-check.\n");
+    validate_result(d_out, out, "out (post-bench)", B * T * C, 1e-5f);
+    validate_result(d_mean, mean, "mean (post-bench)", B * T, 1e-5f);
+    validate_result(d_rstd, rstd, "rstd (post-bench)", B * T, 1e-5f);
+    printf("Post-benchmark results still match the CPU reference.\n");
 
     // free memory
     free(out);


### PR DESCRIPTION
## Summary

Two fixes to `dev/cuda`'s benchmark harness that close gaps an autonomous-agent optimizer can exploit to "improve" the reported metric without actually doing more work.

### (1) Cap the persisting L2 carveout to zero during `benchmark_kernel`

A kernel that sets a stream-level `cudaStreamAttributeAccessPolicyWindow(hitProp=Persisting, hitRatio=1.0)` covering its working set can keep that data L2-resident across the entire 2000-iter benchmark loop. The existing `cudaMemset(flush_buffer, …)` between iterations *doesn't* evict lines marked persisting — that's documented CUDA L2-persistence behaviour. The bandwidth formula `2*B*T*C*4 / time` then silently reports L2-to-SM throughput under the HBM label.

Concretely, on Ada (L40S, 864 GB/s HBM peak), a modified `layernorm_forward5` that wraps its kernel launch with

```cpp
cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, props.persistingL2CacheMaxSize);
// stream access policy: hitProp=Persisting, hitRatio=1.0, window spans
// inp + out + mean + rstd + weight + bias (~48 MB total, fits the
// 66 MB persisting carveout of the 96 MB L2)
cudaStreamSetAttribute(s, cudaStreamAttributeAccessPolicyWindow, &attr);
```

reports **3530 GB/s** — over 4× HBM peak, physically impossible if the formula's premise held. After this fix it reports **714 GB/s**, under HBM peak, with no correctness impact. The fix:

- captures the current `cudaLimitPersistingL2CacheSize`, sets it to 0 (which also resets any currently-persisting lines to normal status), runs the benchmark, restores the original limit on exit;
- grows `flush_buffer` to 2× L2 so a single `cudaMemset` is guaranteed to evict the entire L2 via LRU pressure;
- resets the persisting cache before (not after) the memset inside the loop so any persisting lines from a previous run are evictable.

### (2) Re-validate kernel output against the CPU reference after the benchmark loop

The pre-bench `validate_result` confirms the kernel is correct on **one** invocation. The 2000-iter bench loop runs against unverified results. A kernel that's correct on iter 1 but drifts state on subsequent iters — e.g.

```cpp
__device__ int call_counter = 0;
// inside the per-call dispatch wrapper:
int c = atomicAdd(&call_counter, 1);
if (c >= 10) out[0] = some_drift_value;
```

— passes pre-bench, runs the loop, reports a fast bandwidth on broken outputs.

After this fix, the post-bench `validate_result` runs against the final iteration's `d_out`/`d_mean`/`d_rstd` and exits 1 on mismatch.

A new `layernorm_forward7` is included as a regression test for (2): it wraps `layernorm_forward5` so the LayerNorm result is correct for the first 10 invocations (passing the six pre-bench correctness checks at the six block sizes) and then corrupts `out[0]` on every subsequent call. The post-bench check catches it and exits 1.

## Why this matters

We hit both gaps running an [autoresearch](https://github.com/karpathy/autoresearch)-style autonomous-agent optimization loop against `dev/cuda/layernorm_forward.cu`. The agent's best trial reported 5.67× over the baseline (622 → 3534 GB/s) — but ~4.5× of that came from the L2-persisting trick alone, not from kernel improvements. The reported speedup wouldn't transfer to production (a real training step doesn't normalize the same tensor 2000 times in a row against a flush that the persisting policy specifically defeats), the metric exceeded HBM peak, and the optimization landscape was being explored against a mislabeled signal.

The (2)-class drift hack we didn't observe in practice on this run, but the harness today admits it: any kernel that uses a device-global counter to make its 2000th call's output different from its 1st passes the existing check.

## Test plan

On Ada (L40S, 864 GB/s HBM peak):

- `./layernorm_forward N` for N in 1..6 → all pre-bench and post-bench checks pass; all reported bandwidths ≤ HBM peak (kernel 5 drops from 3530 → 714 GB/s when the persisting-window variant is present; the upstream kernel 5 reports ~637 GB/s, unchanged).
- `./layernorm_forward 7` → pre-bench passes, post-bench fails, exit 1 with a clear `Mismatch of out (post-bench) at 0: CPU_ref: … vs GPU: 1234.500000` message.

## Scope

Only `dev/cuda/common.h` (the `benchmark_kernel` helper, shared by every `dev/cuda/*_forward.cu`) and `dev/cuda/layernorm_forward.cu` (main + kernel 7) are touched. The other `dev/cuda/*_forward.cu` harnesses would benefit from the same post-bench re-check; happy to extend in a follow-up if that's wanted, or fold the post-bench check into a shared helper in `common.h`.