### PR TITLE
fix: use Vp*C for wte gradient tensor check

### DIFF
--- a/test_gpt2.c
+++ b/test_gpt2.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
             // finally check all the gradients
             int gradoks[16];
             ParameterTensors grads = model.grads;
-            gradoks[0] = check_tensor(grads.wte, expected_grads.wte, V*C, "dwte");
+            gradoks[0] = check_tensor(grads.wte, expected_grads.wte, Vp*C, "dwte");
             gradoks[1] = check_tensor(grads.wpe, expected_grads.wpe, maxT*C, "dwpe");
             gradoks[2] = check_tensor(grads.ln1w, expected_grads.ln1w, L*C, "dln1w");
             gradoks[3] = check_tensor(grads.ln1b, expected_grads.ln1b, L*C, "dln1b");


### PR DESCRIPTION
In `test_gpt2.c`, the tensor check for `grads.wte` currently uses `V * C`. 
Since the weight and gradient tensors are allocated using the padded vocabulary size `Vp`, this should be `Vp * C` to ensure the entire tensor (including padding) is correctly checked, matching how other padded tensors are handled.