### PR TITLE
fix two reward-hacking gaps in the bench harness

### DIFF
--- a/dev/cuda/common.h
+++ b/dev/cuda/common.h
@@ -359,15 +359,23 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
     cudaCheck(cudaSetDevice(deviceIdx));
     cudaDeviceProp deviceProp;
     cudaCheck(cudaGetDeviceProperties(&deviceProp, deviceIdx));
+    // 2x L2 so a single memset is guaranteed to evict everything
     void* flush_buffer;
-    cudaCheck(cudaMalloc(&flush_buffer, deviceProp.l2CacheSize));
+    size_t flush_size = 2 * (size_t)deviceProp.l2CacheSize;
+    cudaCheck(cudaMalloc(&flush_buffer, flush_size));
+
+    // disable persisting L2 so kernels can't keep data resident across iters
+    size_t prev_persist_size = 0;
+    cudaCheck(cudaDeviceGetLimit(&prev_persist_size, cudaLimitPersistingL2CacheSize));
+    cudaCheck(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, 0));
 
     cudaCheck(cudaEventCreate(&start));
     cudaCheck(cudaEventCreate(&stop));
     float elapsed_time = 0.f;
     for (int i = 0; i < repeats; i++) {
-        // clear L2
-        cudaCheck(cudaMemset(flush_buffer, 0, deviceProp.l2CacheSize));
+        // clear L2 — reset before memset so any persisting lines become evictable
+        cudaCheck(cudaCtxResetPersistingL2Cache());
+        cudaCheck(cudaMemset(flush_buffer, 0, flush_size));
         // now we can start recording the timing of the kernel
         cudaCheck(cudaEventRecord(start, nullptr));
         kernel(std::forward<KernelArgs>(kernel_args)...);
@@ -380,6 +388,7 @@ float benchmark_kernel(int repeats, Kernel kernel, KernelArgs&&... kernel_args) 
     }
 
     cudaCheck(cudaFree(flush_buffer));
+    cudaCheck(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, prev_persist_size));
 
     return elapsed_time / repeats;
 }

--- a/dev/cuda/layernorm_forward.cu
+++ b/dev/cuda/layernorm_forward.cu
@@ -501,6 +501,26 @@ void layernorm_forward6(float* out, float* mean, float* rstd,
     cudaCheck(cudaGetLastError());
 }
 
+// intentionally broken kernel — passes pre-bench, corrupts out[0] later, for the post-bench check
+__device__ int kernel7_call_counter = 0;
+
+__global__ void kernel7_corrupt_after_n(float* out) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        int c = atomicAdd(&kernel7_call_counter, 1);
+        if (c >= 10) {
+            out[0] = 1234.5f;
+        }
+    }
+}
+
+void layernorm_forward7(float* out, float* mean, float* rstd,
+                        const float* inp, const float* weight, const float* bias,
+                        int B, int T, int C, const int block_size) {
+    layernorm_forward5(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
+    kernel7_corrupt_after_n<<<1, 1>>>(out);
+    cudaCheck(cudaGetLastError());
+}
+
 // kernel version dispatch
 void layernorm_forward(int kernel_num,
                     float* out, float* mean, float* rstd,
@@ -525,6 +545,9 @@ void layernorm_forward(int kernel_num,
             break;
         case 6:
             layernorm_forward6(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
+            break;
+        case 7:
+            layernorm_forward7(out, mean, rstd, inp, weight, bias, B, T, C, block_size);
             break;
         default:
             printf("Invalid kernel number\n");
@@ -610,6 +633,13 @@ int main(int argc, char **argv) {
 
         printf("block_size %4d | time %.4f ms | bandwidth %.2f GB/s\n", block_size, elapsed_time, memory_bandwidth);
     }
+
+    // re-check correctness after the benchmark loop to catch any across-iter drift
+    printf("\nPost-benchmark correctness re-check.\n");
+    validate_result(d_out, out, "out (post-bench)", B * T * C, 1e-5f);
+    validate_result(d_mean, mean, "mean (post-bench)", B * T, 1e-5f);
+    validate_result(d_rstd, rstd, "rstd (post-bench)", B * T, 1e-5f);
+    printf("Post-benchmark results still match the CPU reference.\n");
 
     // free memory
     free(out);


### PR DESCRIPTION
(1) Disable the persisting L2 carveout for benchmark_kernel — without
    this, a kernel that sets a persisting access policy keeps its
    working set L2-resident across iterations (cudaMemset of the
    flush buffer doesn't evict persisting lines), so the bandwidth
    formula reports L2 throughput under the HBM label.

(2) Re-validate kernel output against the CPU reference after the
    benchmark loop, not just before. A kernel that drifts state
    across iters would otherwise report fast bandwidth on broken
    outputs.

layernorm_forward7 is a regression test for (2): a wrapper that runs the existing kernel 5 correctly for the first 10 calls (passes the pre-bench check) then corrupts out[0] (caught by the post-bench check).